### PR TITLE
fix nearly all the remaining linter warnings

### DIFF
--- a/SpherePacking/Basic/E8.lean
+++ b/SpherePacking/Basic/E8.lean
@@ -266,7 +266,7 @@ theorem E8_Set_eq_span : E8_Set = (Submodule.span ℤ (Set.range E8_Matrix) : Se
     · ext y
       rw [← Finsupp.linearCombination_eq_sum]
       rfl
-    · cases' hv₁ with hv₁ hv₁
+    · obtain hv₁ | hv₁ := hv₁
       -- TODO (the y is just F8_Matrix * v, need to prove it has integer coefficients)
       <;> sorry
   · obtain ⟨y, hy⟩ := hv
@@ -351,7 +351,6 @@ theorem E8_Matrix_inner {i j : Fin 8} :
 
 section E8_norm_bounds
 
-set_option maxHeartbeats 2000000 in
 /-- All vectors in E₈ have norm √(2n) -/
 theorem E8_norm_eq_sqrt_even (v : E8_Lattice) :
     ∃ n : ℤ, Even n ∧ ‖v‖ ^ 2 = n := by
@@ -497,10 +496,10 @@ theorem E8Packing_density : E8Packing.density = ENNReal.ofReal π ^ 4 / 384 := b
       _ = x ^ 4 := by rw [Real.sq_sqrt hx]
     rw [← ENNReal.ofReal_pow, ← ENNReal.ofReal_mul, div_pow, this, this, ← mul_div_assoc,
       div_mul_eq_mul_div, mul_comm, mul_div_assoc, mul_div_assoc]
-    norm_num [Nat.factorial, mul_one_div]
-    convert div_one _
-    · rw [E8_Basis_volume]
-    · rw [← ENNReal.ofReal_pow, ENNReal.ofReal_div_of_pos, ENNReal.ofReal_ofNat] <;> positivity
+    · norm_num [Nat.factorial, mul_one_div]
+      convert div_one _
+      · rw [E8_Basis_volume]
+      · rw [← ENNReal.ofReal_pow, ENNReal.ofReal_div_of_pos, ENNReal.ofReal_ofNat] <;> positivity
     · positivity
     · positivity
   · intro x hx

--- a/SpherePacking/Basic/PeriodicPacking.lean
+++ b/SpherePacking/Basic/PeriodicPacking.lean
@@ -498,25 +498,28 @@ theorem PeriodicSpherePacking.aux_le
     intro ⟨_, hux⟩ ⟨_, huy⟩
     obtain ⟨w, hw, hw_unique⟩ := exist_unique_vadd_mem_fundamentalDomain (b.ofZLatticeBasis ℝ _) u
     rw [Set.mem_vadd_set_iff_neg_vadd_mem, vadd_eq_add, neg_add_eq_sub] at hux huy
-    have hx := hw_unique ⟨-x, ?hx'⟩ ?_
-    have hy := hw_unique ⟨-y, ?hy'⟩ ?_
-    case hx' =>
+    have hx := hw_unique ⟨-x, ?hx₁⟩ ?hx₂
+    case hx₁ =>
       apply neg_mem
       apply Set.mem_of_subset_of_mem (s₁ := S.lattice)
       · rw [S.basis_Z_span]
       · exact hx.left
-    case hy' =>
+    case hx₂ =>
+      simp_rw [Submodule.vadd_def, vadd_eq_add, neg_add_eq_sub]
+      exact hux
+    have hy := hw_unique ⟨-y, ?hy₁⟩ ?hy₂
+    case hy₁ =>
       apply neg_mem
       apply Set.mem_of_subset_of_mem (s₁ := S.lattice)
       · rw [S.basis_Z_span]
       · exact hy.left
-    · apply hxy
-      rw [Subtype.ext_iff, ← neg_inj]
-      exact Subtype.ext_iff.mp (hx.trans hy.symm)
-    · simp_rw [Submodule.vadd_def, vadd_eq_add, neg_add_eq_sub]
+    case hy₂ =>
+      simp_rw [Submodule.vadd_def, vadd_eq_add, neg_add_eq_sub]
       exact huy
-    · simp_rw [Submodule.vadd_def, vadd_eq_add, neg_add_eq_sub]
-      exact hux
+    apply hxy
+    rw [Subtype.ext_iff, ← neg_inj]
+    exact Subtype.ext_iff.mp (hx.trans hy.symm)
+
 
 end theorem_2_3
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -181,7 +181,7 @@ bounded above by the Cohn-Elkies bound.
 
 include hP
 open Classical in
-private theorem calc_aux_1 (hd : 0 < d) (hf: Summable f) :
+private theorem calc_aux_1 (hd : 0 < d) (hf : Summable f) :
   ∑' x : P.centers, ∑' y : ↑(P.centers ∩ D), (f (x - ↑y)).re
   ≤ ↑(P.numReps' hd hD_isBounded) * (f 0).re := calc
   ∑' x : P.centers, ∑' y : ↑(P.centers ∩ D), (f (x - ↑y)).re
@@ -316,7 +316,7 @@ private theorem calc_aux_1 (hd : 0 < d) (hf: Summable f) :
               exact Nat.card_eq_fintype_card
 
 include hD_isBounded
-lemma calc_steps' (hd : 0 < d) (hf: Summable f) :
+lemma calc_steps' (hd : 0 < d) (hf : Summable f) :
     ∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)) (ℓ : ↥P.lattice), (f (↑x - ↑y + ↑ℓ)).re =
     (∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)) (ℓ : ↥P.lattice), f (↑x - ↑y + ↑ℓ)).re := by
   have sum_finite := aux4 P D hD_isBounded hd
@@ -335,8 +335,8 @@ lemma calc_steps' (hd : 0 < d) (hf: Summable f) :
 -- There are several summability results stated as intermediate `have`s in the following theorem.
 -- I think their proofs should follow from whatever we define `PSF_Conditions` to be.
 -- If there are assumptions needed beyond PSF, we should require them here, not in `PSF_Conditions`.
