### PR TITLE
remove broken SLPos notation

### DIFF
--- a/SpherePacking/MagicFunction/b/psi.lean
+++ b/SpherePacking/MagicFunction/b/psi.lean
@@ -19,7 +19,6 @@ open Complex Real Asymptotics Filter Topology Manifold SlashInvariantForm Matrix
   ModularForm SlashAction MatrixGroups
 
 local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
-local notation "SL(" n ", " R ")" "⁺" => Matrix.SLPos (Fin n) R
 
 -- namespace MagicFunction.b.psi
 


### PR DESCRIPTION
Removes an unused notation that expands to a nonexistent constant `Matrix.SLPos`.

Everything in a Special Linear group has positive determinant, so there is no need for this special notation.

(In constrast, [`Matrix.GLPos`](https://github.com/leanprover-community/mathlib4/blob/4dd34c03d5ddf62383357d7618645c068053123a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean#L261-L264) does indeed exist.)