### PR TITLE
chore: remove upstreamed lemma hasTemperateGrowth_norm_sq

### DIFF
--- a/SpherePacking/ForMathlib/RadialSchwartz/Multidimensional.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/Multidimensional.lean
@@ -26,21 +26,11 @@ lemma differentiableAt_norm_sq {x : F} :
 lemma differentiable_norm_sq :
   Differentiable ℝ (fun (x : F) ↦ ‖x‖ ^ 2) := fun _ => differentiableAt_norm_sq
 
-lemma hasTemperateGrowth_norm_sq :
-    HasTemperateGrowth (fun (x :F) ↦ ‖x‖ ^ 2) := by
-  refine Function.HasTemperateGrowth.of_fderiv ?_ differentiable_norm_sq (k := 2) (C := 1) ?_
-  · convert (2 • (innerSL ℝ)).hasTemperateGrowth
-    ext
-    simp
-  · intro x
-    rw [norm_pow, norm_norm, one_mul, sq_le_sq, abs_norm, abs_of_nonneg (by positivity)]
-    linear_combination
-
 variable (F : Type*) [NormedAddCommGroup F] [InnerProductSpace ℝ F] (f : 𝓢(ℝ, ℂ))
 
 @[simps!]
 noncomputable def schwartzMap_multidimensional_of_schwartzMap_real : 𝓢(F, ℂ) :=
-    f.compCLM ℝ hasTemperateGrowth_norm_sq <| by
+    f.compCLM ℝ (Function.hasTemperateGrowth_norm_sq F) <| by
   use 1, 1
   intro _
   simp only [norm_pow, norm_norm]


### PR DESCRIPTION
This lemma landed in mathlib in https://github.com/leanprover-community/mathlib4/pull/31682.