-set_option maxHeartbeats 200000
-private theorem calc_steps (hd : 0 < d) (hf: Summable f) :
+set_option maxHeartbeats 200000 in
+private theorem calc_steps (hd : 0 < d) (hf : Summable f) :
     ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥ ↑(P.numReps' hd hD_isBounded) ^ 2 *
     (𝓕 f 0).re / ZLattice.covolume P.lattice := by
   have : Fact (0 < d) := ⟨hd⟩

--- a/SpherePacking/ForMathlib/InvPowSummability.lean
+++ b/SpherePacking/ForMathlib/InvPowSummability.lean
@@ -136,8 +136,6 @@ theorem Summable_of_Inv_Pow_Summable'
       rw [le_add_iff_nonneg_right]
       exact zero_le_one
 
-set_option pp.funBinderTypes true
-
 -- should be in mathlib!!
 lemma Summable.subset {α β : Type*}
     [AddCommGroup β] [UniformSpace β] [IsUniformAddGroup β] [CompleteSpace β]

--- a/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
+++ b/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
@@ -566,8 +566,7 @@ theorem norm_φ₀_le : ∃ C₀ > 0, ∀ z : ℍ, 1 / 2 < z.im →
     calc _ ≤ _ := DivDiscBoundOfPolyFourierCoeff z hz c 4 ?_ 5 hcpoly
           (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) ?_
       _ = _ := by congr 2; ring
-    ·
-      sorry
+    · sorry
     · -- This is where I need to use Bhavik's result
 
       sorry
@@ -590,3 +589,7 @@ example {m n : ℕ} {f : (EuclideanSpace ℝ (Fin m)) × (EuclideanSpace ℝ (Fi
   sorry
 
 end Scratch
+
+end PolyFourierCoeffBound
+
+end MagicFunction

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I2.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I2.lean
@@ -107,8 +107,8 @@ lemma im_parametrisation_lower : ∀ t ∈ Ioo (0 : ℝ) 1, 1 / 2 < (-1 / (↑t 
 lemma im_parametrisation_upper : ∀ t ∈ Ioo (0 : ℝ) 1, (-1 / (↑t + I)).im < 1 := by
   intro t ht
   rw [im_parametrisation_eq t ht, one_div, ← inv_one, inv_lt_inv₀]
-  obtain ⟨ht₀, ht₁⟩ := ht
-  · simp_all only [inv_one, lt_add_iff_pos_left, pow_pos]
+  · obtain ⟨ht₀, ht₁⟩ := ht
+    simp_all only [inv_one, lt_add_iff_pos_left, pow_pos]
   · positivity
   · exact one_pos
 
@@ -220,3 +220,11 @@ end Higher_iteratedFDerivs
 -- decay' := by extract_goal; sorry
 
 end Schwartz_Decay
+
+end I₂
+
+end IntegralEstimates
+
+end a
+
+end MagicFunction

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I5.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I5.lean
@@ -199,7 +199,7 @@ theorem I₅'_bounding (r : ℝ) : ∃ C₀ > 0,
   calc
   _ = ‖-2 * ∫ s in Ici (1 : ℝ), g r s‖ := by simp only [Complete_Change_of_Variables, g]
   _ ≤ 2 * ∫ s in Ici (1 : ℝ), ‖g r s‖ := by
-      simp only [norm_mul, norm_neg, Complex.norm_ofNat, Nat.ofNat_pos, mul_le_mul_left]
+      simp only [norm_mul, norm_neg, Complex.norm_ofNat, Nat.ofNat_pos, mul_le_mul_iff_right₀]
       exact norm_integral_le_integral_norm (g r)
   _ ≤ 2 * ∫ s in Ici (1 : ℝ), C₀ * rexp (-2 * π * s) * rexp (-π * r / s) := by gcongr
 

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I6.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I6.lean
@@ -96,7 +96,7 @@ theorem I₆'_bounding (r : ℝ) : ∃ C₁ > 0,
   calc
   _ = ‖2 * ∫ t in Ici (1 : ℝ), g r t‖ := by simp only [I₆'_eq_integral_g_Ioo, g]
   _ ≤ 2 * ∫ t in Ici (1 : ℝ), ‖g r t‖ := by
-      simp only [norm_mul, Complex.norm_ofNat, Nat.ofNat_pos, mul_le_mul_left]
+      simp only [norm_mul, Complex.norm_ofNat, Nat.ofNat_pos, mul_le_mul_iff_right₀]
       exact norm_integral_le_integral_norm (g r)
   _ ≤ 2 * ∫ t in Ici (1 : ℝ), C₀ * rexp (-2 * π * t) * rexp (-π * r * t) := by gcongr
   _ = _ := by
@@ -157,3 +157,11 @@ end Higher_iteratedFDerivs
 -- decay' := by extract_goal; sorry
 
 end Schwartz_Decay
+
+end I₆
+
+end IntegralEstimates
+
+end a
+
+end MagicFunction

--- a/SpherePacking/MagicFunction/b/SpecialValues.lean
+++ b/SpherePacking/MagicFunction/b/SpecialValues.lean
@@ -21,3 +21,9 @@ section Zero
 theorem b_zero : b 0 = 0 := by sorry
 
 end Zero
+
+end SpecialValues
+
+end b
+
+end MagicFunction

--- a/SpherePacking/MagicFunction/g/Basic.lean
+++ b/SpherePacking/MagicFunction/g/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 
-import Mathlib.Data.Real.Pi.Bounds
+import Mathlib.Analysis.Real.Pi.Bounds
 
 import SpherePacking.MagicFunction.a.Eigenfunction
 import SpherePacking.MagicFunction.a.SpecialValues

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -17,7 +17,7 @@ noncomputable section Definitions
 def Δ (z : UpperHalfPlane) := cexp (2 * π * Complex.I * z) * ∏' (n : ℕ),
     (1 - cexp (2 * π * Complex.I * (n + 1) * z)) ^ 24
 
-lemma DiscriminantProductFormula ( z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' (n : ℕ+),
+lemma DiscriminantProductFormula (z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' (n : ℕ+),
     (1 - cexp (2 * π * Complex.I * (n) * z)) ^ 24 := by
     simp [Δ]
     conv =>
@@ -109,7 +109,7 @@ instance : atImInfty.NeBot := by
   simp only [le_add_iff_nonneg_right, zero_le_one, z]
 
 
-lemma I_in_atImInfty (A: ℝ) : { z : ℍ | A ≤ z.im} ∈ atImInfty := by
+lemma I_in_atImInfty (A : ℝ) : { z : ℍ | A ≤ z.im} ∈ atImInfty := by
   rw [atImInfty_mem]
   use A
   simp only [mem_setOf_eq, imp_self, implies_true]
@@ -253,10 +253,10 @@ theorem Delta_boundedfactor :
       rw [haa]
       simp only [forall_exists_index, and_imp, gt_iff_lt, CharP.cast_eq_zero, zero_add, mul_one,
         dist_zero_right, norm_neg, inf_eq_inter, inter_mem_iff, sup_le_iff, mem_inter_iff,
-        mem_setOf_eq, one_div, Complex.norm_mul, norm_ofNat, Nat.ofNat_pos, mul_le_mul_left,
+        mem_setOf_eq, one_div, Complex.norm_mul, norm_ofNat, Nat.ofNat_pos, mul_le_mul_iff_right₀,
         ge_iff_le] at *
       apply le_trans (this ?_)
-      · simp only [Nat.ofNat_pos, div_pos_iff_of_pos_left, mul_le_mul_left]
+      · simp only [Nat.ofNat_pos, div_pos_iff_of_pos_left, mul_le_mul_iff_right₀]
         have hr := cexp_two_pi_I_im_antimono UpperHalfPlane.I b (n := k + 1) ?_
         · simpa using hr
         simp only [UpperHalfPlane.I_im, hb.2.2]
@@ -278,7 +278,7 @@ theorem Delta_boundedfactor :
 
 open Real
 
-lemma Discriminant_zeroAtImInfty (γ : SL(2, ℤ)): IsZeroAtImInfty
+lemma Discriminant_zeroAtImInfty (γ : SL(2, ℤ)) : IsZeroAtImInfty
     (Discriminant_SIF ∣[(12 : ℤ)] γ) := by
   rw [IsZeroAtImInfty, ZeroAtFilter]
   have := Discriminant_SIF.slash_action_eq' γ (CongruenceSubgroup.mem_Gamma_one γ)

--- a/SpherePacking/ModularForms/Icc_Ico_lems.lean
+++ b/SpherePacking/ModularForms/Icc_Ico_lems.lean
@@ -21,36 +21,35 @@ lemma Icc_succ (n : ℕ) : Finset.Icc (-(n + 1) : ℤ) (n + 1) = Finset.Icc (-n 
 lemma trex (f : ℤ → ℂ) (N : ℕ) (hn : 1 ≤ N) : ∑ m ∈ Finset.Icc (-N : ℤ) N, f m =
   f N + f (-N : ℤ) + ∑ m ∈ Finset.Icc (-(N - 1) : ℤ) (N - 1), f m := by
   induction' N with N ih
-  simp
-  aesop
+  · aesop
   zify
   rw [Icc_succ]
   rw [Finset.sum_union]
-  ring_nf
-  rw [add_assoc]
-  congr
-  rw [ Finset.sum_pair]
-  ring
-  omega
+  · ring_nf
+    rw [add_assoc]
+    congr
+    rw [Finset.sum_pair]
+    · ring
+    omega
   simp
 
 
-lemma Icc_sum_even (f : ℤ → ℂ) (hf : ∀ n, f n = f (-n)) (N : ℕ):
+lemma Icc_sum_even (f : ℤ → ℂ) (hf : ∀ n, f n = f (-n)) (N : ℕ) :
     ∑ m ∈ Finset.Icc (-N : ℤ) N, f m = 2 * ∑ m ∈ Finset.range (N + 1), f m - f 0 := by
   induction' N with N ih
-  simp only [CharP.cast_eq_zero, neg_zero, Finset.Icc_self, Finset.sum_singleton, zero_add,
-    Finset.range_one]
-  ring
+  · simp only [CharP.cast_eq_zero, neg_zero, Finset.Icc_self, Finset.sum_singleton, zero_add,
+      Finset.range_one]
+    ring
   have := Icc_succ N
   simp only [neg_add_rev, Int.reduceNeg, Nat.cast_add, Nat.cast_one] at *
   rw [this, Finset.sum_union, Finset.sum_pair, ih]
-  nth_rw 2 [Finset.sum_range_succ]
-  have HF:= hf (N + 1)
-  simp only [neg_add_rev, Int.reduceNeg] at HF
-  rw [← HF]
-  ring_nf
-  norm_cast
-  omega
+  · nth_rw 2 [Finset.sum_range_succ]
+    have HF:= hf (N + 1)
+    simp only [neg_add_rev, Int.reduceNeg] at HF
+    rw [← HF]
+    ring_nf
+    norm_cast
+  · omega
   simp only [Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Icc, le_add_iff_nonneg_left,
     Left.nonneg_neg_iff, Int.reduceLE, add_neg_le_iff_le_add, false_and, not_false_eq_true,
     Finset.disjoint_singleton_right, add_le_iff_nonpos_right, and_false, and_self]
@@ -63,8 +62,8 @@ lemma verga2 : Tendsto (fun N : ℕ => Finset.Icc (-N : ℤ) N) atTop atTop :=
 
 lemma int_add_abs_self_nonneg (n : ℤ) : 0 ≤ n + |n| := by
   by_cases h : 0 ≤ n
-  apply add_nonneg h
-  exact abs_nonneg n
+  · apply add_nonneg h
+    exact abs_nonneg n
   simp at *
   rw [abs_of_neg h]
   simp
@@ -76,8 +75,8 @@ lemma verga : Tendsto (fun N : ℕ => Finset.Ico (-N : ℤ) N) atTop atTop := by
   simp only [Nat.cast_add, Int.natCast_natAbs, Nat.cast_one, neg_add_rev, Int.reduceNeg,
     Finset.mem_Ico, add_neg_le_iff_le_add]
   constructor
-  apply le_trans _ (int_add_abs_self_nonneg x)
-  omega
+  · apply le_trans _ (int_add_abs_self_nonneg x)
+    omega
   refine Int.lt_add_one_iff.mpr ?_
   exact le_abs_self x
 

--- a/SpherePacking/ModularForms/JacobiTheta.lean
+++ b/SpherePacking/ModularForms/JacobiTheta.lean
@@ -194,7 +194,7 @@ lemma H₂_S_action : (H₂ ∣[(2 : ℤ)] S) = -H₄ := by
 
 lemma H₃_S_action : (H₃ ∣[(2 : ℤ)] S) = -H₃ := by
   ext x
-  have hx' : (x : ℂ) ≠ 0 := by cases' x with x hx; change x ≠ 0; simp [Complex.ext_iff, hx.ne.symm]
+  have hx' : (x : ℂ) ≠ 0 := by obtain ⟨x, hx⟩ := x; change x ≠ 0; simp [Complex.ext_iff, hx.ne.symm]
   have := jacobiTheta₂_functional_equation 0
   simp [-one_div] at this
   simp [modular_slash_S_apply, Pi.neg_apply, H₃, Θ₃_as_jacobiTheta₂]
@@ -345,7 +345,7 @@ theorem isBoundedAtImInfty_H₂ : IsBoundedAtImInfty H₂ := by
       have : (2 * b : ℝ) = -1 := by simp [hb]
       norm_cast at this
       exact Int.not_odd_iff_even.mpr (even_two_mul b) (by rw [this]; simp)
-    convert (mul_le_mul_left (mul_pos pi_pos (sq_pos_of_ne_zero this))).mpr hz using 1
+    convert (mul_le_mul_iff_right₀ (mul_pos pi_pos (sq_pos_of_ne_zero this))).mpr hz using 1
     rw [mul_one]
   · apply Summable.norm
     apply summable_ofReal.mp

--- a/SpherePacking/ModularForms/clog_arg_lems.lean
+++ b/SpherePacking/ModularForms/clog_arg_lems.lean
@@ -14,33 +14,33 @@ open scoped Interval Real NNReal ENNReal Topology BigOperators Nat
 lemma arg_pow_aux (n : ℕ) (x : ℂ) (hx : x ≠ 0) (hna : |arg x| < π / n) :
   Complex.arg (x ^ n) = n * Complex.arg x := by
   induction' n with n hn2
-  simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul]
+  · simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul]
   by_cases hn0 : n = 0
   · simp only [hn0, zero_add, pow_one, Nat.cast_one, one_mul]
   · rw [pow_succ, arg_mul, hn2, Nat.cast_add]
-    ring
-    apply lt_trans hna
-    gcongr
-    exact (lt_add_one n)
-    apply pow_ne_zero n hx
-    exact hx
+    · ring
+    · apply lt_trans hna
+      gcongr
+      exact (lt_add_one n)
+    · apply pow_ne_zero n hx
+    · exact hx
     simp only [mem_Ioc]
     rw [hn2]
-    rw [abs_lt] at hna
-    constructor
-    · have hnal := hna.1
-      rw [← neg_div] at hnal
-      rw [div_lt_iff₀' ] at hnal
-      · rw [@Nat.cast_add, add_mul] at hnal
-        simpa only [gt_iff_lt, Nat.cast_one, one_mul] using hnal
-      · norm_cast
-        omega
-    · have hnal := hna.2
-      rw [lt_div_iff₀', Nat.cast_add] at hnal
-      · rw [add_mul] at hnal
-        simpa only [ge_iff_le, Nat.cast_one, one_mul] using hnal.le
-      · norm_cast
-        omega
+    · rw [abs_lt] at hna
+      constructor
+      · have hnal := hna.1
+        rw [← neg_div] at hnal
+        rw [div_lt_iff₀' ] at hnal
+        · rw [Nat.cast_add, add_mul] at hnal
+          simpa only [gt_iff_lt, Nat.cast_one, one_mul] using hnal
+        · norm_cast
+          omega
+      · have hnal := hna.2
+        rw [lt_div_iff₀', Nat.cast_add] at hnal
+        · rw [add_mul] at hnal
+          simpa only [ge_iff_le, Nat.cast_one, one_mul] using hnal.le
+        · norm_cast
+          omega
     apply lt_trans hna
     gcongr
     exact (lt_add_one n)
@@ -58,30 +58,30 @@ lemma arg_pow (n : ℕ) (f : ℕ → ℂ) (hf : Tendsto f atTop (𝓝 0)) : ∀�
   have hf1 := hf.const_add 1
   simp only [add_zero] at hf1
   have h2 := (Complex.continuousAt_arg (x := 1) ?_)
-  rw [ContinuousAt] at *
-  have h3 := h2.comp hf1
-  simp only [arg_one] at h3
-  rw [Metric.tendsto_nhds] at *
-  simp only [gt_iff_lt, dist_zero_right, eventually_atTop, ge_iff_le,
-    dist_self_add_left, arg_one, Real.norm_eq_abs, comp_apply] at *
-  by_cases hn0 : n = 0
-  · rw [hn0]
-    simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul, implies_true, exists_const]
-  · have hpi : 0 < π / n := by
-      apply div_pos
-      exact Real.pi_pos
-      simp only [Nat.cast_pos]
-      omega
-    obtain ⟨a, hA⟩ := h3 (π / n) hpi
-    obtain ⟨a2, ha2⟩ := hf (1/2) (one_half_pos)
-    use max a a2
-    intro b hb
-    rw [arg_pow_aux n (1 + f b) ?_]
-    apply hA b
-    exact le_of_max_le_left hb
-    have ha2 := ha2 b (le_of_max_le_right hb)
-    simp only [ne_eq]
-    apply one_add_abs_half_ne_zero ha2
+  · rw [ContinuousAt] at *
+    have h3 := h2.comp hf1
+    simp only [arg_one] at h3
+    rw [Metric.tendsto_nhds] at *
+    simp only [gt_iff_lt, dist_zero_right, eventually_atTop, ge_iff_le,
+      dist_self_add_left, arg_one, Real.norm_eq_abs, comp_apply] at *
+    by_cases hn0 : n = 0
+    · rw [hn0]
+      simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul, implies_true, exists_const]
+    · have hpi : 0 < π / n := by
+        apply div_pos
+        exact Real.pi_pos
+        simp only [Nat.cast_pos]
+        omega
+      obtain ⟨a, hA⟩ := h3 (π / n) hpi
+      obtain ⟨a2, ha2⟩ := hf (1/2) (one_half_pos)
+      use max a a2
+      intro b hb
+      rw [arg_pow_aux n (1 + f b) ?_]
+      · apply hA b
+        exact le_of_max_le_left hb
+      have ha2 := ha2 b (le_of_max_le_right hb)
+      simp only [ne_eq]
+      apply one_add_abs_half_ne_zero ha2
   simp only [one_mem_slitPlane]
 
 lemma arg_pow2 (n : ℕ) (f : ℍ → ℂ) (hf : Tendsto f atImInfty (𝓝 0)) : ∀ᶠ m : ℍ in atImInfty,
@@ -90,43 +90,43 @@ lemma arg_pow2 (n : ℕ) (f : ℍ → ℂ) (hf : Tendsto f atImInfty (𝓝 0)) :
   have hf1 := hf.const_add 1
   simp only [add_zero] at hf1
   have h2 := (Complex.continuousAt_arg (x := 1) ?_)
-  rw [ContinuousAt] at *
-  have h3 := h2.comp hf1
-  simp only [arg_one] at h3
-  rw [Metric.tendsto_nhds] at *
-  simp only [gt_iff_lt, dist_zero_right, dist_self_add_left, arg_one, Real.norm_eq_abs,
-    comp_apply] at *
-  by_cases hn0 : n = 0
-  · simp_rw [hn0]
-    simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul, implies_true, and_true]
-    rw [atImInfty]
-    simp only [mem_comap, mem_atTop_sets, ge_iff_le]
-    use {n | 1 ≤ n.im}
-    use {r : ℝ | 1 ≤ r}
-    refine ⟨?_, ?_⟩
-    use 1
-    intro b hb
-    aesop
-    simp only [preimage_setOf_eq, subset_refl]
-  · have hpi : 0 < π / n := by
-      apply div_pos
-      exact Real.pi_pos
-      simp only [Nat.cast_pos]
-      omega
-    have hA1 := h3 (π / n) hpi
-    have hA2 := hf (1/2) (one_half_pos)
-    rw [Filter.eventually_iff_exists_mem ] at hA1 hA2
-    obtain ⟨a, ha1, hA1⟩ := hA1
-    obtain ⟨a2, ha2, hA2⟩ := hA2
-    use min a a2
-    refine ⟨by rw [atImInfty] at *; simp at *; refine ⟨ha1, ha2⟩, ?_⟩
-    intro b hb
-    rw [arg_pow_aux n (1 + f b) ?_]
-    apply hA1 b
-    exact mem_of_mem_inter_left hb
-    have ha2 := hA2 b ( mem_of_mem_inter_right hb)
-    simp only [ne_eq]
-    apply one_add_abs_half_ne_zero ha2
+  · rw [ContinuousAt] at *
+    have h3 := h2.comp hf1
+    simp only [arg_one] at h3
+    rw [Metric.tendsto_nhds] at *
+    simp only [gt_iff_lt, dist_zero_right, dist_self_add_left, arg_one, Real.norm_eq_abs,
+      comp_apply] at *
+    by_cases hn0 : n = 0
+    · simp_rw [hn0]
+      simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul, implies_true, and_true]
+      rw [atImInfty]
+      simp only [mem_comap, mem_atTop_sets, ge_iff_le]
+      use {n | 1 ≤ n.im}
+      use {r : ℝ | 1 ≤ r}
+      refine ⟨?_, ?_⟩
+      · use 1
+        intro b hb
+        aesop
+      simp only [preimage_setOf_eq, subset_refl]
+    · have hpi : 0 < π / n := by
+        apply div_pos
+        exact Real.pi_pos
+        simp only [Nat.cast_pos]
+        omega
+      have hA1 := h3 (π / n) hpi
+      have hA2 := hf (1/2) (one_half_pos)
+      rw [Filter.eventually_iff_exists_mem ] at hA1 hA2
+      obtain ⟨a, ha1, hA1⟩ := hA1
+      obtain ⟨a2, ha2, hA2⟩ := hA2
+      use min a a2
+      refine ⟨by rw [atImInfty] at *; simp at *; refine ⟨ha1, ha2⟩, ?_⟩
+      intro b hb
+      rw [arg_pow_aux n (1 + f b) ?_]
+      · apply hA1 b
+        exact mem_of_mem_inter_left hb
+      have ha2 := hA2 b ( mem_of_mem_inter_right hb)
+      simp only [ne_eq]
+      apply one_add_abs_half_ne_zero ha2
   simp only [one_mem_slitPlane]
 
 lemma clog_pow (n : ℕ) (f : ℕ → ℂ) (hf : Tendsto f atTop (𝓝 0)) : ∀ᶠ m : ℕ in atTop,

--- a/SpherePacking/ModularForms/equivs.lean
+++ b/SpherePacking/ModularForms/equivs.lean
@@ -59,23 +59,26 @@ def sigmaAntidiagonalEquivProd : (Σ n : ℕ+, Nat.divisorsAntidiagonal n) ≃ �
   toFun x := mapdiv x.1 x.2
   invFun x :=
     ⟨⟨x.1.1 * x.2.1, by apply mul_pos x.1.2 x.2.2⟩, ⟨x.1, x.2⟩, by
-      rw [Nat.mem_divisorsAntidiagonal]; simp; constructor; rfl; constructor;
-        linarith [x.1.2]; linarith [x.2.2] ⟩
+      rw [Nat.mem_divisorsAntidiagonal]
+      simp
+      refine ⟨rfl, ?_, ?_⟩
+      · linarith [x.1.2]
+      · linarith [x.2.2]⟩
   left_inv := by
     rintro ⟨n, ⟨k, l⟩, h⟩
     rw [Nat.mem_divisorsAntidiagonal] at h
     simp_rw [mapdiv]
     simp only [PNat.mk_coe]
     ext
-    simp at *
-    simp_rw [h]
-    norm_cast
-    simp only
+    · simp at *
+      simp_rw [h]
+      norm_cast
+    · simp only
     simp only
   right_inv := by
     rintro ⟨n, ⟨k, l⟩, h⟩
-    simp_rw [mapdiv]
-    exfalso
-    simp at *
+    · simp_rw [mapdiv]
+      exfalso
+      simp at *
     simp_rw [mapdiv]
     norm_cast

--- a/SpherePacking/ModularForms/iteratedderivs.lean
+++ b/SpherePacking/ModularForms/iteratedderivs.lean
@@ -26,16 +26,16 @@ theorem aut_iter_deriv (d : ℤ) (k : ℕ) :
       (fun t : ℂ => (-1) ^ k * k ! * (1 / (t + d) ^ (k + 1))) {z : ℂ | 0 < z.im} := by
   intro x hx
   induction' k with k IH generalizing x
-  simp only [iteratedDerivWithin_zero, pow_zero, Nat.factorial_zero, one_mul]
-  simp  at *
+  · simp only [iteratedDerivWithin_zero, pow_zero, Nat.factorial_zero, one_mul]
+    simp at *
   rw [iteratedDerivWithin_succ]
   simp only [one_div, Nat.cast_succ, Nat.factorial, Nat.cast_mul]
   have := (IH hx)
-  have H : derivWithin (fun (z : ℂ) => (-1: ℂ) ^ k * ↑k ! * ((z + ↑d) ^ (k + 1))⁻¹) {z : ℂ | 0 < z.im} x =
-   (-1) ^ (↑k + 1) * ((↑k + 1) * ↑k !) * ((x + ↑d) ^ (↑k + 1 + 1))⁻¹ := by
+  have H : derivWithin (fun (z : ℂ) => (-1: ℂ) ^ k * ↑k ! * ((z + ↑d) ^ (k + 1))⁻¹)
+             {z : ℂ | 0 < z.im} x =
+           (-1) ^ (↑k + 1) * ((↑k + 1) * ↑k !) * ((x + ↑d) ^ (↑k + 1 + 1))⁻¹ := by
     rw [DifferentiableAt.derivWithin]
     · simp only [deriv_const_mul_field']
-
 
       have h0 : (fun z : ℂ => ((z + d) ^ (k + 1))⁻¹) = (fun z : ℂ => (z + d) ^ (k + 1))⁻¹ := by
         rfl
@@ -48,7 +48,8 @@ theorem aut_iter_deriv (d : ℤ) (k : ℕ) :
       rw [pow_add]
       simp [pow_one]
 
-      have Hw : (-(((k : ℂ) + 1) * (x + ↑d) ^ k) / ((x + ↑d) ^ k * (x + ↑d)) ^ 2) = -(↑k + 1) / (x + ↑d) ^ (k + 2) :=
+      have Hw : (-(((k : ℂ) + 1) * (x + ↑d) ^ k) / ((x + ↑d) ^ k * (x + ↑d)) ^ 2) =
+                -(↑k + 1) / (x + ↑d) ^ (k + 2) :=
         by
         rw [div_eq_div_iff]
         norm_cast
@@ -78,10 +79,10 @@ theorem aut_iter_deriv (d : ℤ) (k : ℕ) :
       · fun_prop
   rw [←H]
   apply derivWithin_congr
-  norm_cast at *
-  simp at *
-  intro r hr
-  apply IH hr
+  · norm_cast at *
+    simp at *
+    intro r hr
+    apply IH hr
   norm_cast at *
   simp at *
   apply this
@@ -97,13 +98,13 @@ theorem aut_iter_deriv' (d : ℤ) (k : ℕ) :
   simp_rw [h2]
   simpa using aut_iter_deriv (-d : ℤ) k hx
 
-  theorem aut_contDiffOn (d : ℤ) (k : ℕ) : ContDiffOn ℂ k (fun z : ℂ => 1 / (z - d))
+theorem aut_contDiffOn (d : ℤ) (k : ℕ) : ContDiffOn ℂ k (fun z : ℂ => 1 / (z - d))
     {z : ℂ | 0 < z.im} := by
   simp only [one_div]
   apply ContDiffOn.inv
-  apply ContDiffOn.sub
-  apply contDiffOn_id
-  apply contDiffOn_const
+  · apply ContDiffOn.sub
+    · apply contDiffOn_id
+    apply contDiffOn_const
   intro x hx
   have := upper_ne_int ⟨x, hx⟩ (-d)
   norm_cast at *
@@ -150,13 +151,15 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {F : Type*}
 
 
 theorem exp_iter_deriv_within (n m : ℕ) :
-    EqOn (iteratedDerivWithin n (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * m * s)) {z : ℂ | 0 < z.im})
-      (fun t => (2 * ↑π * Complex.I * m) ^ n * Complex.exp (2 * ↑π * Complex.I * m * t)) {z : ℂ | 0 < z.im} :=
+    EqOn (iteratedDerivWithin n (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * m * s))
+           {z : ℂ | 0 < z.im})
+      (fun t => (2 * ↑π * Complex.I * m) ^ n * Complex.exp (2 * ↑π * Complex.I * m * t))
+      {z : ℂ | 0 < z.im} :=
   by
-  apply EqOn.trans (iteratedDerivWithin_of_isOpen  ?_)
-  rw [EqOn]
-  intro x _
-  apply congr_fun (iteratedDeriv_cexp_const_mul ..)
+  apply EqOn.trans (iteratedDerivWithin_of_isOpen ?_)
+  · rw [EqOn]
+    intro x _
+    apply congr_fun (iteratedDeriv_cexp_const_mul ..)
   refine isOpen_lt ?_ ?_
   · fun_prop
   · fun_prop

--- a/SpherePacking/ModularForms/multipliable_lems.lean
+++ b/SpherePacking/ModularForms/multipliable_lems.lean
@@ -3,7 +3,7 @@ import SpherePacking.ModularForms.summable_lems
 open ModularForm EisensteinSeries UpperHalfPlane TopologicalSpace Set MeasureTheory intervalIntegral
   Metric Filter Function Complex
 
-open scoped Interval Real NNReal ENNReal Topology BigOperators Nat Classical
+open scoped Interval Real NNReal ENNReal Topology BigOperators Nat
 
 open ArithmeticFunction
 
@@ -41,7 +41,7 @@ theorem multipliable_lt_one (x : ℂ) (hx : x ∈ ball 0 1) :
     enter [1]
     ext n
     rw [sub_eq_add_neg]
-  exact this
+  · exact this
   rw [@summable_neg_iff]
   rw [@summable_nat_add_iff]
   rw [@summable_geometric_iff_norm_lt_one]
@@ -51,10 +51,10 @@ lemma MultipliableEtaProductExpansion (z : ℍ) :
     Multipliable (fun (n : ℕ) => (1 - cexp (2 * π * Complex.I * (n + 1) * z)) ) := by
   have := Complex.summable_nat_multipliable_one_add (fun (n : ℕ) =>
     (-cexp (2 * π * Complex.I * (n + 1) * z)) ) ?_
-  simp at this
-  apply this.congr
-  intro n
-  ring
+  · simp at this
+    apply this.congr
+    intro n
+    ring
   rw [←summable_norm_iff]
   simpa using summable_exp_pow z
 
@@ -80,11 +80,11 @@ lemma MultipliableEtaProductExpansion_pnat (z : ℍ) :
 lemma tprod_ne_zero (x : ℍ) (f : ℕ → ℍ → ℂ) (hf : ∀ i x, 1 + f i x ≠ 0)
   (hu : ∀ x : ℍ, Summable fun n => f n x) : (∏' i : ℕ, (1 + f i) x) ≠ 0 := by
   have := Complex.cexp_tsum_eq_tprod (f := fun n => 1 + f n x) ?_
-  simp
-  rw [← this]
-  simp only [exp_ne_zero, not_false_eq_true]
-  apply Complex.summable_log_one_add_of_summable
-  apply hu x
+  · simp
+    rw [← this]
+    · simp only [exp_ne_zero, not_false_eq_true]
+    apply Complex.summable_log_one_add_of_summable
+    apply hu x
   intro n
   apply hf n x
 
@@ -115,8 +115,8 @@ lemma tprod_pow (f : ℕ → ℂ) (hf : Multipliable f) (n : ℕ) : (∏' (i : �
   · rw [pow_succ]
     rw [hn]
     rw [← Multipliable.tprod_mul]
-    congr
-    apply Multipliable_pow f hf n
+    · congr
+    · apply Multipliable_pow f hf n
     exact hf
 
 
@@ -130,7 +130,7 @@ theorem hasProd_le_nonneg (f g : ι → ℝ) (h : ∀ i, f i ≤ g i) (h0 : ∀ 
   intro s
   apply Finset.prod_le_prod
   intros i hi
-  exact h0 i
+  · exact h0 i
   intros i hi
   exact h i
 

--- a/SpherePacking/ModularForms/riemannZetalems.lean
+++ b/SpherePacking/ModularForms/riemannZetalems.lean
@@ -5,28 +5,28 @@ import Mathlib.NumberTheory.LSeries.RiemannZeta
 open TopologicalSpace Set MeasureTheory intervalIntegral
   Metric Filter Function Complex
 
-open scoped Interval Real NNReal ENNReal Topology BigOperators Nat Classical
+open scoped Interval Real NNReal ENNReal Topology BigOperators Nat
 
 
 lemma zeta_two_eqn : ∑' (n : ℤ), ((n : ℂ) ^ 2)⁻¹ = 2 * riemannZeta 2 := by
   have := tsum_nat_add_neg (f := fun n => 1/((n : ℂ) ^ 2)) ?_
-  simp only [Int.cast_natCast, one_div, Int.cast_neg, even_two, Even.neg_pow, Int.cast_zero, ne_eq,
-    OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, div_zero, add_zero] at this
-  rw [← this]
-  have hr := zeta_nat_eq_tsum_of_gt_one (k := 2)
-  simp only [Nat.one_lt_ofNat, Nat.cast_ofNat, one_div, forall_const] at hr
-  rw [hr, Summable.tsum_add]
-  ring
-  repeat{
-  have := Complex.summable_one_div_nat_cpow (p := 2)
-  simp only [cpow_ofNat, one_div, re_ofNat, Nat.one_lt_ofNat, iff_true] at this
-  exact this}
+  · simp only [Int.cast_natCast, one_div, Int.cast_neg, even_two, Even.neg_pow, Int.cast_zero,
+      ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, div_zero, add_zero] at this
+    rw [← this]
+    have hr := zeta_nat_eq_tsum_of_gt_one (k := 2)
+    simp only [Nat.one_lt_ofNat, Nat.cast_ofNat, one_div, forall_const] at hr
+    rw [hr, Summable.tsum_add]
+    · ring
+    repeat{
+    have := Complex.summable_one_div_nat_cpow (p := 2)
+    simp only [cpow_ofNat, one_div, re_ofNat, Nat.one_lt_ofNat, iff_true] at this
+    exact this}
   simp only [one_div]
   have := Complex.summable_one_div_nat_cpow (p := 2)
   simp only [cpow_ofNat, one_div, re_ofNat, Nat.one_lt_ofNat, iff_true] at *
   norm_cast at *
   apply Summable.of_nat_of_neg_add_one
-  apply this
+  · apply this
   rw [← summable_nat_add_iff 1] at this
   apply this.congr
   intro b

--- a/SpherePacking/ModularForms/tsumderivWithin.lean
+++ b/SpherePacking/ModularForms/tsumderivWithin.lean
@@ -1,5 +1,5 @@
 import Mathlib.Analysis.Calculus.UniformLimitsDeriv
-import Mathlib.Analysis.NormedSpace.FunctionSeries
+import Mathlib.Analysis.Normed.Group.FunctionSeries
 import Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.Topology.ContinuousMap.Compact
 import SpherePacking.ModularForms.exp_lems
@@ -25,30 +25,30 @@ theorem derivWithin_tsum_fun' {α : Type _} (f : α → ℂ → ℂ) {s : Set �
     (hf2 : ∀ n (r : s), DifferentiableAt ℂ (f n) r) :
     derivWithin (fun z => ∑' n : α, f n z) s x = ∑' n : α, derivWithin (fun z => f n z) s x := by
   apply HasDerivWithinAt.derivWithin
-  apply HasDerivAt.hasDerivWithinAt
-  have A :
-    ∀ x : ℂ,
-      x ∈ s →
-        Tendsto (fun t : Finset α => ∑ n ∈ t, (fun z => f n z) x) atTop
-          (𝓝 (∑' n : α, (fun z => f n z) x)) :=
-        fun y hy ↦ Summable.hasSum <| hf y hy
-  apply hasDerivAt_of_tendstoLocallyUniformlyOn hs _ _ A hx
-  use fun n : Finset α => fun a => ∑ i ∈ n, derivWithin (fun z => f i z) s a
-  rw [tendstoLocallyUniformlyOn_iff_forall_isCompact hs]
-  intro K hK1 hK2
-  have HU := hu K hK1 hK2
-  obtain ⟨u, hu1, hu2⟩ := HU
-  apply tendstoUniformlyOn_tsum hu1
-  intro n x hx
-  apply hu2 n ⟨x, hx⟩
-  filter_upwards
-  intro t r hr
-  apply HasDerivAt.fun_sum
-  intro q hq
-  apply HasDerivWithinAt.hasDerivAt
-  apply DifferentiableWithinAt.hasDerivWithinAt
-  apply (hf2 q ⟨r, hr⟩).differentiableWithinAt
-  exact IsOpen.mem_nhds hs hr
+  · apply HasDerivAt.hasDerivWithinAt
+    have A :
+      ∀ x : ℂ,
+        x ∈ s →
+          Tendsto (fun t : Finset α => ∑ n ∈ t, (fun z => f n z) x) atTop
+            (𝓝 (∑' n : α, (fun z => f n z) x)) :=
+          fun y hy ↦ Summable.hasSum <| hf y hy
+    apply hasDerivAt_of_tendstoLocallyUniformlyOn hs _ _ A hx
+    · use fun n : Finset α => fun a => ∑ i ∈ n, derivWithin (fun z => f i z) s a
+    · rw [tendstoLocallyUniformlyOn_iff_forall_isCompact hs]
+      intro K hK1 hK2
+      have HU := hu K hK1 hK2
+      obtain ⟨u, hu1, hu2⟩ := HU
+      apply tendstoUniformlyOn_tsum hu1
+      intro n x hx
+      apply hu2 n ⟨x, hx⟩
+    filter_upwards
+    intro t r hr
+    apply HasDerivAt.fun_sum
+    intro q hq
+    apply HasDerivWithinAt.hasDerivAt
+    · apply DifferentiableWithinAt.hasDerivWithinAt
+      apply (hf2 q ⟨r, hr⟩).differentiableWithinAt
+    exact IsOpen.mem_nhds hs hr
   apply IsOpen.uniqueDiffWithinAt hs hx
 
 
@@ -66,14 +66,14 @@ theorem der_iter_eq_der_aux2 (k n : ℕ) (r : ℍ') :
     apply Differentiable.const_mul
     apply differentiable_id
   apply DifferentiableOn.differentiableAt
-  apply DifferentiableOn.congr hh
-  intro x hx
-  apply exp_iter_deriv_within k n hx
+  · apply DifferentiableOn.congr hh
+    intro x hx
+    apply exp_iter_deriv_within k n hx
   refine IsOpen.mem_nhds ?_ ?_
   · apply isOpen_lt (by fun_prop) (by fun_prop)
   exact r.2
 
-  theorem der_iter_eq_der2 (k n : ℕ) (r : ℍ') :
+theorem der_iter_eq_der2 (k n : ℕ) (r : ℍ') :
     deriv (iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s)) ℍ') ↑r =
       derivWithin (iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s)) ℍ')
         ℍ'
@@ -82,11 +82,11 @@ theorem der_iter_eq_der_aux2 (k n : ℕ) (r : ℍ') :
   simp
   apply symm
   apply DifferentiableAt.derivWithin
-  apply der_iter_eq_der_aux2
+  · apply der_iter_eq_der_aux2
   apply IsOpen.uniqueDiffOn upper_half_plane_isOpen
   apply r.2
 
-  theorem der_iter_eq_der2' (k n : ℕ) (r : ℍ') :
+theorem der_iter_eq_der2' (k n : ℕ) (r : ℍ') :
     derivWithin (iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s)) ℍ')
       ℍ' ↑r =
       iteratedDerivWithin (k + 1) (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s)) ℍ' ↑r :=
@@ -98,7 +98,7 @@ noncomputable def cts_exp_two_pi_n (K : Set ℂ) : ContinuousMap K ℂ where
   toFun := fun r : K => Complex.exp (2 * ↑π * Complex.I * r)
 
 
- theorem iter_deriv_comp_bound2 (K : Set ℂ) (hK1 : K ⊆ ℍ') (hK2 : IsCompact K) (k : ℕ) :
+theorem iter_deriv_comp_bound2 (K : Set ℂ) (hK1 : K ⊆ ℍ') (hK2 : IsCompact K) (k : ℕ) :
     ∃ u : ℕ → ℝ,
       Summable u ∧
         ∀ (n : ℕ) (r : K),
@@ -140,41 +140,40 @@ noncomputable def cts_exp_two_pi_n (K : Set ℂ) : ContinuousMap K ℂ where
     apply mul_ne_zero
     linarith
     apply Real.pi_ne_zero
-  refine' ⟨fun n : ℕ => ‖((2 * ↑π * Complex.I * n) ^ (k + 1) * r ^ n)‖, hu, _⟩
-  intro n t
-  have go := der_iter_eq_der2' k n ⟨t.1, hK1 t.2⟩
-  simp at *
-  simp_rw [go]
-  have h1 := exp_iter_deriv_within (k + 1) n (hK1 t.2)
-  norm_cast at *
-  simp at *
-  rw [h1]
-  simp
-  have ineqe : ‖(Complex.exp (2 * π * Complex.I * n * t))‖ ≤ ‖r‖ ^ n :=
-    by
-    have hw1 :
-      ‖ (Complex.exp (2 * π * Complex.I * n * t))‖ =
-        ‖ (Complex.exp (2 * π * Complex.I * t))‖ ^ n := by
-          norm_cast
-          rw [← Complex.norm_pow];
-          congr;
-          rw [← exp_nat_mul];
-          ring_nf
-    rw [hw1]
-    norm_cast
-    apply pow_le_pow_left₀
-    simp only [norm_nonneg]
-    have :=
-      BoundedContinuousFunction.norm_coe_le_norm
-        (BoundedContinuousFunction.mkOfCompact (cts_exp_two_pi_n K)) t
-    rw [norm_norm]
-    simpa using this
-  apply mul_le_mul
-  simp
-  simp at ineqe
-  convert ineqe
-  positivity
-  positivity
+  · use fun n : ℕ => ‖((2 * ↑π * Complex.I * n) ^ (k + 1) * r ^ n)‖, hu
+    intro n t
+    have go := der_iter_eq_der2' k n ⟨t.1, hK1 t.2⟩
+    simp at *
+    simp_rw [go]
+    have h1 := exp_iter_deriv_within (k + 1) n (hK1 t.2)
+    norm_cast at *
+    simp at *
+    rw [h1]
+    simp
+    have ineqe : ‖(Complex.exp (2 * π * Complex.I * n * t))‖ ≤ ‖r‖ ^ n := by
+      have hw1 :
+        ‖ (Complex.exp (2 * π * Complex.I * n * t))‖ =
+          ‖ (Complex.exp (2 * π * Complex.I * t))‖ ^ n := by
+            norm_cast
+            rw [← Complex.norm_pow];
+            congr;
+            rw [← exp_nat_mul];
+            ring_nf
+      rw [hw1]
+      norm_cast
+      apply pow_le_pow_left₀
+      simp only [norm_nonneg]
+      have :=
+        BoundedContinuousFunction.norm_coe_le_norm
+          (BoundedContinuousFunction.mkOfCompact (cts_exp_two_pi_n K)) t
+      rw [norm_norm]
+      simpa using this
+    apply mul_le_mul
+    · simp
+    · simp at ineqe
+      convert ineqe
+    · positivity
+    positivity
 
 
 theorem hasDerivAt_tsum_fun {α : Type _} (f : α → ℂ → ℂ)
@@ -196,21 +195,21 @@ theorem hasDerivAt_tsum_fun {α : Type _} (f : α → ℂ → ℂ)
     simp
     apply hf y hy
   apply hasDerivAt_of_tendstoLocallyUniformlyOn hs _ _ A hx
-  use fun n : Finset α => fun a => ∑ i ∈ n, derivWithin (fun z => f i z) s a
-  rw [tendstoLocallyUniformlyOn_iff_forall_isCompact hs]
-  intro K hK1 hK2
-  have HU := hu K hK1 hK2
-  obtain ⟨u, hu1, hu2⟩ := HU
-  apply tendstoUniformlyOn_tsum hu1
-  intro n x hx
-  apply hu2 n ⟨x, hx⟩
+  · use fun n : Finset α => fun a => ∑ i ∈ n, derivWithin (fun z => f i z) s a
+  · rw [tendstoLocallyUniformlyOn_iff_forall_isCompact hs]
+    intro K hK1 hK2
+    have HU := hu K hK1 hK2
+    obtain ⟨u, hu1, hu2⟩ := HU
+    apply tendstoUniformlyOn_tsum hu1
+    intro n x hx
+    apply hu2 n ⟨x, hx⟩
   filter_upwards
   intro t r hr
   apply HasDerivAt.fun_sum
   intro q hq
   apply HasDerivWithinAt.hasDerivAt
-  apply DifferentiableWithinAt.hasDerivWithinAt
-  apply (hf2 q ⟨r, hr⟩).differentiableWithinAt
+  · apply DifferentiableWithinAt.hasDerivWithinAt
+    apply (hf2 q ⟨r, hr⟩).differentiableWithinAt
   exact IsOpen.mem_nhds hs hr
 
 
@@ -270,7 +269,7 @@ theorem iter_deriv_comp_bound3 (K : Set ℂ) (hK1 : K ⊆ ℍ') (hK2 : IsCompact
     apply mul_ne_zero
     linarith
     apply Real.pi_ne_zero
-  refine' ⟨fun n : ℕ => ‖((2 * ↑π * Complex.I * n) ^ (k) * r ^ n)‖, hu, _⟩
+  use fun n : ℕ => ‖((2 * ↑π * Complex.I * n) ^ (k) * r ^ n)‖, hu
   intro n t
   simp
   have ineqe : ‖(Complex.exp (2 * π * Complex.I * n * t))‖ ≤ ‖r‖ ^ n :=
@@ -293,8 +292,8 @@ theorem iter_deriv_comp_bound3 (K : Set ℂ) (hK1 : K ⊆ ℍ') (hK2 : IsCompact
     rw [norm_norm]
     simpa using this
   apply mul_le_mul
-  simp
-  simp at ineqe
-  convert ineqe
-  positivity
+  · simp
+  · simp at ineqe
+    convert ineqe
+  · positivity
   positivity

--- a/SpherePacking/ModularForms/uniformcts.lean
+++ b/SpherePacking/ModularForms/uniformcts.lean
@@ -7,9 +7,9 @@ import Mathlib.Analysis.Complex.ReImTopology
 import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
 import Mathlib.Analysis.SpecialFunctions.Log.Summable
 import Mathlib.Analysis.SpecificLimits.Normed
-import Mathlib.Analysis.NormedSpace.FunctionSeries
+import Mathlib.Analysis.Normed.Group.FunctionSeries
 import Mathlib.Analysis.NormedSpace.MultipliableUniformlyOn
-import Mathlib.Data.Complex.Exponential
+import Mathlib.Analysis.Complex.Exponential
 
 
 /-!


### PR DESCRIPTION
After this change, the only warnings the remain are about maxHeartbeats and "automatically included section variables" in  SpherePacking/CohnElkies/LPBound.lean.