### PR TITLE
fix: update lake-manifest.json to avoid warning

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -18,7 +18,7 @@
    "rev": "32d24245c7a12ded17325299fd41d412022cd3fe",
    "name": "mathlib",
    "manifestFile": "lake-manifest.json",
-   "inputRev": "v4.27.0-rc1",
+   "inputRev": null,
    "inherited": false,
    "configFile": "lakefile.lean"},
   {"url": "https://github.com/leanprover-community/plausible",


### PR DESCRIPTION
Fixes the warning
```
warning: manifest out of date: git revision of dependency 'mathlib' changed; use `lake update mathlib` to update it
```
introduced by #244.