### PR TITLE
chore: fix new linter warnings

### DIFF
--- a/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
+++ b/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
@@ -282,9 +282,9 @@ private lemma step_10 :
 by
   have hpow : ∀ {ι} (f : ι → ℝ), Multipliable f → ∀ n, Multipliable (fun i => f i ^ n) := by
     intro ι f hf n
-    induction' n with n hn
-    · simpa using (multipliable_one : Multipliable (fun _ : ι => (1 : ℝ)))
-    · simpa [pow_succ] using (hn.mul hf)
+    induction n with
+    | zero => simpa using (multipliable_one : Multipliable (fun _ : ι => (1 : ℝ)))
+    | succ n hn => simpa [pow_succ] using (hn.mul hf)
   gcongr
   · exact aux_8 z
   · apply tprod_le_of_nonneg_of_multipliable

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I6.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I6.lean
@@ -125,7 +125,7 @@ by
       _ = (|A| / K + 1) * K := by
         have h1 : (|A| / K) * K = |A| := by field_simp [div_eq_mul_inv, hKne]
         have h2 : (|A| / K + 1) * K = (|A| / K) * K + 1 * K := by ring
-        simpa [h2, h1]
+        simp [h2, h1]
   simpa [K, A, mul_div_assoc] using h
 
 end Bounding_Integral

--- a/SpherePacking/ModularForms/Cauchylems.lean
+++ b/SpherePacking/ModularForms/Cauchylems.lean
@@ -143,24 +143,25 @@ theorem extracted_2_δ (z : ℍ) (b : ℤ) : CauchySeq fun N : ℕ ↦
 theorem telescope_aux (z : ℍ) (m : ℤ) (b : ℕ) :
   ∑ n ∈ Finset.Ico (-b : ℤ) b, (1 / ((m : ℂ) * ↑z + ↑n) - 1 / (↑m * ↑z + ↑n + 1)) =
     1 / (↑m * ↑z - ↑b) - 1 / (↑m * ↑z + ↑b) := by
-  induction' b with b ihb
-  · aesop
-  simp only [Nat.cast_add, Nat.cast_one, one_div, Finset.sum_sub_distrib] at *
-  rw [fsb, Finset.sum_union, Finset.sum_union, Finset.sum_pair, Finset.sum_pair,add_sub_add_comm,
-    ihb]
-  · simp only [neg_add_rev, Int.reduceNeg, Int.cast_add, Int.cast_neg,
-               Int.cast_one, Int.cast_natCast]
-    ring
-  · omega
-  · omega
-  · simp only [neg_add_rev, Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Ico,
-    le_add_iff_nonneg_left, Left.nonneg_neg_iff, Int.reduceLE, add_neg_lt_iff_lt_add, false_and,
-    not_false_eq_true, Finset.disjoint_singleton_right, neg_le_self_iff, Nat.cast_nonneg,
-    lt_self_iff_false, and_false, and_self]
-  · simp only [neg_add_rev, Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Ico,
-    le_add_iff_nonneg_left, Left.nonneg_neg_iff, Int.reduceLE, add_neg_lt_iff_lt_add, false_and,
-    not_false_eq_true, Finset.disjoint_singleton_right, neg_le_self_iff, Nat.cast_nonneg,
-    lt_self_iff_false, and_false, and_self]
+  induction b with
+  | zero => aesop
+  | succ b ihb =>
+    simp only [Nat.cast_add, Nat.cast_one, one_div, Finset.sum_sub_distrib] at *
+    rw [fsb, Finset.sum_union, Finset.sum_union, Finset.sum_pair, Finset.sum_pair,add_sub_add_comm,
+      ihb]
+    · simp only [neg_add_rev, Int.reduceNeg, Int.cast_add, Int.cast_neg,
+                 Int.cast_one, Int.cast_natCast]
+      ring
+    · omega
+    · omega
+    · simp only [neg_add_rev, Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Ico,
+      le_add_iff_nonneg_left, Left.nonneg_neg_iff, Int.reduceLE, add_neg_lt_iff_lt_add, false_and,
+      not_false_eq_true, Finset.disjoint_singleton_right, neg_le_self_iff, Nat.cast_nonneg,
+      lt_self_iff_false, and_false, and_self]
+    · simp only [neg_add_rev, Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Ico,
+      le_add_iff_nonneg_left, Left.nonneg_neg_iff, Int.reduceLE, add_neg_lt_iff_lt_add, false_and,
+      not_false_eq_true, Finset.disjoint_singleton_right, neg_le_self_iff, Nat.cast_nonneg,
+      lt_self_iff_false, and_false, and_self]
 
 theorem tendstozero_inv_linear (z : ℍ) (b : ℤ) :
   Tendsto (fun d : ℕ ↦ 1 / ((b : ℂ) * ↑z + ↑d)) atTop (𝓝 0) := by

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -489,12 +489,12 @@ lemma cexp_aux5 (t : ℝ) : (cexp (-(2 * π * t))).im = 0 := by
 lemma Delta_imag_axis_real {t : ℝ} (ht : 0 < t) : (ResToImagAxis Delta t).im = 0 := by
   simp [ResToImagAxis, ht]
   rw [Delta_apply, Δ]
