### PR TITLE
Updating Blueprint-LaTeX-Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a (very nascent) project attempting to formalise some notions about Sphere Packing in Lean. Important links:
 
 * [Blueprint (web version)](https://thefundamentaltheor3m.github.io/Sphere-Packing-Lean/blueprint/)
+* [Dependency Graph (web version)](https://thefundamentaltheor3m.github.io/Sphere-Packing-Lean/blueprint/dep_graph_document.html)
 * [Blueprint (PDF version)](https://thefundamentaltheor3m.github.io/Sphere-Packing-Lean/blueprint.pdf)
 * [API Documentation](https://thefundamentaltheor3m.github.io/Sphere-Packing-Lean/docs/)
 


### PR DESCRIPTION
This PR updates the branch `Blueprint-LaTeX-Format` with the latest changes from `main`. This will allow us to continue to stage changes on `Blueprint-LaTeX-Format` before merging them with `main`. Primarily, we will use `Blueprint-LaTeX-Format` as a scratchpad to paste all of the content for the blueprint from our external LaTeX document.