### PR TITLE
Add namespace DummyLemmas

### DIFF
--- a/SpherePacking/DummyLemmas.lean
+++ b/SpherePacking/DummyLemmas.lean
@@ -1,5 +1,7 @@
 import Mathlib
 
+namespace DummyLemmas
+
 lemma foo1 (n : ℕ) : n = n := by simp
 
 lemma foo2 (n : ℤ) : n = n := sorry
@@ -7,3 +9,5 @@ lemma foo2 (n : ℤ) : n = n := sorry
 lemma foo3 : 1 + 1 = 2 := by simp
 
 lemma foo4 : 3 + 4 = 5 := sorry  -- Let's try a false statement
+
+end DummyLemmas


### PR DESCRIPTION
Project wasn't building earlier because `DummyLemmas.foo1` etc didn't exist. Now, they do.