### PR TITLE
feat(ModularForms/Derivative): prove D_slash for derivative of slashed functions

### DIFF
--- a/SpherePacking/ModularForms/Derivative.lean
+++ b/SpherePacking/ModularForms/Derivative.lean
@@ -512,11 +512,10 @@ lemma D_slash (k : ℤ) (F : ℍ → ℂ) (hF : MDifferentiable 𝓘(ℂ) 𝓘(�
     exact (γ • z).im_pos
   have hdiff_F_comp : DifferentiableAt ℂ (F ∘ ofComplex) (num γ z / denom γ z) :=
     MDifferentiableAt_DifferentiableAt (hF ⟨num γ z / denom γ z, hmobius_in_H⟩)
+  have hcomp_eq : (fun w => (F ∘ ofComplex) (num γ w / denom γ w)) =
+      (F ∘ ofComplex) ∘ (fun w => num γ w / denom γ w) := rfl
   have hdiff_F_mobius : DifferentiableAt ℂ (fun w => (F ∘ ofComplex) (num γ w / denom γ w)) z := by
-    -- The composition (F ∘ ofComplex) ∘ (num/denom) : ℂ → ℂ
-    have heq : (fun w => (F ∘ ofComplex) (num γ w / denom γ w)) =
-        (F ∘ ofComplex) ∘ (fun w => num γ w / denom γ w) := rfl
-    rw [heq]
+    rw [hcomp_eq]
     exact DifferentiableAt.comp (z : ℂ) hdiff_F_comp hdiff_mobius
   -- Apply product rule
   -- Note: need to show the functions are equal to use deriv_mul
@@ -528,11 +527,7 @@ lemma D_slash (k : ℤ) (F : ℍ → ℂ) (hF : MDifferentiable 𝓘(ℂ) 𝓘(�
   -- Apply chain rule to (F ∘ ofComplex) ∘ mobius
   have hchain : deriv (fun w => (F ∘ ofComplex) (num γ w / denom γ w)) z =
       deriv (F ∘ ofComplex) (num γ z / denom γ z) * deriv (fun w => num γ w / denom γ w) z := by
-    -- Chain rule: d/dx[f(g(x))] = f'(g(x)) * g'(x)
-    have heq : (fun w => (F ∘ ofComplex) (num γ w / denom γ w)) =
-        (F ∘ ofComplex) ∘ (fun w => num γ w / denom γ w) := rfl
-    have hcomp := hdiff_F_comp.hasDerivAt.comp (z : ℂ) hdiff_mobius.hasDerivAt
-    rw [heq, hcomp.deriv]
+    rw [hcomp_eq, (hdiff_F_comp.hasDerivAt.comp (z : ℂ) hdiff_mobius.hasDerivAt).deriv]
   -- Substitute the micro-lemmas
   have hderiv_mob := deriv_moebius γ z
   have hderiv_zpow := deriv_denom_zpow γ k z


### PR DESCRIPTION
## Summary
- Prove how the normalized derivative D interacts with the slash action
- Key formula: D (F ∣[k] γ) = (D F) ∣[k+2] γ - k(2πi)⁻¹(c/(cz+d))(F ∣[k] γ)

## Relation to other work
- Extracted from #248 (q-expansion-Eisenstein) to enable separate review/golfing
- **#248 depends on this PR** — the `serre_D_slash_equivariant` proof uses `D_slash`
- Addresses partial progress on Issue #86 (Serre derivative equivariance)
- D_slash is the key technical result for Ramanujan's differential equations
- ~~No longer builds on #250 (generalizes serre_D weights from `ℤ` to `ℂ`)~~

## What's included
- 6 helper lemmas for computing derivatives of Möbius components:
  - `deriv_denom`: d/dz[cz + d] = c
  - `deriv_num`: d/dz[az + b] = a
  - `differentiableAt_denom`: differentiability of cz+d
  - `differentiableAt_num`: differentiability of az+b
  - `deriv_moebius`: d/dz[(az+b)/(cz+d)] = 1/(cz+d)² (uses det=1)
  - `deriv_denom_zpow`: d/dz[(cz+d)^(-k)] = -k·c·(cz+d)^(-k-1)
- Main `D_slash` lemma

## Golfing completed
- `deriv_denom` and `deriv_num`: Reduced from ~15 lines each to 2 lines using `simp only [denom/num]` + `rw` approach
- `deriv_moebius`: Reduced from ~44 lines to ~33 lines by removing explicit coercion lemmas
- `deriv_denom_zpow`: Reduced from ~17 lines to ~8 lines using `:=` syntax and `rfl`
- `D_slash`: Removed unused locals (hc, hD_eq, hslash_k, hslash_k2), fixed long lines
- Consolidated 6 `open ModularGroup in` statements into single `section DSlashHelpers`
- Total: ~51 lines removed

## Merge Order

This PR is part of a chain for q-expansion and Ramanujan identities:

1. **#265**: cauchy-boundedness (independent, can merge first)
2. **#251**: D-slash lemma ← (this PR, independent of #265)
3. **#266**: serre-derivative-asymptotics (merge after both #265 and #251)
4. **#267**: core-ramanujan
5. **#268**: q-expansion-identities
6. **#248**: q-expansion-Eisenstein (MLDE)

**Note:** #265 and #251 are independent and can merge in either order. #266 requires both to be merged first.

## Test plan
- [x] `lake build SpherePacking.ModularForms.Derivative` passes
- [x] Linting passes (no lines over 100 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)