### PR TITLE
fix linter warnings

### DIFF
--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I1.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I1.lean
@@ -173,12 +173,12 @@ end Bounding_Integrand
 
 section Integrability
 
-lemma Bound_integrableOn (r C₀ : ℝ) (hC₀_pos : C₀ > 0)
-    (hC₀ : ∀ x ∈ Ici 1, ‖g r x‖ ≤ C₀ * rexp (-2 * π * x) * rexp (-π * r / x)) :
+lemma Bound_integrableOn (r C₀ : ℝ) :
     IntegrableOn (fun s ↦ C₀ * rexp (-2 * π * s) * rexp (-π * r / s)) (Ici 1) volume := by
   set μ := volume.restrict (Ici (1 : ℝ))
   have h_g : Integrable (fun s ↦ C₀ * rexp (-2 * π * s)) μ :=
-    ((integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrableOn_exp_mul_Ioi (by linarith [pi_pos]) 1)).const_mul C₀
+    ((integrableOn_Ici_iff_integrableOn_Ioi).mpr
+      (integrableOn_exp_mul_Ioi (by linarith [pi_pos]) 1)).const_mul C₀
   have hφ : AEStronglyMeasurable (fun s ↦ rexp (-π * r / s)) μ :=
     (Real.continuous_exp.measurable.comp (measurable_const.mul measurable_inv)).aestronglyMeasurable
   have hb : ∀ᵐ s ∂μ, ‖rexp (-π * r / s)‖ ≤ rexp (π * |r|) :=
@@ -203,7 +203,7 @@ lemma I₁'_bounding_1_aux_3 (r : ℝ) : ∃ C₀ > 0, ∫ (s : ℝ) in Ici 1, �
     positivity
   obtain ⟨C₀, hC₀_pos, hC₀⟩ := I₁'_bounding_aux_2 r
   use C₀, hC₀_pos
-  exact setIntegral_mono_on hint (Bound_integrableOn r C₀ hC₀_pos hC₀) measurableSet_Ici hC₀
+  exact setIntegral_mono_on hint (Bound_integrableOn r C₀) measurableSet_Ici hC₀
 
 theorem I₁'_bounding (r : ℝ) : ∃ C₀ > 0,
     ‖I₁' r‖ ≤ ∫ s in Ici (1 : ℝ), C₀ * rexp (-2 * π * s) * rexp (-π * r / s) := by

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I3.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I3.lean
@@ -173,27 +173,31 @@ end Bounding_Integrand
 
 section Integrability
 
-lemma Bound_integrableOn (r C₀ : ℝ) (hC₀_pos : C₀ > 0)
-    (hC₀ : ∀ x ∈ Ici 1, ‖g r x‖ ≤ C₀ * rexp (-2 * π * x) * rexp (-π * r / x)) :
+lemma Bound_integrableOn (r C₀ : ℝ) (hC₀_pos : C₀ > 0) :
     IntegrableOn (fun s ↦ C₀ * rexp (-2 * π * s) * rexp (-π * r / s)) (Ici 1) volume := by
   set f := fun s : ℝ ↦ C₀ * rexp (-2 * π * s) * rexp (-π * r / s)
   have hcont : ContinuousOn f (Ici 1) := by
     have h1 : ContinuousOn (fun s : ℝ ↦ rexp ((-2 * π) * s)) (Ici 1) :=
       Real.continuous_exp.comp_continuousOn (continuousOn_const.mul continuousOn_id)
