### PR TITLE
add free-disk-space step to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Project
     steps:
+      - name: Cleanup to free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Checkout project
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
Many Blueprint projects have recently run into the "No space left on device" error that we saw [here](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/actions/runs/20245041279/job/58122754452).

This PR adds the workaround that has been used elsewhere, e.g. https://github.com/ImperialCollegeLondon/FLT/pull/776