### PR TITLE
chore: update build workflow actions and settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,11 @@ jobs:
 
       - name: Build the project
         uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # v1.2.0
+        with:
+          use-github-cache: false
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@b210116d3e6096c0c7146f7a96a6d56b6884fef5 # 2025-06-12
+        uses: leanprover-community/docgen-action@040f807529972a4d7a5f49967091b0aac8a1f97a # 2025-06-20
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
Disables GitHub cache in the Lean build step and updates the `docgen-action` to a newer commit. These changes ensure the workflow uses the latest tools and avoids potential cache-related issues.