### PR TITLE
chore(logDeriv_lems): shorten proof of logDeriv_tprod_eq_tsum2

### DIFF
--- a/SpherePacking/ModularForms/logDeriv_lems.lean
+++ b/SpherePacking/ModularForms/logDeriv_lems.lean
@@ -74,17 +74,8 @@ theorem logDeriv_tprod_eq_tsum {s : Set ℂ} (hs : IsOpen s) (x : s) (f : ℕ �
       simp only [Finset.prod_apply]
     · exact htend
     · use 0
-    · intro b hb
-      rw [DifferentiableOn]
-      intro z hz
-      apply DifferentiableAt.differentiableWithinAt
-      have hp : ∀ (i : ℕ), i ∈ Finset.range b → DifferentiableAt ℂ (f i) z := by
-        intro i hi
-        have := (hd i z hz).differentiableAt
-        apply this
-        exact IsOpen.mem_nhds hs hz
-      have := DifferentiableAt.finset_prod hp
-      convert this
+    · intro _ _
+      exact DifferentiableOn.finset_prod fun i a ↦ hd i
     · exact hnez
 
 lemma logDeriv_one_sub_exp (r : ℂ) : logDeriv (fun z => 1 - r * cexp (z)) =


### PR DESCRIPTION
Replaces 10 lines of proof with an invocation of [`DifferentiableOn.finset_prod`](https://github.com/leanprover-community/mathlib4/blob/c0578d69c9ef081573c419931de7b7e2ffeda95e/Mathlib/Analysis/Calculus/Deriv/Mul.lean#L456-L459).