### PR TITLE
Add proofs by Gauss in `ModularForms/Derivative.lean`

### DIFF
--- a/SpherePacking/ModularForms/Derivative.lean
+++ b/SpherePacking/ModularForms/Derivative.lean
@@ -328,10 +328,9 @@ example : D (E₄.toFun * E₄.toFun) = 2 * 3⁻¹ * E₄.toFun * (E₂ * E₄.t
 /-
 Interaction between (Serre) derivative and restriction to the imaginary axis.
 -/
-
 lemma StrictAntiOn.eventuallyPos_Ioi {g : ℝ → ℝ} (hAnti : StrictAntiOn g (Set.Ioi (0 : ℝ)))
     {t₀ : ℝ} (ht₀_pos : 0 < t₀) (hEv : ∀ t : ℝ, t₀ ≤ t → 0 < g t) :
-  ∀ t : ℝ, 0 < t → 0 < g t := by
+    ∀ t : ℝ, 0 < t → 0 < g t := by
   intro t ht
   by_cases hcase : t₀ ≤ t
   · exact hEv t hcase
@@ -347,8 +346,7 @@ The key computation is:
 - Since D = (2πi)⁻¹ · d/dz, we have F' = 2πi · D F
 - So d/dt F(it) = 2πi · D F(it) · I = -2π · D F(it)
 -/
-theorem deriv_resToImagAxis_eq (F : ℍ → ℂ) (hF : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) F)
-    {t : ℝ} (ht : 0 < t) :
+theorem deriv_resToImagAxis_eq (F : ℍ → ℂ) (hF : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) F) {t : ℝ} (ht : 0 < t) :
     deriv F.resToImagAxis t = -2 * π * (D F).resToImagAxis t := by
   let z : ℍ := ⟨I * t, by simp [ht]⟩
   let g : ℝ → ℂ := (I * ·)
@@ -369,28 +367,30 @@ theorem deriv_resToImagAxis_eq (F : ℍ → ℂ) (hF : MDifferentiable 𝓘(ℂ)
 If $F$ is a modular form where $F(it)$ is positive for sufficiently large $t$ (i.e. constant term
 is positive) and the derivative is positive, then $F$ is also positive.
 -/
-theorem antiDerPos {F : ℍ → ℂ} {k : ℤ} (hF : ResToImagAxis.EventuallyPos F)
-    (hDF : ResToImagAxis.Pos (D F)) : ResToImagAxis.Pos F := by
-  obtain ⟨hF_real, t₀, ht₀_pos, hF_pos⟩ := hF; obtain ⟨-, hDF_pos⟩ := hDF
+theorem antiDerPos {F : ℍ → ℂ} (hFderiv : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) F)
+    (hFepos : ResToImagAxis.EventuallyPos F) (hDF : ResToImagAxis.Pos (D F)) :
+    ResToImagAxis.Pos F := by
+  obtain ⟨hF_real, t₀, ht₀_pos, hF_pos⟩ := hFepos
+  obtain ⟨-, hDF_pos⟩ := hDF
   let g := fun t => (F.resToImagAxis t).re
-  have hg : ∀ t, 0 < t → HasDerivAt g (-(2 * π) * (ResToImagAxis (D F) t).re) t := fun t ht => by
-    let z0 : ℂ := Complex.I * t; let zH : ℍ := ⟨z0, by simp [z0, ht]⟩; let Φ := F ∘ ofComplex
-    have hax : ResToImagAxis (D F) t = D F zH := by simp [ResToImagAxis, ht, zH, z0]
-    have hΦ : DifferentiableAt ℂ Φ z0 := differentiableAt_of_deriv_ne_zero fun h => by
-      have hpos : 0 < (D F zH).re := by simpa [hax] using hDF_pos t ht
-      simp [D, Φ, zH, h] at hpos
-    have hi : HasDerivAt (Complex.I * ·) Complex.I t := by simpa [mul_comm] using hasDerivAt_mul_const Complex.I
-    have he := (by simpa [Φ, mul_comm, mul_left_comm] using hΦ.hasDerivAt.comp (t : ℂ) hi :
-      HasDerivAt (Φ <| Complex.I * ·) (deriv Φ z0 * Complex.I) t)
-    have hev : ∀ᶠ x in nhds t, g x = (Φ (Complex.I * x)).re := by filter_upwards [lt_mem_nhds ht] with x hx; simp [g, Φ, ResToImagAxis, hx, ofComplex_apply_of_im_pos (by simp [hx] : 0 < (Complex.I * x).im)]
-    have hd : deriv Φ z0 = 2 * π * Complex.I * D F zH := by
-      have h : D F zH = (2 * π * Complex.I)⁻¹ * deriv Φ z0 := by simp [D, Φ, zH]
-      field_simp [Real.pi_ne_zero, Complex.I_ne_zero] at h ⊢; ring_nf at h ⊢; exact h.symm
-    simpa [hd, Complex.mul_re, Complex.mul_im, hax] using he.real_of_complex.congr_of_eventuallyEq hev
-  have hn : ∀ x ∈ Set.Ioi (0 : ℝ), deriv g x < 0 := fun x (hx : 0 < x) => by
-    rw [(hg x hx).deriv]; have hx' : 0 < (ResToImagAxis (D F) x).re := hDF_pos x hx; nlinarith [Real.pi_pos]
-  exact ⟨hF_real, fun t ht => StrictAntiOn.eventuallyPos_Ioi (strictAntiOn_of_deriv_neg (convex_Ioi 0)
-    (fun x hx => (hg x hx).continuousAt.continuousWithinAt) (by simpa [interior_Ioi] using hn)) ht₀_pos hF_pos t ht⟩
+  have hg : ∀ t, 0 < t → HasDerivAt g (-2 * π * (ResToImagAxis (D F) t).re) t := fun t ht => by
+    have hdiff : DifferentiableAt ℝ F.resToImagAxis t :=
+      ResToImagAxis.Differentiable F hFderiv t ht
+    have hderivC : HasDerivAt F.resToImagAxis (-2 * π * (D F).resToImagAxis t) t :=
+      hdiff.hasDerivAt.congr_deriv (deriv_resToImagAxis_eq F hFderiv ht)
+    have hconst : HasDerivAt (fun _ : ℝ => (Complex.reCLM : ℂ →L[ℝ] ℝ)) 0 t := by
+      simpa using (hasDerivAt_const (x := t) (c := (Complex.reCLM : ℂ →L[ℝ] ℝ)))
+    have hreal := hconst.clm_apply hderivC
+    simpa [g] using hreal
+  have hn : ∀ t ∈ Set.Ioi (0 : ℝ), deriv g t < 0 := fun t (ht : 0 < t) => by
+    rw [(hg t ht).deriv]
+    have ht' : 0 < (ResToImagAxis (D F) t).re := hDF_pos t ht
+    nlinarith [Real.pi_pos]
+  have gpos := fun t ht =>
+    StrictAntiOn.eventuallyPos_Ioi (strictAntiOn_of_deriv_neg (convex_Ioi 0)
+    (fun x hx => (hg x hx).continuousAt.continuousWithinAt)
+      (by simpa [interior_Ioi] using hn)) ht₀_pos hF_pos t ht
+  exact ⟨hF_real, gpos⟩
 
 /--
 Let $F : \mathbb{H} \to \mathbb{C}$ be a holomorphic function where $F(it)$ is real for all $t > 0$.


### PR DESCRIPTION
This PR contributes 2 proofs for previously incomplete theorems automatically generated and optimized by Gauss, Math Inc's autoformalization agent.

Theorems solved:
- `E₂_holo'`
- `antiDerPos`

---------