### PR TITLE
feat(ModularForms/ResToImagAxis): prove `ResToImagAxis.Differentiable`

### DIFF
--- a/SpherePacking/ModularForms/ResToImagAxis.lean
+++ b/SpherePacking/ModularForms/ResToImagAxis.lean
@@ -60,7 +60,7 @@ theorem ResToImagAxis.Differentiable (F : ℍ → ℂ) (hF : MDifferentiable �
   apply h_diff.congr_of_eventuallyEq
   filter_upwards [lt_mem_nhds ht] with t ht
   simp_all only [coe_mk_subtype, ResToImagAxis, ↓reduceDIte]
-  rw [ofComplex_apply_of_im_pos _]
+  rw [ofComplex_apply_of_im_pos]
 
 /--
 Restriction and slash action under S: $(F |_k S) (it) = t^{-k} * F(it)$


### PR DESCRIPTION
Co-authored-by: Aristotle Harmonic [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun)