### PR TITLE
chore: add `create-release` workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,23 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'lean-toolchain'
+
+jobs:
+  lean-release-tag:
+    name: Add Lean release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: lean-release-tag action
+      uses: leanprover-community/lean-release-tag@0a978e45247f1ef211cd9d7f99d0dbd87638a70a # 2025-05-22
+      with:
+        before: ${{ github.event.before }}
+        after: ${{ github.event.after }}
+        do-release: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow file uses the new `lean-release-tag action` which creates a Git tag when your project updates to a new Lean release.

It works by looking for changes to the `lean-toolchain` file in the Git history. For every new release that is found in this file, a tag is created on the first commit.

For further details, you might want to see the action [README file](https://github.com/leanprover-community/lean-release-tag).