-  simp [Subtype.coe_mk, cexp_aux1, cexp_aux2, cexp_aux5]
+  simp [cexp_aux1, cexp_aux2, cexp_aux5]
   sorry
 
 /- Δ(it) is positive on the (positive) imaginary axis. -/
 lemma Delta_imag_axis_pos {t : ℝ} (ht : 0 < t) : 0 < (ResToImagAxis Delta t).re := by
   simp [ResToImagAxis, ht]
   rw [Delta_apply, Δ]
-  simp [Subtype.coe_mk, cexp_aux1, cexp_aux2, cexp_aux5]
+  simp [cexp_aux1, cexp_aux2, cexp_aux5]
   sorry

--- a/SpherePacking/ModularForms/DimensionFormulas.lean
+++ b/SpherePacking/ModularForms/DimensionFormulas.lean
@@ -444,7 +444,7 @@ lemma floor_lem1 (k a : ℚ) (ha : 0 < a) (hak : a ≤ k) :
 lemma dim_modforms_lvl_one (k : ℕ) (hk : 3 ≤ (k : ℤ)) (hk2 : Even k) :
     Module.rank ℂ (ModularForm (CongruenceSubgroup.Gamma 1) (k)) = if 12 ∣ ((k) : ℤ) - 2 then
     Nat.floor ((k : ℚ)/ 12) else Nat.floor ((k : ℚ) / 12) + 1 := by
-  induction' k using Nat.strong_induction_on with k ihn
+  induction k using Nat.strong_induction_on with | h k ihn =>
   rw [dim_modforms_eq_one_add_dim_cuspforms (k) (by omega) hk2 ,
     LinearEquiv.rank_eq (CuspForms_iso_Modforms (((k)) : ℤ))]
   by_cases HK : (3 : ℤ) ≤ (((k : ℤ) - 12))