-    have h2 : ContinuousOn (fun s : ℝ ↦ rexp ((-π * r) * s⁻¹)) (Ici 1) := Real.continuous_exp.comp_continuousOn
-      (continuousOn_const.mul (continuousOn_id.inv₀ fun _ hx ↦ (zero_lt_one.trans_le hx).ne'))
+    have h2 : ContinuousOn (fun s : ℝ ↦ rexp ((-π * r) * s⁻¹)) (Ici 1) :=
+      Real.continuous_exp.comp_continuousOn
+        (continuousOn_const.mul (continuousOn_id.inv₀ fun _ hx ↦ (zero_lt_one.trans_le hx).ne'))
     simpa [f, mul_comm, mul_left_comm, div_eq_mul_inv] using continuousOn_const.mul (h1.mul h2)
   have hO : f =O[atTop] fun s ↦ rexp (-(2 * π) * s) := .of_bound (c := |C₀| * rexp (π * |r|)) <| by
     filter_upwards [Filter.Ici_mem_atTop 1] with s hs
-    have heb : rexp (-π * r / s) ≤ rexp (π * |r|) := Real.exp_le_exp.mpr <| (le_abs_self _).trans <| by
-      simp [abs_div, abs_mul, abs_of_nonneg Real.pi_pos.le]; exact div_le_self (by positivity) (by rwa [abs_of_nonneg (zero_lt_one.trans_le hs).le])
-    simp only [f, Real.norm_eq_abs, Real.abs_exp, abs_mul, mul_comm, mul_left_comm, mul_assoc, div_eq_mul_inv]
+    have heb : rexp (-π * r / s) ≤ rexp (π * |r|) :=
+      Real.exp_le_exp.mpr <| (le_abs_self _).trans <| by
+        simp [abs_div, abs_mul, abs_of_nonneg Real.pi_pos.le]
+        exact div_le_self (by positivity) (by rwa [abs_of_nonneg (zero_lt_one.trans_le hs).le])
+    simp only [f, Real.norm_eq_abs, Real.abs_exp, abs_mul, mul_comm, mul_left_comm,
+      mul_assoc, div_eq_mul_inv]
     calc |C₀| * (rexp (r * (s⁻¹ * -π)) * rexp (s * (π * -2)))
         = |C₀| * rexp ((-2 * π) * s) * rexp (-π * r / s) := by ring_nf
       _ ≤ _ := mul_le_mul_of_nonneg_left heb (by positivity)
       _ = _ := by ring_nf
   simpa [f, div_eq_mul_inv, neg_mul, mul_neg, mul_comm, mul_left_comm, mul_assoc] using
-    (integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrable_of_isBigO_exp_neg (by positivity) hcont hO)
+    (integrableOn_Ici_iff_integrableOn_Ioi).mpr
+      (integrable_of_isBigO_exp_neg (by positivity) hcont hO)
 
 end Integrability
 
@@ -209,7 +213,7 @@ lemma I₃'_bounding_1_aux_3 (r : ℝ) : ∃ C₀ > 0, ∫ (s : ℝ) in Ici 1, �
     positivity
   obtain ⟨C₀, hC₀_pos, hC₀⟩ := I₃'_bounding_aux_2 r
   use C₀, hC₀_pos
-  exact setIntegral_mono_on hint (Bound_integrableOn r C₀ hC₀_pos hC₀) measurableSet_Ici hC₀
+  exact setIntegral_mono_on hint (Bound_integrableOn r C₀ hC₀_pos) measurableSet_Ici hC₀
 
 theorem I₃'_bounding (r : ℝ) : ∃ C₀ > 0,
     ‖I₃' r‖ ≤ ∫ s in Ici (1 : ℝ), C₀ * rexp (-2 * π * s) * rexp (-π * r / s) := by

--- a/SpherePacking/MagicFunction/a/IntegralEstimates/I5.lean
+++ b/SpherePacking/MagicFunction/a/IntegralEstimates/I5.lean
@@ -172,19 +172,21 @@ end Bounding_Integrand
 
 section Integrability
 
-lemma Bound_integrableOn (r C₀ : ℝ) (hC₀_pos : C₀ > 0)
-    (hC₀ : ∀ x ∈ Ici 1, ‖g r x‖ ≤ C₀ * rexp (-2 * π * x) * rexp (-π * r / x)) :
+lemma Bound_integrableOn (r C₀ : ℝ) :
     IntegrableOn (fun s ↦ C₀ * rexp (-2 * π * s) * rexp (-π * r / s)) (Ici 1) volume := by
-  have h_exp : IntegrableOn (fun s => rexp ((-2 * π) * s)) (Ici 1) := (integrableOn_Ici_iff_integrableOn_Ioi).mpr <|
-    by simpa [mul_comm] using integrableOn_exp_mul_Ioi (by linarith [Real.pi_pos] : -2 * π < 0) 1
+  have h_exp : IntegrableOn (fun s => rexp ((-2 * π) * s)) (Ici 1) :=
+    (integrableOn_Ici_iff_integrableOn_Ioi).mpr <| by
+      simpa [mul_comm] using integrableOn_exp_mul_Ioi (by linarith [Real.pi_pos] : -2 * π < 0) 1
   have h_bnd : ∀ᵐ s ∂volume.restrict (Ici (1:ℝ)), ‖rexp (-π * r / s)‖ ≤ rexp (π * |r|) := by
     rw [ae_restrict_iff' measurableSet_Ici]; refine .of_forall fun s (hs : 1 ≤ s) ↦ ?_
     simp only [Real.norm_eq_abs, abs_of_nonneg (Real.exp_pos _).le]; apply Real.exp_le_exp.mpr
     calc -π * r / s ≤ |-(π * r) / s| := by simpa [neg_mul] using le_abs_self _
-      _ = (π * |r|) / s := by simp [abs_div, abs_neg, abs_mul, abs_of_nonneg Real.pi_pos.le, abs_of_nonneg (zero_le_one.trans hs)]
+      _ = (π * |r|) / s := by simp [abs_div, abs_neg, abs_mul, abs_of_nonneg Real.pi_pos.le,
+                                abs_of_nonneg (zero_le_one.trans hs)]
       _ ≤ _ := div_le_self (mul_nonneg Real.pi_pos.le (abs_nonneg _)) hs
-  simpa [IntegrableOn, mul_comm, mul_left_comm, mul_assoc, div_eq_mul_inv] using (h_exp.const_mul C₀).bdd_mul'
-    (Real.continuous_exp.measurable.comp (measurable_const.mul measurable_id.inv)).aestronglyMeasurable h_bnd
+  simpa [IntegrableOn, mul_comm, mul_left_comm, mul_assoc, div_eq_mul_inv] using
+    (h_exp.const_mul C₀).bdd_mul' (Real.continuous_exp.measurable.comp
+      (measurable_const.mul measurable_id.inv)).aestronglyMeasurable h_bnd
 
 end Integrability
 
@@ -200,7 +202,7 @@ lemma I₅'_bounding_1_aux_3 (r : ℝ) : ∃ C₀ > 0, ∫ (s : ℝ) in Ici 1, �
     positivity
   obtain ⟨C₀, hC₀_pos, hC₀⟩ := I₅'_bounding_aux_2 r
   use C₀, hC₀_pos
-  exact setIntegral_mono_on hint (Bound_integrableOn r C₀ hC₀_pos hC₀) measurableSet_Ici hC₀
+  exact setIntegral_mono_on hint (Bound_integrableOn r C₀) measurableSet_Ici hC₀
 
 theorem I₅'_bounding (r : ℝ) : ∃ C₀ > 0,
     ‖I₅' r‖ ≤ 2 * ∫ s in Ici (1 : ℝ), C₀ * rexp (-2 * π * s) * rexp (-π * r / s) := by

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -50,12 +50,19 @@ theorem I₂'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₂' := by
 
 theorem I₃'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₃' := by
   have hI : RealIntegrals.I₃' = fun x : ℝ => cexp (2 * π * I * x) * RealIntegrals.I₁' x := by
-    ext x; have hEqOn : EqOn (fun t => I * φ₀'' (-1 / (z₃' t - 1)) * (z₃' t - 1) ^ 2 * cexp (π * I * x * z₃' t))
-        (fun t => cexp (2 * π * I * x) * (I * φ₀'' (-1 / (z₁' t + 1)) * (z₁' t + 1) ^ 2 * cexp (π * I * x * z₁' t)))
+    ext x
+    have hEqOn : EqOn
+        (fun t => I * φ₀'' (-1 / (z₃' t - 1)) * (z₃' t - 1) ^ 2 * cexp (π * I * x * z₃' t))
+        (fun t => cexp (2 * π * I * x) * (I * φ₀'' (-1 / (z₁' t + 1)) * (z₁' t + 1) ^ 2 *
+                                          cexp (π * I * x * z₁' t)))
         (uIcc 0 1) := fun t ht => by
-      rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1)] at ht; have h1 := z₁'_eq_of_mem ht; have h3 := z₃'_eq_of_mem ht
-      simp_rw [show z₃' t - 1 = I * t by simp [h3], show z₃' t = z₁' t + 2 by simp [h1, h3]; ring,
-        show z₁' t + 1 = I * t by simp [h1], mul_add, Complex.exp_add, mul_comm, mul_left_comm, mul_assoc]
+      rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1)] at ht
+      have h1 := z₁'_eq_of_mem ht; have h3 := z₃'_eq_of_mem ht
+      simp_rw [
+        show z₃' t - 1 = I * t by simp [h3],
+        show z₃' t = z₁' t + 2 by simp [h1, h3]; ring,
+        show z₁' t + 1 = I * t by simp [h1],
+        mul_add, Complex.exp_add, mul_comm, mul_left_comm, mul_assoc]
     simpa [RealIntegrals.I₃', RealIntegrals.I₁', mul_comm, mul_left_comm, mul_assoc] using
       intervalIntegral.integral_congr (a := 0) (b := 1) hEqOn
   simpa [hI] using (contDiff_const.mul ofRealCLM.contDiff).cexp.mul I₁'_smooth'

--- a/SpherePacking/MagicFunction/b/Eigenfunction.lean
+++ b/SpherePacking/MagicFunction/b/Eigenfunction.lean
@@ -21,9 +21,20 @@ theorem perm_J₅ : fourierTransformCLE ℂ (J₅) = -J₆ := by sorry
 -- Should use results from `RadialSchwartz.Radial` and linearity to prove the reverse.
 
 theorem perm_₃_J₄ : fourierTransformCLE ℂ (J₃ + J₄) = -(J₁ + J₂) := by
-  have h₁ : fourierTransformCLE ℂ (fourierTransformCLE ℂ J₁) = J₁ := by ext x; simpa [J₁, schwartzMap_multidimensional_of_schwartzMap_real, compCLM_apply, Real.fourierIntegralInv_eq_fourierIntegral_neg] using congrArg (· (-x)) (J₁.continuous.fourier_inversion J₁.integrable (fourierTransformCLE ℂ J₁).integrable)
-  have h₂ : fourierTransformCLE ℂ (fourierTransformCLE ℂ J₂) = J₂ := by ext x; simpa [J₂, schwartzMap_multidimensional_of_schwartzMap_real, compCLM_apply, Real.fourierIntegralInv_eq_fourierIntegral_neg] using congrArg (· (-x)) (J₂.continuous.fourier_inversion J₂.integrable (fourierTransformCLE ℂ J₂).integrable)
-  simpa [map_add, map_neg, h₁, h₂, add_comm] using congrArg (-fourierTransformCLE ℂ ·) perm_J₁_J₂ |>.symm
+  have h₁ : fourierTransformCLE ℂ (fourierTransformCLE ℂ J₁) = J₁ := by
+    ext x
+    simpa [J₁, schwartzMap_multidimensional_of_schwartzMap_real, compCLM_apply,
+      Real.fourierIntegralInv_eq_fourierIntegral_neg] using
+        congrArg (· (-x)) (J₁.continuous.fourier_inversion J₁.integrable
+          (fourierTransformCLE ℂ J₁).integrable)
+  have h₂ : fourierTransformCLE ℂ (fourierTransformCLE ℂ J₂) = J₂ := by
+    ext x
+    simpa [J₂, schwartzMap_multidimensional_of_schwartzMap_real, compCLM_apply,
+      Real.fourierIntegralInv_eq_fourierIntegral_neg] using
+        congrArg (· (-x)) (J₂.continuous.fourier_inversion J₂.integrable
+          (fourierTransformCLE ℂ J₂).integrable)
+  simpa [map_add, map_neg, h₁, h₂, add_comm] using
+    congrArg (-fourierTransformCLE ℂ ·) perm_J₁_J₂ |>.symm
 
 theorem perm_J₆ : fourierTransformCLE ℂ (J₆) = -J₅ := by
   have h : (fourierTransformCLE ℂ).symm J₆ = fourierTransformCLE ℂ J₆ := by


### PR DESCRIPTION
Fixes `linter.style.longLine` and `linter.unusedVariables` warnings introduced in #204.