--- a/SpherePacking/ModularForms/Icc_Ico_lems.lean
+++ b/SpherePacking/ModularForms/Icc_Ico_lems.lean
@@ -20,39 +20,42 @@ lemma Icc_succ (n : ℕ) : Finset.Icc (-(n + 1) : ℤ) (n + 1) = Finset.Icc (-n 
 
 lemma trex (f : ℤ → ℂ) (N : ℕ) (hn : 1 ≤ N) : ∑ m ∈ Finset.Icc (-N : ℤ) N, f m =
   f N + f (-N : ℤ) + ∑ m ∈ Finset.Icc (-(N - 1) : ℤ) (N - 1), f m := by
-  induction' N with N ih
-  · aesop
-  zify
-  rw [Icc_succ]
-  rw [Finset.sum_union]
-  · ring_nf
-    rw [add_assoc]
-    congr
-    rw [Finset.sum_pair]
-    · ring
-    omega
-  simp
+  induction N with
+  | zero => aesop
+  | succ N ih =>
+    zify
+    rw [Icc_succ]
+    rw [Finset.sum_union]
+    · ring_nf
+      rw [add_assoc]
+      congr
+      rw [Finset.sum_pair]
+      · ring
+      omega
+    simp
 
 
 lemma Icc_sum_even (f : ℤ → ℂ) (hf : ∀ n, f n = f (-n)) (N : ℕ) :
     ∑ m ∈ Finset.Icc (-N : ℤ) N, f m = 2 * ∑ m ∈ Finset.range (N + 1), f m - f 0 := by
-  induction' N with N ih
-  · simp only [CharP.cast_eq_zero, neg_zero, Finset.Icc_self, Finset.sum_singleton, zero_add,
-      Finset.range_one]
+  induction N with
+  | zero =>
+    simp only [CharP.cast_eq_zero, neg_zero, Finset.Icc_self, Finset.sum_singleton,
+      zero_add, Finset.range_one]
     ring
-  have := Icc_succ N
-  simp only [neg_add_rev, Int.reduceNeg, Nat.cast_add, Nat.cast_one] at *
-  rw [this, Finset.sum_union, Finset.sum_pair, ih]
-  · nth_rw 2 [Finset.sum_range_succ]
-    have HF:= hf (N + 1)
-    simp only [neg_add_rev, Int.reduceNeg] at HF
-    rw [← HF]
-    ring_nf
-    norm_cast
-  · omega
-  simp only [Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Icc, le_add_iff_nonneg_left,
-    Left.nonneg_neg_iff, Int.reduceLE, add_neg_le_iff_le_add, false_and, not_false_eq_true,
-    Finset.disjoint_singleton_right, add_le_iff_nonpos_right, and_false, and_self]
+  | succ N ih =>
+    have := Icc_succ N
+    simp only [neg_add_rev, Int.reduceNeg, Nat.cast_add, Nat.cast_one] at *
+    rw [this, Finset.sum_union, Finset.sum_pair, ih]
+    · nth_rw 2 [Finset.sum_range_succ]
+      have HF:= hf (N + 1)
+      simp only [neg_add_rev, Int.reduceNeg] at HF
+      rw [← HF]
+      ring_nf
+      norm_cast
+    · omega
+    simp only [Int.reduceNeg, Finset.disjoint_insert_right, Finset.mem_Icc, le_add_iff_nonneg_left,
+      Left.nonneg_neg_iff, Int.reduceLE, add_neg_le_iff_le_add, false_and, not_false_eq_true,
+      Finset.disjoint_singleton_right, add_le_iff_nonpos_right, and_false, and_self]
 
 
 

--- a/SpherePacking/ModularForms/clog_arg_lems.lean
+++ b/SpherePacking/ModularForms/clog_arg_lems.lean
@@ -13,37 +13,38 @@ open scoped Interval Real NNReal ENNReal Topology BigOperators Nat
 
 lemma arg_pow_aux (n : ℕ) (x : ℂ) (hx : x ≠ 0) (hna : |arg x| < π / n) :
   Complex.arg (x ^ n) = n * Complex.arg x := by
-  induction' n with n hn2
-  · simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul]
-  by_cases hn0 : n = 0
-  · simp only [hn0, zero_add, pow_one, Nat.cast_one, one_mul]
-  · rw [pow_succ, arg_mul, hn2, Nat.cast_add]
-    · ring
-    · apply lt_trans hna
+  induction n with
+  | zero => simp only [pow_zero, arg_one, CharP.cast_eq_zero, zero_mul]
+  | succ n hn2 =>
+    by_cases hn0 : n = 0
+    · simp only [hn0, zero_add, pow_one, Nat.cast_one, one_mul]
+    · rw [pow_succ, arg_mul, hn2, Nat.cast_add]
+      · ring
+      · apply lt_trans hna
+        gcongr
+        exact (lt_add_one n)
+      · apply pow_ne_zero n hx
+      · exact hx
+      simp only [mem_Ioc]
+      rw [hn2]
+      · rw [abs_lt] at hna
+        constructor
+        · have hnal := hna.1
+          rw [← neg_div] at hnal
+          rw [div_lt_iff₀' ] at hnal
+          · rw [Nat.cast_add, add_mul] at hnal
+            simpa only [gt_iff_lt, Nat.cast_one, one_mul] using hnal
+          · norm_cast
+            omega
+        · have hnal := hna.2
+          rw [lt_div_iff₀', Nat.cast_add] at hnal
+          · rw [add_mul] at hnal
+            simpa only [ge_iff_le, Nat.cast_one, one_mul] using hnal.le
+          · norm_cast
+            omega
+      apply lt_trans hna
       gcongr
       exact (lt_add_one n)
-    · apply pow_ne_zero n hx
-    · exact hx
-    simp only [mem_Ioc]
-    rw [hn2]
-    · rw [abs_lt] at hna
-      constructor
-      · have hnal := hna.1
-        rw [← neg_div] at hnal
-        rw [div_lt_iff₀' ] at hnal
-        · rw [Nat.cast_add, add_mul] at hnal
-          simpa only [gt_iff_lt, Nat.cast_one, one_mul] using hnal
-        · norm_cast
-          omega
-      · have hnal := hna.2
-        rw [lt_div_iff₀', Nat.cast_add] at hnal
-        · rw [add_mul] at hnal
-          simpa only [ge_iff_le, Nat.cast_one, one_mul] using hnal.le
-        · norm_cast
-          omega
-    apply lt_trans hna
-    gcongr
-    exact (lt_add_one n)
 
 lemma one_add_abs_half_ne_zero {x : ℂ} (hb : ‖x‖ < 1 / 2) : 1 + x ≠ 0 := by
   by_contra h

--- a/SpherePacking/ModularForms/iteratedderivs.lean
+++ b/SpherePacking/ModularForms/iteratedderivs.lean
@@ -25,67 +25,69 @@ theorem aut_iter_deriv (d : ℤ) (k : ℕ) :
     EqOn (iteratedDerivWithin k (fun z : ℂ => 1 / (z + d)) {z : ℂ | 0 < z.im})
       (fun t : ℂ => (-1) ^ k * k ! * (1 / (t + d) ^ (k + 1))) {z : ℂ | 0 < z.im} := by
   intro x hx
-  induction' k with k IH generalizing x
-  · simp only [iteratedDerivWithin_zero, pow_zero, Nat.factorial_zero, one_mul]
+  induction k generalizing x with
+  | zero =>
+    simp only [iteratedDerivWithin_zero, pow_zero, Nat.factorial_zero, one_mul]
     simp at *
-  rw [iteratedDerivWithin_succ]
-  simp only [one_div, Nat.cast_succ, Nat.factorial, Nat.cast_mul]
-  have := (IH hx)
-  have H : derivWithin (fun (z : ℂ) => (-1: ℂ) ^ k * ↑k ! * ((z + ↑d) ^ (k + 1))⁻¹)
-             {z : ℂ | 0 < z.im} x =
-           (-1) ^ (↑k + 1) * ((↑k + 1) * ↑k !) * ((x + ↑d) ^ (↑k + 1 + 1))⁻¹ := by
-    rw [DifferentiableAt.derivWithin]
-    · simp only [deriv_const_mul_field']
+  | succ k IH =>
+    rw [iteratedDerivWithin_succ]
+    simp only [one_div, Nat.cast_succ, Nat.factorial, Nat.cast_mul]
+    have := (IH hx)
+    have H : derivWithin (fun (z : ℂ) => (-1: ℂ) ^ k * ↑k ! * ((z + ↑d) ^ (k + 1))⁻¹)
+               {z : ℂ | 0 < z.im} x =
+             (-1) ^ (↑k + 1) * ((↑k + 1) * ↑k !) * ((x + ↑d) ^ (↑k + 1 + 1))⁻¹ := by
+      rw [DifferentiableAt.derivWithin]
+      · simp only [deriv_const_mul_field']
 
-      have h0 : (fun z : ℂ => ((z + d) ^ (k + 1))⁻¹) = (fun z : ℂ => (z + d) ^ (k + 1))⁻¹ := by
-        rfl
-      rw [h0]
-      have h1 : (fun z : ℂ => ((z + d) ^ (k + 1))) = (fun z : ℂ => (z + d)) ^ (k + 1) := by
-        rfl
-      rw [h1]
-      rw [deriv_inv'', deriv_pow, deriv_add_const', deriv_id'']
-      simp only [Nat.cast_add, Nat.cast_one, add_tsub_cancel_right, mul_one]
-      rw [pow_add]
-      simp [pow_one]
+        have h0 : (fun z : ℂ => ((z + d) ^ (k + 1))⁻¹) = (fun z : ℂ => (z + d) ^ (k + 1))⁻¹ := by
+          rfl
+        rw [h0]
+        have h1 : (fun z : ℂ => ((z + d) ^ (k + 1))) = (fun z : ℂ => (z + d)) ^ (k + 1) := by
+          rfl
+        rw [h1]
+        rw [deriv_inv'', deriv_pow, deriv_add_const', deriv_id'']
+        simp only [Nat.cast_add, Nat.cast_one, add_tsub_cancel_right, mul_one]
+        rw [pow_add]
+        simp [pow_one]
 
-      have Hw : (-(((k : ℂ) + 1) * (x + ↑d) ^ k) / ((x + ↑d) ^ k * (x + ↑d)) ^ 2) =
-                -(↑k + 1) / (x + ↑d) ^ (k + 2) :=
-        by
-        rw [div_eq_div_iff]
-        norm_cast
-        simp
+        have Hw : (-(((k : ℂ) + 1) * (x + ↑d) ^ k) / ((x + ↑d) ^ k * (x + ↑d)) ^ 2) =
+                  -(↑k + 1) / (x + ↑d) ^ (k + 2) :=
+          by
+          rw [div_eq_div_iff]
+          norm_cast
+          simp
+          ring
+          norm_cast
+          apply pow_ne_zero
+          apply mul_ne_zero
+          apply pow_ne_zero k (upper_ne_int ⟨x, hx⟩ d)
+          apply upper_ne_int ⟨x, hx⟩ d
+          norm_cast
+          apply pow_ne_zero (k + 2) (upper_ne_int ⟨x, hx⟩ d)
+        rw [Hw]
         ring
-        norm_cast
-        apply pow_ne_zero
-        apply mul_ne_zero
-        apply pow_ne_zero k (upper_ne_int ⟨x, hx⟩ d)
-        apply upper_ne_int ⟨x, hx⟩ d
-        norm_cast
-        apply pow_ne_zero (k + 2) (upper_ne_int ⟨x, hx⟩ d)
-      rw [Hw]
-      ring
-      fun_prop
-      fun_prop
-      norm_cast
-      apply pow_ne_zero (k + 1) (upper_ne_int ⟨x, hx⟩ d)
-    · apply DifferentiableAt.mul
-      · fun_prop
-      · apply DifferentiableAt.inv
         fun_prop
+        fun_prop
+        norm_cast
         apply pow_ne_zero (k + 1) (upper_ne_int ⟨x, hx⟩ d)
-    · apply IsOpen.uniqueDiffWithinAt _ hx
-      refine isOpen_lt ?_ ?_
-      · fun_prop
-      · fun_prop
-  rw [←H]
-  apply derivWithin_congr
-  · norm_cast at *
+      · apply DifferentiableAt.mul
+        · fun_prop
+        · apply DifferentiableAt.inv
+          fun_prop
+          apply pow_ne_zero (k + 1) (upper_ne_int ⟨x, hx⟩ d)
+      · apply IsOpen.uniqueDiffWithinAt _ hx
+        refine isOpen_lt ?_ ?_
+        · fun_prop
+        · fun_prop
+    rw [←H]
+    apply derivWithin_congr
+    · norm_cast at *
+      simp at *
+      intro r hr
+      apply IH hr
+    norm_cast at *
     simp at *
-    intro r hr
-    apply IH hr
-  norm_cast at *
-  simp at *
-  apply this
+    apply this
 
 theorem aut_iter_deriv' (d : ℤ) (k : ℕ) :
     EqOn (iteratedDerivWithin k (fun z : ℂ => 1 / (z - d)) {z : ℂ | 0 < z.im})

--- a/SpherePacking/ModularForms/multipliable_lems.lean
+++ b/SpherePacking/ModularForms/multipliable_lems.lean
@@ -91,10 +91,12 @@ lemma tprod_ne_zero (x : ℍ) (f : ℕ → ℍ → ℂ) (hf : ∀ i x, 1 + f i x
 
 lemma Multipliable_pow {ι : Type*} (f : ι → ℂ) (hf : Multipliable f) (n : ℕ) :
      Multipliable (fun i => f i ^ n) := by
-  induction' n with n hn
-  · simp
+  induction n with
+  | zero =>
+    simp
     apply multipliable_one
-  · conv =>
+  | succ n hn =>
+    conv =>
       enter [1]
       intro u
       rw [pow_succ]
@@ -110,9 +112,10 @@ lemma MultipliableDeltaProductExpansion_pnat (z : ℍ) :
 
 lemma tprod_pow (f : ℕ → ℂ) (hf : Multipliable f) (n : ℕ) : (∏' (i : ℕ), f i) ^ n = ∏' (i : ℕ),
     (f i) ^ n := by
-  induction' n with n hn
-  · simp
-  · rw [pow_succ]
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    rw [pow_succ]
     rw [hn]
     rw [← Multipliable.tprod_mul]
     · congr

--- a/SpherePacking/ModularForms/summable_lems.lean
+++ b/SpherePacking/ModularForms/summable_lems.lean
@@ -974,42 +974,44 @@ theorem exp_series_ite_deriv_uexp2 (k : ℕ) (x : {z : ℂ | 0 < z.im}) :
     {z : ℂ | 0 < z.im} x =
     ∑' n : ℕ, iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s))
     {z : ℂ | 0 < z.im} x := by
-  induction' k with k IH generalizing x
-  · simp only [iteratedDerivWithin_zero]
-  rw [iteratedDerivWithin_succ]
-  have HH :
-    derivWithin (iteratedDerivWithin k (fun z => ∑' n : ℕ, Complex.exp (2 * ↑π * Complex.I * n * z))
-      {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im}
-        x =
-      derivWithin
-        (fun z =>
-          ∑' n : ℕ, iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s)) {z
-            : ℂ | 0 < z.im} z)
-        {z : ℂ | 0 < z.im} x := by
-    apply derivWithin_congr
-    intro y hy
-    apply IH ⟨y, hy⟩
-    apply IH x
-  simp_rw [HH]
-  rw [derivWithin_tsum_fun']
-  · apply tsum_congr
-    intro b
+  induction k generalizing x with
+  | zero => simp only [iteratedDerivWithin_zero]
+  | succ k IH =>
     rw [iteratedDerivWithin_succ]
-  · exact isOpen_lt (by fun_prop) (by fun_prop)
-  · exact x.2
-  · intro y hy
-    apply Summable.congr (summable_iter_derv' k ⟨y, hy⟩)
-    intro b
-    apply symm
-    apply exp_iter_deriv_within k b hy
-  · intro K hK1 hK2
-    let K2 := Set.image (Set.inclusion hK1) univ
-    have hKK2 : IsCompact (Set.image (inclusion hK1) univ) := by
-      apply IsCompact.image_of_continuousOn
-      · exact isCompact_iff_isCompact_univ.mp hK2
-      · exact continuous_inclusion hK1 |>.continuousOn
-    apply iter_deriv_comp_bound2 K hK1 hK2 k
-  apply der_iter_eq_der_aux2
+    have HH :
+      derivWithin (iteratedDerivWithin k (fun z => ∑' n : ℕ,
+                                            Complex.exp (2 * ↑π * Complex.I * n * z))
+        {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im}
+          x =
+        derivWithin
+          (fun z =>
+            ∑' n : ℕ, iteratedDerivWithin k (fun s : ℂ => Complex.exp (2 * ↑π * Complex.I * n * s))
+                                          {z : ℂ | 0 < z.im} z)
+          {z : ℂ | 0 < z.im} x := by
+      apply derivWithin_congr
+      intro y hy
+      apply IH ⟨y, hy⟩
+      apply IH x
+    simp_rw [HH]
+    rw [derivWithin_tsum_fun']
+    · apply tsum_congr
+      intro b
+      rw [iteratedDerivWithin_succ]
+    · exact isOpen_lt (by fun_prop) (by fun_prop)
+    · exact x.2
+    · intro y hy
+      apply Summable.congr (summable_iter_derv' k ⟨y, hy⟩)
+      intro b
+      apply symm
+      apply exp_iter_deriv_within k b hy
+    · intro K hK1 hK2
+      let K2 := Set.image (Set.inclusion hK1) univ
+      have hKK2 : IsCompact (Set.image (inclusion hK1) univ) := by
+        apply IsCompact.image_of_continuousOn
+        · exact isCompact_iff_isCompact_univ.mp hK2
+        · exact continuous_inclusion hK1 |>.continuousOn
+      apply iter_deriv_comp_bound2 K hK1 hK2 k
+    apply der_iter_eq_der_aux2
 
 theorem exp_series_ite_deriv_uexp'' (k : ℕ) (x : {z : ℂ | 0 < z.im}) :
     iteratedDerivWithin k (fun z => ∑' n : ℕ, Complex.exp (2 * ↑π * Complex.I * n * z))
@@ -1258,45 +1260,47 @@ theorem aut_series_ite_deriv_uexp2 (k : ℕ) (x : ℍ) :
       ∑' n : ℕ+, iteratedDerivWithin k (fun z : ℂ => 1 / (z - n) + 1 / (z + n)) {z : ℂ | 0 < z.im} x
         :=
   by
-  induction' k with k IH generalizing x
-  · simp only [iteratedDerivWithin_zero]
-  rw [iteratedDerivWithin_succ]
-  have HH :
-    derivWithin (iteratedDerivWithin k (fun z : ℂ => ∑' n : ℕ+, (1 / (z - n) + 1 / (z + n)))
-      {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im} x =
-      derivWithin
-        (fun z => ∑' n : ℕ+, iteratedDerivWithin k (fun z : ℂ => 1 / (z - n) + 1 / (z + n)) {z : ℂ |
-          0 < z.im} z) {z : ℂ | 0 < z.im}
-        x := by
-    apply derivWithin_congr
-    intro y hy
-    apply IH ⟨y, hy⟩
-    apply IH x
-  simp_rw [HH]
-  simp
-  rw [derivWithin_tsum_fun']
-  · apply tsum_congr
-    intro b
+  induction k generalizing x with
+  | zero => simp only [iteratedDerivWithin_zero]
+  | succ k IH =>
     rw [iteratedDerivWithin_succ]
-  · refine isOpen_lt ?_ ?_
-    · fun_prop
-    · fun_prop
-  · simpa using x.2
-  · intro y hy
-    simpa using summable_iter_aut k ⟨y, hy⟩
-  · intro K hK hK2
-    let K2 := Set.image (Set.inclusion hK) univ
-    have hKK2 : IsCompact (Set.image (inclusion hK) univ) := by
-      apply IsCompact.image_of_continuousOn
-      · exact isCompact_iff_isCompact_univ.mp hK2
-      · exact continuous_inclusion hK |>.continuousOn
-    have := aut_bound_on_comp K2 hKK2 k
-    obtain ⟨u, hu1, hu2⟩ := this
-    refine ⟨u, hu1, ?_⟩
-    intro n s
-    apply hu2 n ⟨⟨s, by aesop⟩, by aesop⟩
-  intro n r
-  apply diff_at_aux
+    have HH :
+      derivWithin (iteratedDerivWithin k (fun z : ℂ => ∑' n : ℕ+, (1 / (z - n) + 1 / (z + n)))
+        {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im} x =
+        derivWithin
+          (fun z => ∑' n : ℕ+, iteratedDerivWithin k (fun z : ℂ => 1 / (z - n) + 1 / (z + n))
+                                                     {z : ℂ | 0 < z.im} z)
+          {z : ℂ | 0 < z.im}
+          x := by
+      apply derivWithin_congr
+      intro y hy
+      apply IH ⟨y, hy⟩
+      apply IH x
+    simp_rw [HH]
+    simp
+    rw [derivWithin_tsum_fun']
+    · apply tsum_congr
+      intro b
+      rw [iteratedDerivWithin_succ]
+    · refine isOpen_lt ?_ ?_
+      · fun_prop
+      · fun_prop
+    · simpa using x.2
+    · intro y hy
+      simpa using summable_iter_aut k ⟨y, hy⟩
+    · intro K hK hK2
+      let K2 := Set.image (Set.inclusion hK) univ
+      have hKK2 : IsCompact (Set.image (inclusion hK) univ) := by
+        apply IsCompact.image_of_continuousOn
+        · exact isCompact_iff_isCompact_univ.mp hK2
+        · exact continuous_inclusion hK |>.continuousOn
+      have := aut_bound_on_comp K2 hKK2 k
+      obtain ⟨u, hu1, hu2⟩ := this
+      refine ⟨u, hu1, ?_⟩
+      intro n s
+      apply hu2 n ⟨⟨s, by aesop⟩, by aesop⟩
+    intro n r
+    apply diff_at_aux
 
 theorem tsum_ider_der_eq (k : ℕ) (x : {z : ℂ | 0 < z.im}) :
     ∑' n : ℕ+, iteratedDerivWithin k (fun z : ℂ => 1 / (z - n) + 1 / (z + n)) {z : ℂ | 0 < z.im} x =


### PR DESCRIPTION
After the version bump in #172, there are some new linter warnings, mostly about `induction'` being deprecated. This PR fixes them.
