### PR TITLE
feat(MagicFunction): vertical-ray integrability for double zeros

### DIFF
--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -47,6 +47,7 @@ public import SpherePacking.MagicFunction.a.IntegralEstimates.I6
 public import SpherePacking.MagicFunction.a.PhiBounds
 public import SpherePacking.MagicFunction.a.Schwartz
 public import SpherePacking.MagicFunction.a.SpecialValues
+public import SpherePacking.MagicFunction.a.VerticalIntegrability
 public import SpherePacking.MagicFunction.b.Basic
 public import SpherePacking.MagicFunction.b.Eigenfunction
 public import SpherePacking.MagicFunction.b.Schwartz

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -31,6 +31,7 @@ public import SpherePacking.MagicFunction.IntegralParametrisations
 public import SpherePacking.MagicFunction.PolyFourierCoeffBound
 public import SpherePacking.MagicFunction.a.Basic
 public import SpherePacking.MagicFunction.a.Eigenfunction
+public import SpherePacking.MagicFunction.a.FourierExpansions
 public import SpherePacking.MagicFunction.a.Integrability.ComplexIntegrands
 public import SpherePacking.MagicFunction.a.Integrability.CuspPath
 public import SpherePacking.MagicFunction.a.Integrability.Integrability
@@ -42,6 +43,7 @@ public import SpherePacking.MagicFunction.a.IntegralEstimates.I3
 public import SpherePacking.MagicFunction.a.IntegralEstimates.I4
 public import SpherePacking.MagicFunction.a.IntegralEstimates.I5
 public import SpherePacking.MagicFunction.a.IntegralEstimates.I6
+public import SpherePacking.MagicFunction.a.PhiBounds
 public import SpherePacking.MagicFunction.a.Schwartz
 public import SpherePacking.MagicFunction.a.SpecialValues
 public import SpherePacking.MagicFunction.b.Basic

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -30,6 +30,7 @@ public import SpherePacking.ForMathlib.tprod
 public import SpherePacking.MagicFunction.IntegralParametrisations
 public import SpherePacking.MagicFunction.PolyFourierCoeffBound
 public import SpherePacking.MagicFunction.a.Basic
+public import SpherePacking.MagicFunction.a.ContourEndpoints
 public import SpherePacking.MagicFunction.a.Eigenfunction
 public import SpherePacking.MagicFunction.a.FourierExpansions
 public import SpherePacking.MagicFunction.a.Integrability.ComplexIntegrands

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -295,14 +295,14 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
   have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
   -- Each term tends to 0
   have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s)) atTop (𝓝 0) :=
-    _root_.tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) h1
+    tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) h1
   have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
     have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
     simp only [mul_zero] at this
     convert this using 1; funext s; ring
   have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s)) atTop (𝓝 0) :=
-    _root_.tendsto_const_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) h3
+    tendsto_const_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) h3
   unfold verticalBound
   tendsto_cont
 
@@ -415,11 +415,11 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
       atTop (𝓝 0) := by
     -- Expand: (1+T)² = 1 + 2T + T²
     have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      _root_.tendsto_const_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
+      tendsto_const_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
     have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      _root_.tendsto_const_mul_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) h1
+      tendsto_const_mul_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) h1
     have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      _root_.tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
+      tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
     have hsum := (t1a.add t1b).add t1c
     simp only [add_zero] at hsum
     convert hsum using 1
@@ -429,7 +429,7 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   have t2 : Tendsto (fun T => (12 * C_φ₂' / (π * T)) * (1 + T)^2 * Real.exp (-π * r * T))
       atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T)) atTop (𝓝 0) :=
-      _root_.tendsto_const_mul_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) h2
+      tendsto_const_mul_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) h2
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith
@@ -459,7 +459,7 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
       Real.exp (2 * π * T) * Real.exp (-π * r * T)) atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T))
         atTop (𝓝 0) :=
-      _root_.tendsto_const_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) h3
+      tendsto_const_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) h3
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -295,14 +295,15 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
   have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
   -- Each term tends to 0
   have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s)) atTop (𝓝 0) :=
-    tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) h1
+    tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) 2 h1
   have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
     have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
     simp only [mul_zero] at this
     convert this using 1; funext s; ring
-  have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s)) atTop (𝓝 0) :=
-    tendsto_const_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) h3
+  have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
+      atTop (𝓝 0) := by
+    simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
   unfold verticalBound
   tendsto_cont
 
@@ -414,12 +415,12 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   have t1 : Tendsto (fun T => C_φ₀ * (1 + T)^2 * Real.exp (-(π * r + 2 * π) * T))
       atTop (𝓝 0) := by
     -- Expand: (1+T)² = 1 + 2T + T²
-    have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      tendsto_const_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
-    have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      tendsto_const_mul_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) h1
+    have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
+      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 0 h1
+    have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
+      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) 1 h1
     have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
+      tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 2 h1
     have hsum := (t1a.add t1b).add t1c
     simp only [add_zero] at hsum
     convert hsum using 1
@@ -428,8 +429,9 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   -- Use squeeze: (1+T)²/T ≤ 4T for T ≥ 1
   have t2 : Tendsto (fun T => (12 * C_φ₂' / (π * T)) * (1 + T)^2 * Real.exp (-π * r * T))
       atTop (𝓝 0) := by
-    have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T)) atTop (𝓝 0) :=
-      tendsto_const_mul_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) h2
+    have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T))
+        atTop (𝓝 0) := by
+      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) 1 h2
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith
@@ -458,8 +460,8 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   have t3 : Tendsto (fun T => (36 * C_φ₄' / (π^2 * T^2)) * (1 + T)^2 *
       Real.exp (2 * π * T) * Real.exp (-π * r * T)) atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T))
-        atTop (𝓝 0) :=
-      tendsto_const_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) h3
+        atTop (𝓝 0) := by
+      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -294,14 +294,15 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
   have h2 : 0 < π * r := by nlinarith [Real.pi_pos]
   have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
   -- Each term tends to 0
-  have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s)) atTop (𝓝 0) :=
-    tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) 2 h1
+  have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s)) atTop (𝓝 0) := by
+    simpa [Real.rpow_two] using
+      tendsto_const_mul_rpow_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) 2 h1
   have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
-    simpa [neg_mul] using tendsto_const_mul_pow_mul_exp_neg_atTop (12 * C_φ₂' / π) (π * r) 1 h2
+    simpa [neg_mul] using tendsto_const_mul_rpow_mul_exp_neg_atTop (12 * C_φ₂' / π) (π * r) 1 h2
   have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
       atTop (𝓝 0) := by
-    simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
+    simpa using tendsto_const_mul_rpow_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
   unfold verticalBound
   tendsto_cont
 
@@ -414,11 +415,12 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
       atTop (𝓝 0) := by
     -- Expand: (1+T)² = 1 + 2T + T²
     have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
-      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 0 h1
+      simpa using tendsto_const_mul_rpow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 0 h1
     have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
-      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) 1 h1
-    have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
-      tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 2 h1
+      simpa using tendsto_const_mul_rpow_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) 1 h1
+    have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
+      simpa [Real.rpow_two] using
+        tendsto_const_mul_rpow_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) 2 h1
     have hsum := (t1a.add t1b).add t1c
     simp only [add_zero] at hsum
     convert hsum using 1
@@ -429,7 +431,7 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
       atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T))
         atTop (𝓝 0) := by
-      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) 1 h2
+      simpa using tendsto_const_mul_rpow_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) 1 h2
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith
@@ -459,7 +461,7 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
       Real.exp (2 * π * T) * Real.exp (-π * r * T)) atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T))
         atTop (𝓝 0) := by
-      simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
+      simpa using tendsto_const_mul_rpow_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -294,20 +294,15 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
   have h2 : 0 < π * r := by nlinarith [Real.pi_pos]
   have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
   -- Each term tends to 0
-  have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s))
-      atTop (𝓝 0) := by
-    have := (_root_.tendsto_sq_mul_exp_neg_atTop (2 * π + π * r) h1).const_mul C_φ₀
-    simp only [mul_zero] at this
-    convert this using 1; funext s; ring
+  have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s)) atTop (𝓝 0) :=
+    _root_.tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) h1
   have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
     have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
     simp only [mul_zero] at this
     convert this using 1; funext s; ring
-  have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
-      atTop (𝓝 0) := by
-    simpa [mul_zero] using
-      (_root_.tendsto_exp_neg_atTop (π * r - 2 * π) h3).const_mul (36 * C_φ₄' / π^2)
+  have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s)) atTop (𝓝 0) :=
+    _root_.tendsto_const_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) h3
   unfold verticalBound
   tendsto_cont
 
@@ -419,19 +414,12 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   have t1 : Tendsto (fun T => C_φ₀ * (1 + T)^2 * Real.exp (-(π * r + 2 * π) * T))
       atTop (𝓝 0) := by
     -- Expand: (1+T)² = 1 + 2T + T²
-    have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
-      have h := (_root_.tendsto_exp_neg_atTop (π * r + 2 * π) h1).const_mul C_φ₀
-      simp only [mul_zero] at h; exact h
-    have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T))
-        atTop (𝓝 0) := by
-      have h := (_root_.tendsto_mul_exp_neg_atTop (π * r + 2 * π) h1).const_mul (2 * C_φ₀)
-      simp only [mul_zero] at h
-      convert h using 1; funext T; ring
-    have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T))
-        atTop (𝓝 0) := by
-      have h := (_root_.tendsto_sq_mul_exp_neg_atTop (π * r + 2 * π) h1).const_mul C_φ₀
-      simp only [mul_zero] at h
-      convert h using 1; funext T; ring
+    have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
+      _root_.tendsto_const_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
+    have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
+      _root_.tendsto_const_mul_mul_exp_neg_atTop (2 * C_φ₀) (π * r + 2 * π) h1
+    have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) :=
+      _root_.tendsto_const_mul_sq_mul_exp_neg_atTop C_φ₀ (π * r + 2 * π) h1
     have hsum := (t1a.add t1b).add t1c
     simp only [add_zero] at hsum
     convert hsum using 1
@@ -440,11 +428,8 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
   -- Use squeeze: (1+T)²/T ≤ 4T for T ≥ 1
   have t2 : Tendsto (fun T => (12 * C_φ₂' / (π * T)) * (1 + T)^2 * Real.exp (-π * r * T))
       atTop (𝓝 0) := by
-    have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-π * r * T))
-        atTop (𝓝 0) := by
-      have h := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (48 * C_φ₂' / π)
-      simp only [mul_zero] at h
-      convert h using 1; funext T; ring_nf
+    have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T)) atTop (𝓝 0) :=
+      _root_.tendsto_const_mul_mul_exp_neg_atTop (48 * C_φ₂' / π) (π * r) h2
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith
@@ -466,16 +451,15 @@ lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
         _ ≤ (12 * C_φ₂' / π) * (4 * T) * Real.exp (-π * r * T) := by
             exact mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left h3
               (div_nonneg (by linarith [C_φ₂'_pos]) hπ.le)) (Real.exp_pos _).le
-        _ = (48 * C_φ₂' / π) * T * Real.exp (-π * r * T) := by ring
+        _ = (48 * C_φ₂' / π) * T * Real.exp (-(π * r) * T) := by ring
     · exact hbound
   -- Term 3: (36C₄/(π²T²)) * (1+T)² * exp(2πT-πrT) → 0
   -- Use squeeze: (1+T)²/T² ≤ 4 for T ≥ 1
   have t3 : Tendsto (fun T => (36 * C_φ₄' / (π^2 * T^2)) * (1 + T)^2 *
       Real.exp (2 * π * T) * Real.exp (-π * r * T)) atTop (𝓝 0) := by
     have hbound : Tendsto (fun T => (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T))
-        atTop (𝓝 0) := by
-      simpa using (_root_.tendsto_exp_neg_atTop (π * r - 2 * π) h3).const_mul
-        (144 * C_φ₄' / π^2)
+        atTop (𝓝 0) :=
+      _root_.tendsto_const_mul_exp_neg_atTop (144 * C_φ₄' / π^2) (π * r - 2 * π) h3
     apply squeeze_zero'
     · filter_upwards [eventually_ge_atTop 1] with T hT
       have hT_pos : 0 < T := by linarith

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -298,9 +298,7 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
     tendsto_const_mul_pow_mul_exp_neg_atTop C_φ₀ (2 * π + π * r) 2 h1
   have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
-    have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
-    simp only [mul_zero] at this
-    convert this using 1; funext s; ring
+    simpa [neg_mul] using tendsto_const_mul_pow_mul_exp_neg_atTop (12 * C_φ₂' / π) (π * r) 1 h2
   have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
       atTop (𝓝 0) := by
     simpa using tendsto_const_mul_pow_mul_exp_neg_atTop (36 * C_φ₄' / π^2) (π * r - 2 * π) 0 h3

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -1,0 +1,650 @@
+/-
+Copyright (c) 2025 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+module
+
+public import SpherePacking.ModularForms.PhiTransform
+public import SpherePacking.MagicFunction.a.Integrability.RealDecay
+public import SpherePacking.MagicFunction.a.Integrability.CuspPath
+public import SpherePacking.MagicFunction.a.PhiBounds
+public import Mathlib.MeasureTheory.Integral.IntegrableOn
+
+@[expose] public section
+
+/-!
+# Contour Endpoint Bounds for Vertical Rays
+
+This file provides endpoint bounds and integrability lemmas for vertical contour rays,
+as needed for the Cauchy-Goursat applications in the double zeroes proof (#229).
+
+## Blueprint references
+
+- **Corollary 7.5-7.7**: Bounds on φ₀, φ₋₂, φ₋₄ for Im(z) > 1/2
+- **Corollary 7.13**: φ₀(i/t) = O(t⁻² e^{2πt}) as t → ∞
+- **Proposition 7.14**: Vertical integrand → 0 as Im(z) → ∞ for r > 2
+
+## Main results
+
+- `norm_φ₀''_I_div_t_le`: Corollary 7.13 (3-term S-transform bound)
+- `verticalIntegrandX`: Integrand for vertical edges at any x position
+- `integrableOn_verticalIntegrandX`: Integrability for r > 2
+- `tendsto_verticalIntegrandX_atTop`: Integrand → 0 as t → ∞
+
+## Notes
+
+We use `Im(z) ≥ 1` (stronger than the blueprint's `Im(z) > 1/2`) as a convenient
+safe strip that covers all rectangle contour points.
+-/
+
+open MeasureTheory Set Filter Real UpperHalfPlane TopologicalSpace
+open MagicFunction.a
+
+open scoped Interval Real NNReal ENNReal Topology BigOperators
+
+noncomputable section
+
+namespace MagicFunction.ContourEndpoints
+
+/-! ## Filter for imaginary part tending to infinity on ℂ -/
+
+/-- The filter on ℂ of sets containing { z | M ≤ z.im } for some M.
+    This is the preimage of `atTop` under `Complex.im`. -/
+def atImInfty_ℂ : Filter ℂ := Filter.comap Complex.im atTop
+
+/-- Characterization of membership in `atImInfty_ℂ`. -/
+lemma mem_atImInfty_ℂ {s : Set ℂ} : s ∈ atImInfty_ℂ ↔ ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → z ∈ s := by
+  simp only [atImInfty_ℂ, Filter.mem_comap, Filter.mem_atTop_sets]
+  exact ⟨fun ⟨_, ⟨a, ha⟩, hts⟩ => ⟨a, fun z hz => hts (ha z.im hz)⟩,
+         fun ⟨M, hM⟩ => ⟨Ici M, ⟨M, fun _ hb => hb⟩, fun z hz => hM z hz⟩⟩
+
+/-- Tendsto characterization for `atImInfty_ℂ` to `𝓝 0`. -/
+lemma tendsto_zero_atImInfty_ℂ_iff {f : ℂ → ℂ} :
+    Tendsto f atImInfty_ℂ (𝓝 0) ↔ ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε := by
+  simp [Metric.tendsto_nhds, dist_zero_right, Filter.eventually_iff, mem_atImInfty_ℂ]
+
+/-- Tendsto characterization for `atImInfty_ℂ` to `𝓝 0` (real-valued version). -/
+lemma tendsto_zero_atImInfty_ℂ_iff' {f : ℂ → ℝ} :
+    Tendsto f atImInfty_ℂ (𝓝 0) ↔ ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → |f z| < ε := by
+  simp [Metric.tendsto_nhds, dist_zero_right, Real.norm_eq_abs, Filter.eventually_iff,
+    mem_atImInfty_ℂ]
+
+/-! ## Corollary 7.13 - S-transform bound for φ₀''(I/t) -/
+
+/-- The point it as an element of ℍ for t > 0. -/
+def mkI_mul_t (t : ℝ) (ht : 0 < t) : ℍ :=
+  ⟨Complex.I * t, by simp; exact ht⟩
+
+/-- S action on it gives i/t. -/
+lemma S_smul_I_mul_t (t : ℝ) (ht : 0 < t) :
+    (↑(ModularGroup.S • mkI_mul_t t ht) : ℂ) = Complex.I / t := by
+  rw [modular_S_smul]
+  simp [mkI_mul_t, div_eq_mul_inv, mul_comm]
+
+/-- im(it) = t when viewed as element of ℍ. -/
+lemma mkI_mul_t_im (t : ℝ) (ht : 0 < t) : (mkI_mul_t t ht).im = t := by
+  simp [mkI_mul_t]
+
+/-- φ₀''(I/t) equals φ₀ applied to S•(I*t). -/
+lemma φ₀''_I_div_t_eq (t : ℝ) (ht : 0 < t) :
+    φ₀'' (Complex.I / t) = φ₀ (ModularGroup.S • mkI_mul_t t ht) := by
+  rw [φ₀''_def (by rw [Complex.div_ofReal_im, Complex.I_im]; positivity)]
+  simpa using congrArg φ₀ (UpperHalfPlane.ext (S_smul_I_mul_t t ht).symm)
+
+/-- Norm of I*t equals t for t > 0. -/
+lemma norm_I_mul_t (t : ℝ) (ht : 0 < t) : ‖(Complex.I * t : ℂ)‖ = t := by
+  simp only [norm_mul, Complex.norm_I, one_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos ht]
+
+/-- The coefficient (12I)/(πz) has norm 12/(π|z|). -/
+lemma norm_coeff_12I_div (z : ℂ) :
+    ‖(12 * Complex.I) / (↑π * z)‖ = 12 / (π * ‖z‖) := by
+  rw [norm_div, norm_mul, norm_mul, Complex.norm_I, Complex.norm_real, Complex.norm_ofNat]
+  simp only [mul_one, Real.norm_eq_abs, abs_of_pos Real.pi_pos]
+
+/-- The coefficient 36/(π²z²) has norm 36/(π²|z|²). -/
+lemma norm_coeff_36_div_sq (z : ℂ) :
+    ‖36 / (↑π ^ 2 * z ^ 2)‖ = 36 / (π^2 * ‖z‖^2) := by
+  rw [norm_div, norm_mul, norm_pow, norm_pow, Complex.norm_real]
+  simp only [Real.norm_eq_abs, abs_of_pos Real.pi_pos, Complex.norm_ofNat]
+
+/-- General S-transform bound for any z with im(z) ≥ 1.
+    This is the generalized Corollary 7.13. -/
+lemma norm_φ₀_S_smul_le (z : ℍ) (hz : 1 ≤ z.im) :
+    ‖φ₀ (ModularGroup.S • z)‖ ≤ C_φ₀ * Real.exp (-2 * π * z.im)
+        + (12 / (π * ‖(z : ℂ)‖)) * C_φ₂'
+        + (36 / (π^2 * ‖(z : ℂ)‖^2)) * C_φ₄'
+            * Real.exp (2 * π * z.im) := by
+  -- Step 1: Use the S-transform formula
+  rw [φ₀_S_transform]
+  -- Step 2: Apply triangle inequality twice for a - b - c
+  have h_tri : ‖φ₀ z - (12 * Complex.I) / (↑π * z) * φ₂' z - 36 / (↑π ^ 2 * ↑z ^ 2) * φ₄' z‖
+      ≤ ‖φ₀ z‖ + ‖(12 * Complex.I) / (↑π * z) * φ₂' z‖
+          + ‖36 / (↑π ^ 2 * ↑z ^ 2) * φ₄' z‖ := by
+    have h1 : ‖φ₀ z - (12 * Complex.I) / (↑π * z) * φ₂' z - 36 / (↑π ^ 2 * ↑z ^ 2) * φ₄' z‖
+        ≤ ‖φ₀ z - (12 * Complex.I) / (↑π * z) * φ₂' z‖
+            + ‖36 / (↑π ^ 2 * ↑z ^ 2) * φ₄' z‖ := norm_sub_le _ _
+    have h2 : ‖φ₀ z - (12 * Complex.I) / (↑π * z) * φ₂' z‖
+        ≤ ‖φ₀ z‖ + ‖(12 * Complex.I) / (↑π * z) * φ₂' z‖ := norm_sub_le _ _
+    linarith
+  refine h_tri.trans ?_
+  -- Step 3: Bound each of the three terms
+  -- Derive 1/2 < z.im from 1 ≤ z.im for the φ-bound lemmas
+  have hz' : 1/2 < z.im := by linarith
+  -- Bound (i): ‖φ₀ z‖ ≤ C₀ * exp(-2πt)  [from φ₀_bound]
+  have hbound1 : ‖φ₀ z‖ ≤ C_φ₀ * exp (-2 * π * z.im) := φ₀_bound z hz'
+  -- Bound (ii): ‖(12I)/(πz) * φ₂' z‖ ≤ (12/(π‖z‖)) * C₂
+  have hbound2 : ‖(12 * Complex.I) / (↑π * z) * φ₂' z‖ ≤ (12 / (π * ‖(z : ℂ)‖)) * C_φ₂' := by
+    rw [norm_mul, norm_coeff_12I_div (z : ℂ)]
+    exact mul_le_mul_of_nonneg_left (φ₂'_bound z hz') (by positivity)
+  -- Bound (iii): ‖36/(π²z²) * φ₄' z‖ ≤ (36/(π²‖z‖²)) * C₄ * exp(2πt)
+  have hbound3 : ‖36 / (↑π ^ 2 * ↑z ^ 2) * φ₄' z‖ ≤
+      (36 / (π^2 * ‖(z : ℂ)‖^2)) * C_φ₄' * exp (2 * π * z.im) := by
+    rw [norm_mul, norm_coeff_36_div_sq (z : ℂ)]
+    calc 36 / (π ^ 2 * ‖(z : ℂ)‖ ^ 2) * ‖φ₄' z‖
+        ≤ 36 / (π ^ 2 * ‖(z : ℂ)‖ ^ 2) * (C_φ₄' * exp (2 * π * z.im)) :=
+          mul_le_mul_of_nonneg_left (φ₄'_bound z hz') (by positivity)
+      _ = 36 / (π ^ 2 * ‖(z : ℂ)‖ ^ 2) * C_φ₄' * exp (2 * π * z.im) := by ring
+  -- Combine bounds
+  linarith
+
+/-- Corollary 7.13: S-transform bound for φ₀(i/t) at large t.
+    Specializes norm_φ₀_S_smul_le to z = I*t where z.im = ‖z‖ = t. -/
+lemma norm_φ₀''_I_div_t_le (t : ℝ) (ht : 1 ≤ t) :
+    ‖φ₀'' (Complex.I / t)‖ ≤ C_φ₀ * Real.exp (-2 * π * t)
+                    + (12 / (π * t)) * C_φ₂'
+                    + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t) := by
+  have ht_pos : 0 < t := by linarith
+  rw [φ₀''_I_div_t_eq t ht_pos]
+  have h := norm_φ₀_S_smul_le (mkI_mul_t t ht_pos) (by simpa [mkI_mul_t_im] using ht)
+  simp only [mkI_mul_t_im] at h
+  rwa [show ‖(↑(mkI_mul_t t ht_pos) : ℂ)‖ = t from norm_I_mul_t t ht_pos] at h
+
+/-! ## Vertical Ray Integrand -/
+
+/-- Vertical ray integrand at horizontal position x.
+    Covers #229's edges at x = -1, 0, 1.
+
+    Note: The integrand for vertical contours in the rectangle proof uses
+    φ₀''(i/t) rather than φ₀''(it) due to the parameterization. -/
+def verticalIntegrandX (x r t : ℝ) : ℂ :=
+  Complex.I * φ₀'' (Complex.I / t) * (Complex.I * t)^2 *
+    Complex.exp (Complex.I * π * r * (x + Complex.I * t))
+
+/-- Special case x = 0. -/
+def verticalIntegrand (r t : ℝ) : ℂ := verticalIntegrandX 0 r t
+
+/-- The exponential phase factor has norm independent of x. -/
+lemma norm_cexp_verticalPhase (x r t : ℝ) :
+    ‖Complex.exp (Complex.I * π * r * (x + Complex.I * t))‖ = Real.exp (-π * r * t) := by
+  rw [Complex.norm_exp]
+  ring_nf
+  simp
+
+/-! ## Integrability (complex-valued) -/
+
+/-- Norm of the vertical integrand. -/
+lemma norm_verticalIntegrandX (x r t : ℝ) (_ht : 0 < t) :
+    ‖verticalIntegrandX x r t‖ = t^2 * ‖φ₀'' (Complex.I / t)‖ * Real.exp (-π * r * t) := by
+  simp [verticalIntegrandX, norm_cexp_verticalPhase, sq]
+  ring
+
+/-- Bounding function for the vertical integrand norm.
+    Uses the 3-term Cor 7.13 bound with t² · exp(-πrt) distributed. -/
+def verticalBound (r t : ℝ) : ℝ :=
+  C_φ₀ * t^2 * Real.exp (-(2 * π + π * r) * t)
+  + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
+  + (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * t)
+
+/-- The vertical bound dominates the integrand norm for t ≥ 1. -/
+lemma norm_verticalIntegrandX_le (x r t : ℝ) (ht : 1 ≤ t) :
+    ‖verticalIntegrandX x r t‖ ≤ verticalBound r t := by
+  have ht_pos : 0 < t := one_pos.trans_le ht
+  rw [norm_verticalIntegrandX x r t ht_pos]
+  -- Apply Cor 7.13 bound: ‖φ₀''(I/t)‖ ≤ 3-term bound
+  have hbound := norm_φ₀''_I_div_t_le t ht
+  -- Need: t² * ‖φ₀''(I/t)‖ * exp(-πrt) ≤ verticalBound
+  calc t^2 * ‖φ₀'' (Complex.I / ↑t)‖ * Real.exp (-π * r * t)
+      ≤ t^2 * (C_φ₀ * Real.exp (-2 * π * t)
+               + (12 / (π * t)) * C_φ₂'
+               + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t))
+          * Real.exp (-π * r * t) := by
+        exact mul_le_mul_of_nonneg_right
+          (mul_le_mul_of_nonneg_left hbound (sq_nonneg t)) (Real.exp_pos _).le
+    _ = verticalBound r t := by
+        simp only [verticalBound]
+        have ht_ne : t ≠ 0 := ne_of_gt ht_pos
+        have hexp1 : Real.exp (-2 * π * t) * Real.exp (-π * r * t) =
+            Real.exp (-(2 * π + π * r) * t) := by rw [← Real.exp_add]; ring_nf
+        have hexp3 : Real.exp (2 * π * t) * Real.exp (-π * r * t) =
+            Real.exp (-(π * r - 2 * π) * t) := by rw [← Real.exp_add]; ring_nf
+        calc t^2 * (C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
+               + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t))
+             * Real.exp (-π * r * t)
+           = C_φ₀ * t^2 * (Real.exp (-2 * π * t) * Real.exp (-π * r * t))
+             + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
+             + (36 * C_φ₄' / π^2) * (Real.exp (2 * π * t) * Real.exp (-π * r * t)) := by
+               field_simp
+         _ = C_φ₀ * t^2 * Real.exp (-(2 * π + π * r) * t)
+             + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
+             + (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * t) := by
+               rw [hexp1, hexp3]
+
+/-- The vertical bound is integrable on [1,∞) for r > 2. -/
+lemma integrableOn_verticalBound (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (verticalBound r) (Ici 1) volume := by
+  -- Sum of three integrable functions
+  have h1 : 0 < 2 * π + π * r := by nlinarith [Real.pi_pos]
+  have h2 : 0 < π * r := by nlinarith [Real.pi_pos]
+  have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
+  -- Define integrable components (note: const_mul applies on the left as c * f(x))
+  have i1 : IntegrableOn (fun s => C_φ₀ * (s^2 * Real.exp (-(2 * π + π * r) * s)))
+      (Ici 1) volume :=
+    (_root_.integrableOn_sq_mul_exp_neg_Ici (2 * π + π * r) h1).const_mul _
+  have i2 : IntegrableOn (fun s => (12 * C_φ₂' / π) * (s * Real.exp (-(π * r) * s)))
+      (Ici 1) volume :=
+    (_root_.integrableOn_mul_exp_neg_Ici (π * r) h2).const_mul _
+  have i3 : IntegrableOn (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
+      (Ici 1) volume :=
+    (_root_.integrableOn_exp_mul_Ici (-(π * r - 2 * π)) (by linarith)).const_mul _
+  convert (i1.add i2).add i3 using 1
+  funext s
+  simp [verticalBound]
+  ring_nf
+
+/-- Vertical ray integrand is integrable on [1,∞) for r > 2. -/
+lemma integrableOn_verticalIntegrandX (x r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t => verticalIntegrandX x r t) (Ici 1) volume := by
+  -- Bound by verticalBound and use integrability of the bound
+  apply MeasureTheory.Integrable.mono' (integrableOn_verticalBound r hr)
+  · -- Measurability: verticalIntegrandX is continuous on Ici 1 → AEStronglyMeasurable
+    -- I/t = -1/(I*t) via div_mul_eq_div_div + NormNumI
+    have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (Complex.I / t)) (Ici 1) := by
+      have h1 := continuousOn_φ₀''_cusp_path.mono
+        (fun t ht => lt_of_lt_of_le zero_lt_one (mem_Ici.mp ht))
+      refine h1.congr (fun t ht => congrArg φ₀'' ?_)
+      simp [div_mul_eq_div_div, Complex.div_I]
+    have h_cont : ContinuousOn (fun t : ℝ => verticalIntegrandX x r t) (Ici 1) := by
+      unfold verticalIntegrandX
+      refine ((continuousOn_const.mul h_cont_phi).mul ?_).mul ?_
+      · exact (continuousOn_const.mul Complex.continuous_ofReal.continuousOn).pow _
+      · refine Complex.continuous_exp.comp_continuousOn ?_
+        refine (continuousOn_const.mul continuousOn_const).mul ?_
+        exact continuousOn_const.add
+          (continuousOn_const.mul Complex.continuous_ofReal.continuousOn)
+    exact h_cont.aestronglyMeasurable measurableSet_Ici
+  · rw [ae_restrict_iff' measurableSet_Ici]
+    apply ae_of_all
+    intro t ht
+    simp only [mem_Ici] at ht
+    exact norm_verticalIntegrandX_le x r t ht
+
+/-- Corollary: norm is also integrable. -/
+lemma integrableOn_norm_verticalIntegrandX (x r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t => ‖verticalIntegrandX x r t‖) (Ici 1) volume :=
+  (integrableOn_verticalIntegrandX x r hr).norm
+
+/-! ## Tendsto at Infinity (Proposition 7.14) -/
+
+/-- The vertical bound → 0 as t → ∞ for r > 2. -/
+lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
+    Tendsto (verticalBound r) atTop (𝓝 0) := by
+  have h1 : 0 < 2 * π + π * r := by nlinarith [Real.pi_pos]
+  have h2 : 0 < π * r := by nlinarith [Real.pi_pos]
+  have h3 : 0 < π * r - 2 * π := by nlinarith [Real.pi_pos]
+  -- Each term tends to 0
+  have t1 : Tendsto (fun s => C_φ₀ * s^2 * Real.exp (-(2 * π + π * r) * s))
+      atTop (𝓝 0) := by
+    have := (_root_.tendsto_sq_mul_exp_neg_atTop (2 * π + π * r) h1).const_mul C_φ₀
+    simp only [mul_zero] at this
+    convert this using 1; funext s; ring
+  have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-(π * r) * s))
+      atTop (𝓝 0) := by
+    have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
+    simp only [mul_zero] at this
+    convert this using 1; funext s; ring
+  have t3 : Tendsto (fun s => (36 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * s))
+      atTop (𝓝 0) := by
+    simpa [mul_zero] using
+      (_root_.tendsto_exp_neg_atTop (π * r - 2 * π) h3).const_mul (36 * C_φ₄' / π^2)
+  have hsum := (t1.add t2).add t3
+  simp only [add_zero] at hsum
+  convert hsum using 1
+  funext s
+  simp only [verticalBound]
+  ring_nf
+
+/-- The vertical bound is nonnegative for t ≥ 1. -/
+lemma verticalBound_nonneg (r t : ℝ) (ht : 1 ≤ t) : 0 ≤ verticalBound r t := by
+  simp only [verticalBound]
+  have := C_φ₀_pos; have := C_φ₂'_pos; have := C_φ₄'_pos
+  positivity
+
+/-- Vertical integrand → 0 as t → ∞ for r > 2. -/
+lemma tendsto_verticalIntegrandX_atTop (x r : ℝ) (hr : 2 < r) :
+    Tendsto (fun t => verticalIntegrandX x r t) atTop (𝓝 0) := by
+  -- Use squeeze theorem: ‖f(t)‖ ≤ g(t) → 0 implies f(t) → 0
+  apply Metric.tendsto_atTop.mpr
+  intro ε hε
+  obtain ⟨N₁, hN₁⟩ := Metric.tendsto_atTop.mp (tendsto_verticalBound_atTop r hr) ε hε
+  -- Use max(N₁, 1) to ensure we can apply norm_verticalIntegrandX_le
+  use max N₁ 1
+  intro t ht
+  have ht_ge_1 : 1 ≤ t := le_of_max_le_right ht
+  have ht_ge_N₁ : t ≥ N₁ := le_of_max_le_left ht
+  simp only [dist_zero_right]
+  -- ‖integrand‖ ≤ bound < ε
+  calc ‖verticalIntegrandX x r t‖
+      ≤ verticalBound r t := norm_verticalIntegrandX_le x r t ht_ge_1
+    _ < ε := by
+        have := hN₁ t ht_ge_N₁
+        simp only [dist_zero_right, Real.norm_eq_abs] at this
+        rwa [abs_of_nonneg (verticalBound_nonneg r t ‹_›)] at this
+
+/-- Uniform vanishing: the vertical integrand is arbitrarily small for all z
+    with sufficiently large imaginary part. This is the form needed by Cauchy-Goursat. -/
+lemma uniform_vanishing_verticalIntegrandX (r : ℝ) (hr : 2 < r) :
+    ∀ ε > 0, ∃ M : ℝ, ∀ x t : ℝ, M ≤ t → ‖verticalIntegrandX x r t‖ < ε := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp (tendsto_verticalBound_atTop r hr) ε hε
+  refine ⟨max N 1, fun x t ht => ?_⟩
+  have ht1 : 1 ≤ t := le_trans (le_max_right N 1) ht
+  have htN : N ≤ t := le_trans (le_max_left N 1) ht
+  exact lt_of_le_of_lt (norm_verticalIntegrandX_le x r t ht1)
+    (by simpa [abs_of_nonneg (verticalBound_nonneg r t ‹_›)] using hN t htN)
+
+/-! ## Top Edge Integral → 0 -/
+
+/-- Top edge integrand for the S-transformed function.
+    The actual integrand in the rectangle deformation is φ₀(-1/z) · z² · exp(πir²z)
+    where z = x + iT. Note: φ₀''(-1/z) = φ₀(S•z) when z is in ℍ. -/
+def topEdgeIntegrand (r x T : ℝ) : ℂ :=
+  φ₀'' (-1 / (↑x + Complex.I * ↑T)) * (↑x + Complex.I * ↑T)^2 *
+    Complex.exp (Complex.I * π * r * (↑x + Complex.I * ↑T))
+
+/-- Norm of z = x + iT when x ∈ [-1,1] and T ≥ 1. -/
+lemma norm_x_add_I_mul_T_bounds (x T : ℝ) (hx : x ∈ Icc (-1 : ℝ) 1) (hT : 1 ≤ T) :
+    T ≤ ‖(↑x + Complex.I * ↑T : ℂ)‖ ∧ ‖(↑x + Complex.I * ↑T : ℂ)‖ ≤ 1 + T := by
+  constructor
+  · have hsq : T^2 ≤ ‖(↑x + Complex.I * ↑T : ℂ)‖^2 := by
+      rw [← Complex.normSq_eq_norm_sq, Complex.normSq_apply]
+      simp
+      nlinarith [sq_nonneg x]
+    exact (sq_le_sq₀ (by linarith : 0 ≤ T) (norm_nonneg _)).mp hsq
+  · -- Upper bound: ‖z‖ ≤ |x| + |T| ≤ 1 + T
+    simp only [mem_Icc] at hx
+    calc ‖(↑x + Complex.I * ↑T : ℂ)‖
+        ≤ ‖(↑x : ℂ)‖ + ‖Complex.I * ↑T‖ := norm_add_le _ _
+      _ = |x| + |T| := by simp [Complex.norm_real, Complex.norm_I, Real.norm_eq_abs]
+      _ ≤ 1 + T := by
+          have hx_abs : |x| ≤ 1 := abs_le.mpr ⟨by linarith, by linarith⟩
+          have hT_abs : |T| = T := abs_of_pos (by linarith)
+          linarith
+
+/-- S action on x + iT gives -1/(x + iT).
+    This is a restatement of `modular_S_smul` with explicit computation. -/
+lemma S_smul_x_add_I_mul_T (x T : ℝ) (hT : 0 < T) :
+    let w : ℍ := ⟨↑x + Complex.I * ↑T, by simp; exact hT⟩
+    (↑(ModularGroup.S • w) : ℂ) = -1 / (↑x + Complex.I * ↑T) := by
+  simp only [modular_S_smul, UpperHalfPlane.coe_mk]
+  rw [← neg_inv]; ring
+
+/-- φ₀''(-1/z) equals φ₀(S•w) where w = ⟨z, _⟩ ∈ ℍ.
+    This connects the extension φ₀'' on ℂ to the original φ₀ on ℍ via S-transform. -/
+lemma φ₀''_neg_inv_eq_φ₀_S_smul (x T : ℝ) (hT : 0 < T) :
+    let z : ℂ := ↑x + Complex.I * ↑T
+    let w : ℍ := ⟨z, by simp only [z]; simp; exact hT⟩
+    φ₀'' (-1 / z) = φ₀ (ModularGroup.S • w) := by
+  intro z w
+  have hneg_inv_im : 0 < (-1 / z : ℂ).im := by
+    simp only [z, neg_div, one_div, neg_inv]
+    exact UpperHalfPlane.im_inv_neg_coe_pos ⟨_, by simp [Complex.add_im]; exact hT⟩
+  rw [φ₀''_def hneg_inv_im]
+  exact congrArg φ₀ (UpperHalfPlane.ext (S_smul_x_add_I_mul_T x T hT).symm)
+
+/-- Bounding function for top edge integrand norm.
+    For z = x + iT with x ∈ [-1,1] and T ≥ 1, this bounds ‖topEdgeIntegrand r x T‖. -/
+def topEdgeBound (r T : ℝ) : ℝ :=
+  (1 + T)^2 * Real.exp (-π * r * T) *
+    (C_φ₀ * Real.exp (-2 * π * T) + (12 * C_φ₂' / (π * T))
+        + (36 * C_φ₄' / (π^2 * T^2)) * Real.exp (2 * π * T))
+
+/-- The top edge bound → 0 as T → ∞ for r > 2. -/
+lemma tendsto_topEdgeBound_atTop (r : ℝ) (hr : 2 < r) :
+    Tendsto (topEdgeBound r) atTop (𝓝 0) := by
+  unfold topEdgeBound
+  have hπ := Real.pi_pos
+  have h1 : 0 < π * r + 2 * π := by nlinarith
+  have h2 : 0 < π * r := by nlinarith
+  have h3 : 0 < π * r - 2 * π := by nlinarith
+  -- Strategy: Expand (1+T)² = 1 + 2T + T² and use individual tendsto lemmas
+  -- Term 1: C₀ * (1+T)² * exp(-(πr+2π)T) → 0
+  have t1 : Tendsto (fun T => C_φ₀ * (1 + T)^2 * Real.exp (-(π * r + 2 * π) * T))
+      atTop (𝓝 0) := by
+    -- Expand: (1+T)² = 1 + 2T + T²
+    have t1a : Tendsto (fun T => C_φ₀ * Real.exp (-(π * r + 2 * π) * T)) atTop (𝓝 0) := by
+      have h := (_root_.tendsto_exp_neg_atTop (π * r + 2 * π) h1).const_mul C_φ₀
+      simp only [mul_zero] at h; exact h
+    have t1b : Tendsto (fun T => 2 * C_φ₀ * T * Real.exp (-(π * r + 2 * π) * T))
+        atTop (𝓝 0) := by
+      have h := (_root_.tendsto_mul_exp_neg_atTop (π * r + 2 * π) h1).const_mul (2 * C_φ₀)
+      simp only [mul_zero] at h
+      convert h using 1; funext T; ring
+    have t1c : Tendsto (fun T => C_φ₀ * T^2 * Real.exp (-(π * r + 2 * π) * T))
+        atTop (𝓝 0) := by
+      have h := (_root_.tendsto_sq_mul_exp_neg_atTop (π * r + 2 * π) h1).const_mul C_φ₀
+      simp only [mul_zero] at h
+      convert h using 1; funext T; ring
+    have hsum := (t1a.add t1b).add t1c
+    simp only [add_zero] at hsum
+    convert hsum using 1
+    funext T; ring
+  -- Term 2: (12C₂/(πT)) * (1+T)² * exp(-πrT) → 0
+  -- Use squeeze: (1+T)²/T ≤ 4T for T ≥ 1
+  have t2 : Tendsto (fun T => (12 * C_φ₂' / (π * T)) * (1 + T)^2 * Real.exp (-π * r * T))
+      atTop (𝓝 0) := by
+    have hbound : Tendsto (fun T => (48 * C_φ₂' / π) * T * Real.exp (-π * r * T))
+        atTop (𝓝 0) := by
+      have h := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (48 * C_φ₂' / π)
+      simp only [mul_zero] at h
+      convert h using 1; funext T; ring_nf
+    apply squeeze_zero'
+    · filter_upwards [eventually_ge_atTop 1] with T hT
+      have hT_pos : 0 < T := by linarith
+      apply mul_nonneg (mul_nonneg _ (sq_nonneg _)) (le_of_lt (Real.exp_pos _))
+      exact div_nonneg (by linarith [C_φ₂'_pos]) (by positivity)
+    · filter_upwards [eventually_ge_atTop 1] with T hT
+      have hT_pos : 0 < T := by linarith
+      have hπT_pos : 0 < π * T := by positivity
+      have h1 : (12 * C_φ₂' / (π * T)) * (1 + T)^2 =
+          (12 * C_φ₂' / π) * ((1 + T)^2 / T) := by
+        field_simp
+      have h2 : (1 + T)^2 / T = 1 / T + 2 + T := by field_simp; ring
+      have h3 : 1 / T + 2 + T ≤ 4 * T := by
+        have : 1 / T ≤ 1 := (div_le_one hT_pos).mpr hT
+        linarith
+      calc (12 * C_φ₂' / (π * T)) * (1 + T)^2 * Real.exp (-π * r * T)
+          = (12 * C_φ₂' / π) * (1 / T + 2 + T) * Real.exp (-π * r * T) := by
+              rw [h1, h2]
+        _ ≤ (12 * C_φ₂' / π) * (4 * T) * Real.exp (-π * r * T) := by
+            exact mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left h3
+              (div_nonneg (by linarith [C_φ₂'_pos]) hπ.le)) (Real.exp_pos _).le
+        _ = (48 * C_φ₂' / π) * T * Real.exp (-π * r * T) := by ring
+    · exact hbound
+  -- Term 3: (36C₄/(π²T²)) * (1+T)² * exp(2πT-πrT) → 0
+  -- Use squeeze: (1+T)²/T² ≤ 4 for T ≥ 1
+  have t3 : Tendsto (fun T => (36 * C_φ₄' / (π^2 * T^2)) * (1 + T)^2 *
+      Real.exp (2 * π * T) * Real.exp (-π * r * T)) atTop (𝓝 0) := by
+    have hbound : Tendsto (fun T => (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T))
+        atTop (𝓝 0) := by
+      simpa using (_root_.tendsto_exp_neg_atTop (π * r - 2 * π) h3).const_mul
+        (144 * C_φ₄' / π^2)
+    apply squeeze_zero'
+    · filter_upwards [eventually_ge_atTop 1] with T hT
+      have hT_pos : 0 < T := by linarith
+      apply mul_nonneg (mul_nonneg (mul_nonneg _ (sq_nonneg _)) (le_of_lt (Real.exp_pos _)))
+          (le_of_lt (Real.exp_pos _))
+      exact div_nonneg (by linarith [C_φ₄'_pos]) (by positivity)
+    · filter_upwards [eventually_ge_atTop 1] with T hT
+      have hT_pos : 0 < T := by linarith
+      have hexp_comb : Real.exp (2 * π * T) * Real.exp (-π * r * T) =
+          Real.exp (-(π * r - 2 * π) * T) := by rw [← Real.exp_add]; ring_nf
+      have h1 : (1 + T)^2 / T^2 = (1 / T + 1)^2 := by field_simp
+      have hle2 : 1 / T + 1 ≤ 2 := by
+        have : 1 / T ≤ 1 := (div_le_one hT_pos).mpr hT
+        linarith
+      have h2 : (1 / T + 1)^2 ≤ 4 := by
+        have h0 : 0 ≤ 1 / T + 1 := by positivity
+        calc (1 / T + 1)^2 ≤ 2^2 := sq_le_sq' (by linarith) hle2
+          _ = 4 := by norm_num
+      -- Combine the exponentials and rearrange
+      calc (36 * C_φ₄' / (π^2 * T^2)) * (1 + T)^2 * Real.exp (2 * π * T) *
+               Real.exp (-π * r * T)
+          = (36 * C_φ₄' / π^2) * ((1 + T)^2 / T^2) *
+              (Real.exp (2 * π * T) * Real.exp (-π * r * T)) := by field_simp
+        _ = (36 * C_φ₄' / π^2) * (1 / T + 1)^2 * Real.exp (-(π * r - 2 * π) * T) := by
+              rw [h1, hexp_comb]
+        _ ≤ (36 * C_φ₄' / π^2) * 4 * Real.exp (-(π * r - 2 * π) * T) := by
+            exact mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left h2
+              (div_nonneg (by linarith [C_φ₄'_pos]) (sq_nonneg π))) (Real.exp_pos _).le
+        _ = (144 * C_φ₄' / π^2) * Real.exp (-(π * r - 2 * π) * T) := by ring
+    · exact hbound
+  simpa [pow_two, topEdgeBound, mul_add, add_mul, left_distrib, right_distrib,
+    mul_assoc, mul_left_comm, mul_comm, Real.exp_add] using (t1.add t2).add t3
+
+/-- The top edge bound is nonnegative for T ≥ 1. -/
+lemma topEdgeBound_nonneg (r T : ℝ) (hT : 1 ≤ T) : 0 ≤ topEdgeBound r T := by
+  simp only [topEdgeBound]
+  have := C_φ₀_pos; have := C_φ₂'_pos; have := C_φ₄'_pos
+  positivity
+
+/-- Uniform bound on top edge integrand for x ∈ [-1,1], T ≥ 1.
+    Uses S-transform bound (norm_φ₀_S_smul_le) with ‖z‖ ≥ T.
+
+    Proof strategy:
+    1. Show φ₀''(-1/z) = φ₀(S•w) where w = x + iT ∈ ℍ
+    2. Apply norm_φ₀_S_smul_le to get 3-term bound
+    3. Use ‖z‖ ≥ T to bound 1/‖z‖ terms by 1/T
+    4. Combine with ‖z²‖ ≤ (1+T)² and exponential phase norm -/
+lemma norm_topEdgeIntegrand_le (r : ℝ) (x T : ℝ)
+    (hx : x ∈ Icc (-1 : ℝ) 1) (hT : 1 ≤ T) :
+    ‖topEdgeIntegrand r x T‖ ≤ topEdgeBound r T := by
+  have hT_pos : 0 < T := lt_of_lt_of_le one_pos hT
+  let z : ℂ := ↑x + Complex.I * ↑T
+  have hz_im : z.im = T := by simp [z]
+  let w : ℍ := ⟨z, hz_im ▸ hT_pos⟩
+  rcases norm_x_add_I_mul_T_bounds x T hx hT with ⟨hz_norm_ge, hz_norm_le⟩
+  have hφ₀_eq : φ₀'' (-1 / z) = φ₀ (ModularGroup.S • w) := by
+    simpa [w, z] using φ₀''_neg_inv_eq_φ₀_S_smul x T hT_pos
+  have hS_bound := norm_φ₀_S_smul_le w (by simpa [w, z] using hT)
+  have hz_sq_norm : ‖z^2‖ ≤ (1 + T)^2 := by
+    rw [norm_pow]
+    exact sq_le_sq' (by linarith) hz_norm_le
+  have hexp_norm : ‖Complex.exp (Complex.I * π * r * z)‖ = Real.exp (-π * r * T) := by
+    simpa [z] using norm_cexp_verticalPhase x r T
+  unfold topEdgeIntegrand topEdgeBound
+  simp only [z] at *
+  rw [norm_mul, norm_mul, hφ₀_eq, hexp_norm]
+  -- Replace ‖z‖ with T in the S-transform bound (‖z‖ ≥ T → 1/‖z‖ ≤ 1/T)
+  have hS_bound' : ‖φ₀ (ModularGroup.S • w)‖ ≤
+      C_φ₀ * Real.exp (-2 * π * T) + 12 * C_φ₂' / (π * T) +
+        36 * C_φ₄' / (π^2 * T^2) * Real.exp (2 * π * T) := by
+    rw [show w.im = T from hz_im] at hS_bound
+    calc ‖φ₀ (ModularGroup.S • w)‖
+        ≤ C_φ₀ * Real.exp (-2 * π * T) + 12 / (π * ‖(w : ℂ)‖) * C_φ₂' +
+            36 / (π^2 * ‖(w : ℂ)‖^2) * C_φ₄' * Real.exp (2 * π * T) := hS_bound
+      _ ≤ C_φ₀ * Real.exp (-2 * π * T) + 12 / (π * T) * C_φ₂' +
+            36 / (π^2 * T^2) * C_φ₄' * Real.exp (2 * π * T) := by
+          apply add_le_add
+          · apply add_le_add le_rfl
+            apply mul_le_mul_of_nonneg_right _ (le_of_lt C_φ₂'_pos)
+            exact div_le_div_of_nonneg_left (by norm_num) (by positivity)
+              (mul_le_mul_of_nonneg_left hz_norm_ge (le_of_lt Real.pi_pos))
+          · apply mul_le_mul_of_nonneg_right _ (le_of_lt (Real.exp_pos _))
+            apply mul_le_mul_of_nonneg_right _ (le_of_lt C_φ₄'_pos)
+            exact div_le_div_of_nonneg_left (by norm_num) (by positivity)
+              (mul_le_mul_of_nonneg_left
+                ((sq_le_sq₀ (by linarith : 0 ≤ T) (norm_nonneg _)).mpr hz_norm_ge) (sq_nonneg π))
+      _ = _ := by ring
+  calc ‖φ₀ (ModularGroup.S • w)‖ * ‖(↑x + Complex.I * ↑T)^2‖ * Real.exp (-π * r * T)
+      ≤ (C_φ₀ * Real.exp (-2 * π * T) + 12 * C_φ₂' / (π * T) +
+          36 * C_φ₄' / (π^2 * T^2) * Real.exp (2 * π * T)) * (1 + T)^2 *
+            Real.exp (-π * r * T) := by
+        apply mul_le_mul_of_nonneg_right _ (le_of_lt (Real.exp_pos _))
+        apply mul_le_mul hS_bound' hz_sq_norm (norm_nonneg _)
+        have := C_φ₀_pos; have := C_φ₂'_pos; have := C_φ₄'_pos
+        positivity
+    _ = _ := by ring
+
+/-- Uniform vanishing: the top edge integrand is arbitrarily small for all z = x + iT
+    with x ∈ [-1,1] and sufficiently large T. This is the form needed by Cauchy-Goursat. -/
+lemma uniform_vanishing_topEdgeIntegrand (r : ℝ) (hr : 2 < r) :
+    ∀ ε > 0, ∃ M : ℝ, ∀ x T : ℝ, x ∈ Icc (-1 : ℝ) 1 → M ≤ T →
+      ‖topEdgeIntegrand r x T‖ < ε := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp (tendsto_topEdgeBound_atTop r hr) ε hε
+  refine ⟨max N 1, fun x T hx hT => ?_⟩
+  have hT1 : 1 ≤ T := le_trans (le_max_right N 1) hT
+  have hTN : N ≤ T := le_trans (le_max_left N 1) hT
+  exact lt_of_le_of_lt (norm_topEdgeIntegrand_le r x T hx hT1)
+    (by simpa [abs_of_nonneg (topEdgeBound_nonneg r T hT1)] using hN T hTN)
+
+/-! ## Filter-based uniform vanishing (alternative formulation)
+
+These lemmas express uniform vanishing using the `atImInfty_ℂ` filter,
+providing a filter-theoretic interface that composes well with other lemmas.
+
+Note: The bounds `topEdgeBound` require `x ∈ [-1,1]` because `‖z‖ ≤ 1+T` is used.
+For the full Cauchy-Goursat application, the rectangle contour has bounded real part,
+so this restriction is acceptable.
+-/
+
+/-- Filter version of uniform_vanishing_verticalIntegrandX.
+    The vertical integrand tends to 0 under the `atImInfty_ℂ` filter
+    (composed with the embedding t ↦ x + it for any fixed x). -/
+lemma tendsto_verticalIntegrandX_atImInfty_ℂ (x r : ℝ) (hr : 2 < r) :
+    Tendsto (fun t : ℝ => verticalIntegrandX x r t) atTop (𝓝 0) :=
+  tendsto_verticalIntegrandX_atTop x r hr
+
+/-- Filter version of uniform_vanishing_topEdgeIntegrand for a fixed x ∈ [-1,1].
+    The top edge integrand tends to 0 under `atTop` filter on T. -/
+lemma tendsto_topEdgeIntegrand_atTop (r : ℝ) (hr : 2 < r) (x : ℝ) (hx : x ∈ Icc (-1 : ℝ) 1) :
+    Tendsto (fun T : ℝ => topEdgeIntegrand r x T) atTop (𝓝 0) := by
+  simpa [Metric.tendsto_atTop] using fun ε hε =>
+    (uniform_vanishing_topEdgeIntegrand r hr ε hε).imp fun M hM T hT => hM x T hx hT
+
+/-- The uniform vanishing property expressed as: eventually, the integrand norm
+    is bounded by any positive ε, uniformly in x. -/
+lemma eventually_norm_topEdgeIntegrand_lt (r : ℝ) (hr : 2 < r) (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ T in atTop, ∀ x ∈ Icc (-1 : ℝ) 1, ‖topEdgeIntegrand r x T‖ < ε := by
+  obtain ⟨M, hM⟩ := uniform_vanishing_topEdgeIntegrand r hr ε hε
+  filter_upwards [eventually_ge_atTop M] with T hT x hx
+  exact hM x T hx hT
+
+/-- Top horizontal edge integral vanishes as height T → ∞.
+    This is the "integrand at i∞ disappears" fact from Proposition 7.14.
+
+    The integrand involves φ₀(-1/z) = φ₀(S•z), not φ₀(z) directly.
+    For z = x + iT with T large, the S-transform bound gives exponential decay.
+
+    Strategy: Use squeeze theorem with topEdgeBound
+    ‖∫₋₁¹ f(x,T) dx‖ ≤ ∫₋₁¹ ‖f(x,T)‖ dx ≤ 2 * topEdgeBound(T) → 0 -/
+lemma tendsto_topEdgeIntegral_zero (r : ℝ) (hr : 2 < r) :
+    Tendsto (fun (T : ℝ) => ∫ x : ℝ in Icc (-1 : ℝ) 1, topEdgeIntegrand r x T)
+    atTop (𝓝 0) := by
+  -- Strategy: Use tendsto_zero_iff_norm_tendsto_zero + squeeze_zero'
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  apply squeeze_zero'
+  · exact Eventually.of_forall fun _ => norm_nonneg _
+  · filter_upwards [eventually_ge_atTop 1] with T hT
+    calc ‖∫ x in Icc (-1 : ℝ) 1, topEdgeIntegrand r x T‖
+        ≤ topEdgeBound r T * volume.real (Icc (-1 : ℝ) 1) :=
+          norm_setIntegral_le_of_norm_le_const measure_Icc_lt_top
+            (fun x hx => norm_topEdgeIntegrand_le r x T hx hT)
+      _ = 2 * topEdgeBound r T := by
+          norm_num [Measure.real, Real.volume_Icc, mul_comm]
+  · simpa using (tendsto_topEdgeBound_atTop r hr).const_mul 2
+
+end MagicFunction.ContourEndpoints
+
+end

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -11,8 +11,6 @@ public import SpherePacking.MagicFunction.a.Integrability.CuspPath
 public import SpherePacking.MagicFunction.a.PhiBounds
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
-@[expose] public section
-
 /-!
 # Contour Endpoint Bounds for Vertical Rays
 
@@ -37,6 +35,8 @@ as needed for the Cauchy-Goursat applications in the double zeroes proof (#229).
 We use `Im(z) ≥ 1` (stronger than the blueprint's `Im(z) > 1/2`) as a convenient
 safe strip that covers all rectangle contour points.
 -/
+
+@[expose] public section
 
 open MeasureTheory Set Filter Real UpperHalfPlane TopologicalSpace
 open MagicFunction.a

--- a/SpherePacking/MagicFunction/a/ContourEndpoints.lean
+++ b/SpherePacking/MagicFunction/a/ContourEndpoints.lean
@@ -9,6 +9,7 @@ public import SpherePacking.ModularForms.PhiTransform
 public import SpherePacking.MagicFunction.a.Integrability.RealDecay
 public import SpherePacking.MagicFunction.a.Integrability.CuspPath
 public import SpherePacking.MagicFunction.a.PhiBounds
+public import SpherePacking.Tactic.TendstoCont
 public import Mathlib.MeasureTheory.Integral.IntegrableOn
 
 /-!
@@ -298,7 +299,7 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
     have := (_root_.tendsto_sq_mul_exp_neg_atTop (2 * π + π * r) h1).const_mul C_φ₀
     simp only [mul_zero] at this
     convert this using 1; funext s; ring
-  have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-(π * r) * s))
+  have t2 : Tendsto (fun s => (12 * C_φ₂' / π) * s * Real.exp (-π * r * s))
       atTop (𝓝 0) := by
     have := (_root_.tendsto_mul_exp_neg_atTop (π * r) h2).const_mul (12 * C_φ₂' / π)
     simp only [mul_zero] at this
@@ -307,12 +308,8 @@ lemma tendsto_verticalBound_atTop (r : ℝ) (hr : 2 < r) :
       atTop (𝓝 0) := by
     simpa [mul_zero] using
       (_root_.tendsto_exp_neg_atTop (π * r - 2 * π) h3).const_mul (36 * C_φ₄' / π^2)
-  have hsum := (t1.add t2).add t3
-  simp only [add_zero] at hsum
-  convert hsum using 1
-  funext s
-  simp only [verticalBound]
-  ring_nf
+  unfold verticalBound
+  tendsto_cont
 
 /-- The vertical bound is nonnegative for t ≥ 1. -/
 lemma verticalBound_nonneg (r t : ℝ) (ht : 1 ≤ t) : 0 ≤ verticalBound r t := by

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -32,7 +32,7 @@ This means:
 ## References
 
 - Blueprint Corollaries 7.5-7.7
-- PR #268: q-expansion identities for Eisenstein series
+- `SpherePacking.ModularForms.FG`: q-expansion identities (`E₂_mul_E₄_sub_E₆`, `E₄_sigma_qexp`)
 -/
 
 open Real Complex UpperHalfPlane
@@ -201,34 +201,17 @@ lemma summable_E₄_sq (z : ℍ) :
     Summable fun (i : ℕ) ↦ fouterm c_E₄_sq z (i + 0) :=
   summable_fouterm_of_poly c_E₄_sq_poly z 0
 
-/-! ## Q-expansion identities
-
-These are proved in FG.lean; we re-export them here with the exact signatures
-needed by downstream code. -/
-
-/-- Q-expansion of E₂E₄ - E₆.
-    E₂·E₄ - E₆ = 720·∑_{n≥1} n·σ₃(n)·q^n where q = exp(2πiz). -/
-lemma E₂_mul_E₄_sub_E₆_qexp (z : ℍ) :
-    E₂ z * E₄ z - E₆ z = 720 * ∑' (n : ℕ+), (n : ℂ) * (σ 3 n : ℂ) *
-      Complex.exp (2 * π * Complex.I * n * z) := E₂_mul_E₄_sub_E₆ z
-
-/-- Q-expansion of E₄ (standard result).
-    E₄ = 1 + 240·∑_{n≥1} σ₃(n)·q^n where q = exp(2πiz). -/
-lemma E₄_qexp (z : ℍ) :
-    E₄ z = 1 + 240 * ∑' (n : ℕ+), (σ 3 n : ℂ) *
-      Complex.exp (2 * π * Complex.I * n * z) := E₄_sigma_qexp z
-
 /-! ## Fourier Expansion Identities
 
 These connect the Eisenstein series products to fouterm sums.
-The proofs use the q-expansion stubs above. -/
+The proofs use `E₂_mul_E₄_sub_E₆` and `E₄_sigma_qexp` from `FG.lean`. -/
 
 /-- Fourier expansion of (E₂E₄ - E₆)².
     In q = exp(2πiz) convention: (E₂E₄ - E₆) = 720·∑_{n≥1} n·σ₃(n)·qⁿ
     The square starts at q², which is r⁴ in r = exp(πiz) convention. -/
 lemma E₂E₄E₆_sq_fourier (x : ℍ) :
     ((E₂ x) * (E₄ x) - (E₆ x)) ^ 2 = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 4) := by
-  -- From E₂_mul_E₄_sub_E₆_qexp and Cauchy product of q-series
+  -- From E₂_mul_E₄_sub_E₆ and Cauchy product of q-series
   -- (720 * ∑ n·σ₃(n)·q^n)² = 720² * (∑ n·σ₃(n)·q^n)²
   -- Cauchy product: (∑ aₙq^n)² = ∑ (∑_{j+k=n} aⱼaₖ) q^n
   -- Starting at n=1, square starts at n=2 in q-space = index 4 in r-space
@@ -238,7 +221,7 @@ lemma E₂E₄E₆_sq_fourier (x : ℍ) :
     Product starts at q¹, which is r² in fouterm convention. -/
 lemma E₄_E₂E₄E₆_fourier (x : ℍ) :
     E₄ x * (E₂ x * E₄ x - E₆ x) = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 2) := by
-  -- From E₄_qexp and E₂_mul_E₄_sub_E₆_qexp
+  -- From E₄_sigma_qexp and E₂_mul_E₄_sub_E₆
   -- E₄ starts at q⁰, E₂E₄-E₆ starts at q¹, so product starts at q¹ = r²
   sorry
 
@@ -246,7 +229,7 @@ lemma E₄_E₂E₄E₆_fourier (x : ℍ) :
     E₄ = 1 + 240·∑_{n≥1} σ₃(n)·qⁿ, so E₄² starts at constant term 1. -/
 lemma E₄_sq_fourier (x : ℍ) :
     E₄ x ^ 2 = ∑' (n : ℕ), fouterm c_E₄_sq x (n + 0) := by
-  -- From E₄_qexp: E₄² = (1 + 240·∑...)² starts at q⁰ = r⁰
+  -- From E₄_sigma_qexp: E₄² = (1 + 240·∑...)² starts at q⁰ = r⁰
   sorry
 
 end MagicFunction.a.FourierExpansions

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -127,9 +127,8 @@ lemma isBigO_shift {c : ℤ → ℂ} {k : ℕ} (n₀ : ℤ)
     simp only [norm_pow, norm_eq_abs] at hCa ⊢
     refine ⟨(m - n₀).toNat, fun n hn ↦ ?_⟩
     have hmn : (n : ℤ) + n₀ ≥ m := by
-      have h1 : (n : ℤ) ≥ ((m - n₀).toNat : ℤ) := Int.ofNat_le.mpr hn
-      have h2 : ((m - n₀).toNat : ℤ) ≥ m - n₀ := Int.self_le_toNat _
-      linarith
+      have := Int.self_le_toNat (m - n₀)
+      omega
     exact_mod_cast hCa (n + n₀) hmn
   -- Second: (n + n₀)^k = O(n^k) using |n + n₀| ≤ 2n for n ≥ |n₀|
   refine h_shift.trans ?_
@@ -174,22 +173,13 @@ lemma summable_fouterm_of_poly {c : ℤ → ℂ} {k : ℕ}
   let const := cexp (π * Complex.I * n₀ * z)
   let u : ℕ → ℂ := fun i => c (i + n₀) * const
   have h_factor : ∀ i : ℕ, fouterm c z (i + n₀) = u i * r ^ i := fun i => by
-    simp only [fouterm, u, r, const]
-    -- cexp(π * I * (i + n₀) * z) = cexp(π * I * n₀ * z) * cexp(π * I * z)^i
-    have hexp : cexp (↑π * Complex.I * ↑(↑i + n₀) * ↑z) = const * r ^ i := by
-      simp only [const, r, ← Complex.exp_nat_mul, Int.cast_add, Int.cast_natCast]
-      rw [← Complex.exp_add]
-      congr 1
-      ring
-    rw [hexp]
+    simp only [fouterm, u, r, const, ← Complex.exp_nat_mul, Int.cast_add, Int.cast_natCast]
+    rw [show (↑π * Complex.I * (↑i + ↑n₀) * ↑z : ℂ) =
+        ↑π * Complex.I * ↑n₀ * ↑z + ↑π * Complex.I * ↑i * ↑z by ring, Complex.exp_add]
     ring
   -- u has polynomial growth: ‖u n‖ = ‖c(n+n₀)‖ * ‖const‖ is O(n^k)
   have hu : u =O[Filter.atTop] (fun n ↦ (↑(n ^ k) : ℝ)) := by
-    simp only [u]
-    -- f(i) * const = const * f(i), and const * f is O(g) if f is O(g)
-    have heq : (fun i : ℕ => c (↑i + n₀) * const) = (fun i : ℕ => const * c (↑i + n₀)) := by
-      ext i; ring
-    rw [heq]
+    simp only [u, show ∀ i, c (↑i + n₀) * const = const * c (↑i + n₀) from fun _ => mul_comm _ _]
     exact hshift.const_mul_left const
   -- Apply summability theorem
   simp_rw [h_factor]

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -50,6 +50,10 @@ These match the coefficient growth patterns needed for DivDiscBound. -/
 /-- Coefficient function with growth O(n^5), used for E₂E₄-E₆ related expansions. -/
 def c_E₂E₄E₆ : ℤ → ℂ := fun n ↦ n * (σ 3 n.toNat)
 
+/-- Coefficient function for E₄(E₂E₄ - E₆), the product (not square).
+    Note: Uses same simplified bound as c_E₂E₄E₆ for this branch. -/
+def c_E₄_E₂E₄E₆ : ℤ → ℂ := fun n ↦ n * (σ 3 n.toNat)
+
 /-- Coefficient function for E₄², with constant term 1. -/
 def c_E₄_sq : ℤ → ℂ := fun n ↦ if n ≤ 0 then 1 else n * (σ 3 n.toNat)
 
@@ -83,6 +87,12 @@ lemma c_E₂E₄E₆_poly : c_E₂E₄E₆ =O[Filter.atTop] (fun n ↦ (n ^ 5 : 
   _ = R * |↑n| ^ 5 := by
     simp only [mul_eq_mul_left_iff]; norm_cast; left
     rw [Nat.cast_pow, hnnat]; simp [hnnonneg, abs_of_nonneg]
+
+/-- c_E₄_E₂E₄E₆ has polynomial growth O(n^5).
+    Note: Same growth as c_E₂E₄E₆ since they have the same simplified definition. -/
+lemma c_E₄_E₂E₄E₆_poly : c_E₄_E₂E₄E₆ =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
+  -- c_E₄_E₂E₄E₆ = c_E₂E₄E₆ definitionally
+  exact c_E₂E₄E₆_poly
 
 /-- c_E₄_sq has polynomial growth O(n^5). -/
 lemma c_E₄_sq_poly : c_E₄_sq =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
@@ -191,10 +201,11 @@ lemma summable_E₂E₄E₆_sq (z : ℍ) :
     Summable fun (i : ℕ) ↦ fouterm c_E₂E₄E₆ z (i + 4) :=
   summable_fouterm_of_poly c_E₂E₄E₆_poly z 4
 
-/-- Summability for E₄(E₂E₄ - E₆) expansion (n₀ = 2). -/
+/-- Summability for E₄(E₂E₄ - E₆) expansion (n₀ = 2).
+    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
 lemma summable_E₄_E₂E₄E₆ (z : ℍ) :
-    Summable fun (i : ℕ) ↦ fouterm c_E₂E₄E₆ z (i + 2) :=
-  summable_fouterm_of_poly c_E₂E₄E₆_poly z 2
+    Summable fun (i : ℕ) ↦ fouterm c_E₄_E₂E₄E₆ z (i + 2) :=
+  summable_fouterm_of_poly c_E₄_E₂E₄E₆_poly z 2
 
 /-- Summability for E₄² expansion (n₀ = 0). -/
 lemma summable_E₄_sq (z : ℍ) :
@@ -218,9 +229,10 @@ lemma E₂E₄E₆_sq_fourier (x : ℍ) :
   sorry
 
 /-- Fourier expansion of E₄(E₂E₄ - E₆).
-    Product starts at q¹, which is r² in fouterm convention. -/
+    Product starts at q¹, which is r² in fouterm convention.
+    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
 lemma E₄_E₂E₄E₆_fourier (x : ℍ) :
-    E₄ x * (E₂ x * E₄ x - E₆ x) = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 2) := by
+    E₄ x * (E₂ x * E₄ x - E₆ x) = ∑' (n : ℕ), fouterm c_E₄_E₂E₄E₆ x (n + 2) := by
   -- From E₄_sigma_qexp and E₂_mul_E₄_sub_E₆
   -- E₄ starts at q⁰, E₂E₄-E₆ starts at q¹, so product starts at q¹ = r²
   sorry

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -5,6 +5,7 @@ Authors: Cameron Freer
 -/
 import SpherePacking.MagicFunction.PolyFourierCoeffBound
 import SpherePacking.ForMathlib.SpecificLimits
+import SpherePacking.ModularForms.FG
 
 /-!
 # Fourier Expansion Identities for Phi Bounds
@@ -200,24 +201,22 @@ lemma summable_E₄_sq (z : ℍ) :
     Summable fun (i : ℕ) ↦ fouterm c_E₄_sq z (i + 0) :=
   summable_fouterm_of_poly c_E₄_sq_poly z 0
 
-/-! ## Stubs from PR #268
+/-! ## Q-expansion identities
 
-These q-expansion identities are proved in PR #268. We state them here as sorries
-so that downstream code can be structured around them. -/
+These are proved in FG.lean; we re-export them here with the exact signatures
+needed by downstream code. -/
 
-/-- Q-expansion of E₂E₄ - E₆ (from PR #268).
+/-- Q-expansion of E₂E₄ - E₆.
     E₂·E₄ - E₆ = 720·∑_{n≥1} n·σ₃(n)·q^n where q = exp(2πiz). -/
 lemma E₂_mul_E₄_sub_E₆_qexp (z : ℍ) :
     E₂ z * E₄ z - E₆ z = 720 * ∑' (n : ℕ+), (n : ℂ) * (σ 3 n : ℂ) *
-      Complex.exp (2 * π * Complex.I * n * z) := by
-  sorry -- From PR #268: E₂_mul_E₄_sub_E₆
+      Complex.exp (2 * π * Complex.I * n * z) := E₂_mul_E₄_sub_E₆ z
 
 /-- Q-expansion of E₄ (standard result).
     E₄ = 1 + 240·∑_{n≥1} σ₃(n)·q^n where q = exp(2πiz). -/
 lemma E₄_qexp (z : ℍ) :
     E₄ z = 1 + 240 * ∑' (n : ℕ+), (σ 3 n : ℂ) *
-      Complex.exp (2 * π * Complex.I * n * z) := by
-  sorry -- Standard q-expansion, should be in Eisenstein.lean or PR #268
+      Complex.exp (2 * π * Complex.I * n * z) := E₄_sigma_qexp z
 
 /-! ## Fourier Expansion Identities
 

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2025 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import SpherePacking.MagicFunction.PolyFourierCoeffBound
+import SpherePacking.ForMathlib.SpecificLimits
+
+/-!
+# Fourier Expansion Identities for Phi Bounds
+
+States the Fourier expansion identities needed to connect the phi functions
+(φ₀, φ₂', φ₄') to the DivDiscBound machinery in PolyFourierCoeffBound.
+
+## Convention
+
+The standard q-expansion uses q = exp(2πiz), while `fouterm` uses exp(πinz).
+Since q = exp(2πiz) and setting r = exp(πiz), we have q = r².
+
+This means:
+- A q-expansion ∑ aₙ qⁿ becomes ∑ aₙ r^{2n} in the fouterm convention
+- The starting index n₀ in fouterm corresponds to n₀/2 in q-space
+
+## Main Results
+
+- `summable_fouterm_of_poly`: Summability from polynomial growth + exponential decay
+- `E₂E₄E₆_sq_fourier`: (E₂E₄ - E₆)² in fouterm form (n₀ = 4)
+- `E₄_E₂E₄E₆_fourier`: E₄(E₂E₄ - E₆) in fouterm form (n₀ = 2)
+- `E₄_sq_fourier`: E₄² in fouterm form (n₀ = 0)
+
+## References
+
+- Blueprint Corollaries 7.5-7.7
+- PR #268: q-expansion identities for Eisenstein series
+-/
+
+open Real Complex UpperHalfPlane
+open scoped ArithmeticFunction.sigma
+open MagicFunction.PolyFourierCoeffBound
+
+noncomputable section
+
+namespace MagicFunction.a.FourierExpansions
+
+/-! ## Coefficient Functions
+
+These match the coefficient growth patterns needed for DivDiscBound. -/
+
+/-- Coefficient function with growth O(n^5), used for E₂E₄-E₆ related expansions. -/
+def c_E₂E₄E₆ : ℤ → ℂ := fun n ↦ n * (σ 3 n.toNat)
+
+/-- Coefficient function for E₄², with constant term 1. -/
+def c_E₄_sq : ℤ → ℂ := fun n ↦ if n ≤ 0 then 1 else n * (σ 3 n.toNat)
+
+/-- c_E₂E₄E₆ has polynomial growth O(n^5). -/
+lemma c_E₂E₄E₆_poly : c_E₂E₄E₆ =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
+  -- Coefficients n·σ₃(n) grow as O(n) × O(n^4) = O(n^5)
+  let d : ℕ → ℂ := fun n ↦ n * (σ 3 n)
+  have hcd (n : ℕ) : c_E₂E₄E₆ n = d n := by simp [c_E₂E₄E₆, d]
+  have hdpoly : d =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℂ)) := by
+    have h₁ (n : ℕ) : n ^ 5 = n * n ^ 4 := Nat.pow_succ'
+    norm_cast
+    simp only [h₁]
+    push_cast
+    refine Asymptotics.IsBigO.mul (Asymptotics.isBigO_refl _ Filter.atTop) ?_
+    have h := ArithmeticFunction.sigma_asymptotic' 3
+    simp only [Nat.reduceAdd] at h
+    norm_cast at h ⊢
+  simp only [Asymptotics.isBigO_iff, norm_pow, Complex.norm_natCast, Filter.eventually_atTop,
+    ge_iff_le] at hdpoly ⊢
+  obtain ⟨R, m, hR⟩ := hdpoly
+  use R, m
+  intro n hn
+  have hnnonneg : 0 ≤ n := calc 0 ≤ (m : ℤ) := by positivity
+    _ ≤ ↑n := hn
+  have hnnat : n.toNat = n := by simp only [Int.ofNat_toNat, sup_eq_left, hnnonneg]
+  have hmnnat : m ≤ n.toNat := by zify; rw [hnnat]; exact hn
+  specialize hR n.toNat hmnnat
+  rw [← hcd, hnnat] at hR
+  calc norm (c_E₂E₄E₆ n)
+  _ ≤ R * n.toNat ^ 5 := hR
+  _ = R * |↑n| ^ 5 := by
+    simp only [mul_eq_mul_left_iff]; norm_cast; left
+    rw [Nat.cast_pow, hnnat]; simp [hnnonneg, abs_of_nonneg]
+
+/-- c_E₄_sq has polynomial growth O(n^5). -/
+lemma c_E₄_sq_poly : c_E₄_sq =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
+  have heq : c_E₄_sq =ᶠ[Filter.atTop] c_E₂E₄E₆ := by
+    simp only [Filter.EventuallyEq, Filter.eventually_atTop, ge_iff_le]
+    use 1
+    intro n hn
+    simp only [c_E₄_sq, c_E₂E₄E₆]
+    have h : ¬n ≤ 0 := by omega
+    simp only [h, ↓reduceIte]
+  exact c_E₂E₄E₆_poly.congr' heq.symm Filter.EventuallyEq.rfl
+
+/-! ## Auxiliary lemmas for summability -/
+
+/-- The norm of exp(πiz) for z : ℍ is less than 1.
+    Proof: |exp(πiz)| = exp(Re(πiz)) = exp(-π·z.im) < 1 since z.im > 0. -/
+lemma norm_exp_pi_I_z_lt_one (z : ℍ) : ‖Complex.exp (π * Complex.I * z)‖ < 1 := by
+  rw [Complex.norm_exp]
+  -- (π * I * z).re = -π * z.im because I.re = 0, I.im = 1
+  have him : (π * Complex.I * (z : ℂ)).re = -π * z.im := by
+    have h1 : (π * Complex.I : ℂ).re = 0 := by simp [Complex.I_re]
+    have h2 : (π * Complex.I : ℂ).im = π := by simp [Complex.I_im]
+    simp only [mul_re, h1, zero_mul, h2]
+    simp only [UpperHalfPlane.coe_im]
+    ring
+  rw [him]
+  have hneg : -π * z.im < 0 := by nlinarith [Real.pi_pos, z.im_pos]
+  exact Real.exp_lt_one_iff.mpr hneg
+
+/-- Shifting a function by a constant preserves Big-O growth.
+    For c : ℤ → ℂ with c = O(n^k), the shifted function i ↦ c(i + n₀) is also O(n^k). -/
+lemma isBigO_shift {c : ℤ → ℂ} {k : ℕ} (n₀ : ℤ)
+    (hc : c =O[Filter.atTop] (fun n ↦ (n ^ k : ℝ))) :
+    (fun i : ℕ ↦ c (i + n₀)) =O[Filter.atTop] (fun n ↦ (↑(n ^ k) : ℝ)) := by
+  -- For large i, |i + n₀| ≤ C * i for some C, so |i + n₀|^k ≤ C^k * i^k
+  -- Thus O(|i + n₀|^k) ⊆ O(i^k)
+  sorry
+
+/-! ## Summability Lemmas
+
+The Fourier series terms are summable because:
+1. Coefficients have polynomial growth O(n^k)
+2. Exponential factor exp(-π·n·z.im) decays geometrically for z.im > 0
+3. Polynomial times geometric is summable -/
+
+/-- Summability of fouterm series with polynomial-growth coefficients.
+    For z : ℍ, the exponential term exp(πinz) has norm exp(-πn·z.im) < 1,
+    so polynomial-growth coefficients give a summable series.
+
+    Proof sketch:
+    1. Rewrite fouterm c z (i + n₀) = u(i) * r^i where r = exp(πiz), u(i) = c(i+n₀) * const
+    2. ‖r‖ = exp(-π·z.im) < 1 (by norm_exp_pi_I_z_lt_one)
+    3. u has O(n^k) growth (isBigO_shift + multiplication by constant)
+    4. Apply summable_real_norm_mul_geometric_of_norm_lt_one -/
+lemma summable_fouterm_of_poly {c : ℤ → ℂ} {k : ℕ}
+    (hpoly : c =O[Filter.atTop] (fun n ↦ (n ^ k : ℝ)))
+    (z : ℍ) (n₀ : ℤ) : Summable fun (i : ℕ) ↦ fouterm c z (i + n₀) := by
+  -- Key fact: ‖exp(πiz)‖ < 1 for z : ℍ
+  have hr : ‖Complex.exp (π * Complex.I * z)‖ < 1 := norm_exp_pi_I_z_lt_one z
+  -- Shifted coefficients have polynomial growth
+  have hshift := isBigO_shift n₀ hpoly
+  -- The detailed proof needs careful handling of the factorization
+  -- fouterm c z (i + n₀) = (c(i+n₀) * const) * exp(πiz)^i
+  -- and application of summable_real_norm_mul_geometric_of_norm_lt_one
+  sorry
+
+/-- Summability for (E₂E₄ - E₆)² expansion (n₀ = 4). -/
+lemma summable_E₂E₄E₆_sq (z : ℍ) :
+    Summable fun (i : ℕ) ↦ fouterm c_E₂E₄E₆ z (i + 4) :=
+  summable_fouterm_of_poly c_E₂E₄E₆_poly z 4
+
+/-- Summability for E₄(E₂E₄ - E₆) expansion (n₀ = 2). -/
+lemma summable_E₄_E₂E₄E₆ (z : ℍ) :
+    Summable fun (i : ℕ) ↦ fouterm c_E₂E₄E₆ z (i + 2) :=
+  summable_fouterm_of_poly c_E₂E₄E₆_poly z 2
+
+/-- Summability for E₄² expansion (n₀ = 0). -/
+lemma summable_E₄_sq (z : ℍ) :
+    Summable fun (i : ℕ) ↦ fouterm c_E₄_sq z (i + 0) :=
+  summable_fouterm_of_poly c_E₄_sq_poly z 0
+
+/-! ## Stubs from PR #268
+
+These q-expansion identities are proved in PR #268. We state them here as sorries
+so that downstream code can be structured around them. -/
+
+/-- Q-expansion of E₂E₄ - E₆ (from PR #268).
+    E₂·E₄ - E₆ = 720·∑_{n≥1} n·σ₃(n)·q^n where q = exp(2πiz). -/
+lemma E₂_mul_E₄_sub_E₆_qexp (z : ℍ) :
+    E₂ z * E₄ z - E₆ z = 720 * ∑' (n : ℕ+), (n : ℂ) * (σ 3 n : ℂ) *
+      Complex.exp (2 * π * Complex.I * n * z) := by
+  sorry -- From PR #268: E₂_mul_E₄_sub_E₆
+
+/-- Q-expansion of E₄ (standard result).
+    E₄ = 1 + 240·∑_{n≥1} σ₃(n)·q^n where q = exp(2πiz). -/
+lemma E₄_qexp (z : ℍ) :
+    E₄ z = 1 + 240 * ∑' (n : ℕ+), (σ 3 n : ℂ) *
+      Complex.exp (2 * π * Complex.I * n * z) := by
+  sorry -- Standard q-expansion, should be in Eisenstein.lean or PR #268
+
+/-! ## Fourier Expansion Identities
+
+These connect the Eisenstein series products to fouterm sums.
+The proofs use the q-expansion stubs above. -/
+
+/-- Fourier expansion of (E₂E₄ - E₆)².
+    In q = exp(2πiz) convention: (E₂E₄ - E₆) = 720·∑_{n≥1} n·σ₃(n)·qⁿ
+    The square starts at q², which is r⁴ in r = exp(πiz) convention. -/
+lemma E₂E₄E₆_sq_fourier (x : ℍ) :
+    ((E₂ x) * (E₄ x) - (E₆ x)) ^ 2 = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 4) := by
+  -- From E₂_mul_E₄_sub_E₆_qexp and Cauchy product of q-series
+  -- (720 * ∑ n·σ₃(n)·q^n)² = 720² * (∑ n·σ₃(n)·q^n)²
+  -- Cauchy product: (∑ aₙq^n)² = ∑ (∑_{j+k=n} aⱼaₖ) q^n
+  -- Starting at n=1, square starts at n=2 in q-space = index 4 in r-space
+  sorry
+
+/-- Fourier expansion of E₄(E₂E₄ - E₆).
+    Product starts at q¹, which is r² in fouterm convention. -/
+lemma E₄_E₂E₄E₆_fourier (x : ℍ) :
+    E₄ x * (E₂ x * E₄ x - E₆ x) = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 2) := by
+  -- From E₄_qexp and E₂_mul_E₄_sub_E₆_qexp
+  -- E₄ starts at q⁰, E₂E₄-E₆ starts at q¹, so product starts at q¹ = r²
+  sorry
+
+/-- Fourier expansion of E₄².
+    E₄ = 1 + 240·∑_{n≥1} σ₃(n)·qⁿ, so E₄² starts at constant term 1. -/
+lemma E₄_sq_fourier (x : ℍ) :
+    E₄ x ^ 2 = ∑' (n : ℕ), fouterm c_E₄_sq x (n + 0) := by
+  -- From E₄_qexp: E₄² = (1 + 240·∑...)² starts at q⁰ = r⁰
+  sorry
+
+end MagicFunction.a.FourierExpansions
+
+end

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -360,6 +360,28 @@ lemma bE₄_isBigO : bE₄ =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
     Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
   nlinarith [hσ, hm1, pow_nonneg (by linarith : (0:ℝ) ≤ (m:ℝ)) 4]
 
+/-! ## Linear quotient bounds (Design B #3)
+
+Direct `DivDiscBoundOfPolyFourierCoeff` applications using the linear `fouterm` identities. -/
+
+/-- `‖(E₂E₄−E₆)/Δ‖ ≤ DivDiscBound (evenCoeff bg) 2` (constant: `n₀=2 ⇒ exp 0 = 1`). -/
+lemma g_div_Δ_bound (z : ℍ) (hz : 1 / 2 < z.im) :
+    ‖(E₂ z * E₄ z - E₆ z) / Δ z‖ ≤ DivDiscBound (evenCoeff bg) 2 := by
+  have h := DivDiscBoundOfPolyFourierCoeff z hz (evenCoeff bg) 2
+    (summable_fouterm_of_poly (evenCoeff_isBigO bg_isBigO) z 2) 5 (evenCoeff_isBigO bg_isBigO)
+    (fun x => E₂ x * E₄ x - E₆ x) g_eq_fouterm
+  convert h using 2
+  norm_num
+
+/-- `‖E₄/Δ‖ ≤ DivDiscBound (evenCoeff bE₄) 0 · exp(2π·im)` (from `n₀=0`). -/
+lemma E₄_div_Δ_bound (z : ℍ) (hz : 1 / 2 < z.im) :
+    ‖E₄ z / Δ z‖ ≤ DivDiscBound (evenCoeff bE₄) 0 * Real.exp (2 * π * z.im) := by
+  have h := DivDiscBoundOfPolyFourierCoeff z hz (evenCoeff bE₄) 0
+    (summable_fouterm_of_poly (evenCoeff_isBigO bE₄_isBigO) z 0) 5 (evenCoeff_isBigO bE₄_isBigO)
+    (fun x => E₄ x) E₄_eq_fouterm
+  convert h using 2
+  push_cast; ring
+
 /-! ## Fourier Expansion Identities
 
 These connect the Eisenstein series products to fouterm sums.

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -411,6 +411,61 @@ lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
                 (le_of_lt (Real.exp_pos _))
     _ = (∑' m, ‖a m‖ * rexp (-π * (m : ℝ))) * rexp (-(2 * π) * n₀ * z.im) := tsum_mul_right
 
+/-- The constant `∑ ‖b m‖·exp(-πm)` converges for any polynomially-bounded `b`. -/
+lemma summable_norm_mul_exp {b : ℕ → ℂ} {k : ℕ}
+    (hb : b =O[Filter.atTop] (fun n : ℕ => (n ^ k : ℝ))) :
+    Summable fun m : ℕ => ‖b m‖ * rexp (-π * (m : ℝ)) := by
+  have hr : ‖(↑(rexp (-π)) : ℂ)‖ < 1 := by
+    rw [Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
+    exact Real.exp_lt_one_iff.mpr (by nlinarith [Real.pi_pos])
+  have hu : b =O[Filter.atTop] (fun n : ℕ => (↑(n ^ k) : ℝ)) := by simpa [Nat.cast_pow] using hb
+  refine (summable_real_norm_mul_geometric_of_norm_lt_one hr hu).congr (fun m => ?_)
+  rw [norm_mul, norm_pow, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _),
+    ← Real.exp_nat_mul]
+  ring_nf
+
+/-- Shifting the argument preserves `O(n⁵)` growth of `bg`. -/
+lemma bg_shift_isBigO : (fun m : ℕ => bg (m + 1)) =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
+  refine (bg_isBigO.comp_tendsto (Filter.tendsto_add_atTop_nat 1)).trans ?_
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨2 ^ 5, Filter.eventually_atTop.mpr ⟨1, fun m hm => ?_⟩⟩
+  have hm1 : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  simp only [Function.comp_apply, Real.norm_eq_abs]
+  rw [abs_of_nonneg (by positivity), abs_of_nonneg (by positivity)]
+  calc ((m + 1 : ℕ) : ℝ) ^ 5 = ((m : ℝ) + 1) ^ 5 := by push_cast; ring
+    _ ≤ (2 * (m : ℝ)) ^ 5 := by gcongr; linarith
+    _ = 2 ^ 5 * (m : ℝ) ^ 5 := by ring
+
+/-- `E₂E₄ − E₆` with the constant (zero) term peeled, indexed from `q¹`. -/
+lemma g_qexp_succ (z : ℍ) :
+    E₂ z * E₄ z - E₆ z = ∑' m : ℕ, bg (m + 1) * cexp (2 * ↑π * Complex.I * ↑(m + 1) * ↑z) := by
+  rw [E₂_mul_E₄_sub_E₆,
+    tsum_pnat_eq_tsum_succ (f := fun k : ℕ => (k : ℂ) * (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)),
+    ← tsum_mul_left]
+  refine tsum_congr (fun m => ?_)
+  simp only [bg]
+  push_cast; ring
+
+/-- Explicit constant bounding `‖E₄‖` on `im ≥ 1/2`. -/
+def B_E₄ : ℝ := ∑' m : ℕ, ‖bE₄ m‖ * rexp (-π * (m : ℝ))
+
+/-- Explicit constant for the `exp(-2π·im)` decay of `‖E₂E₄ − E₆‖`. -/
+def B_g : ℝ := ∑' m : ℕ, ‖bg (m + 1)‖ * rexp (-π * (m : ℝ))
+
+/-- `E₄` is bounded by `B_E₄` on `im ≥ 1/2`. -/
+lemma norm_E₄_le (z : ℍ) (hz : 1 / 2 ≤ z.im) : ‖E₄ z‖ ≤ B_E₄ := by
+  rw [E₄_qexp_nat z]
+  have h := norm_qseries_shift_le (a := bE₄) 0 (summable_norm_mul_exp bE₄_isBigO) z hz
+  simpa [B_E₄] using h
+
+/-- `E₂E₄ − E₆` decays like `exp(-2π·im)` on `im ≥ 1/2`, with constant `B_g`. -/
+lemma norm_g_le (z : ℍ) (hz : 1 / 2 ≤ z.im) :
+    ‖E₂ z * E₄ z - E₆ z‖ ≤ B_g * rexp (-(2 * π) * z.im) := by
+  rw [g_qexp_succ z]
+  have h := norm_qseries_shift_le (a := fun m => bg (m + 1)) 1
+    (summable_norm_mul_exp bg_shift_isBigO) z hz
+  simpa [B_g] using h
+
 /-! ## Linear quotient bounds
 
 Direct `DivDiscBoundOfPolyFourierCoeff` applications using the linear `fouterm` identities. -/

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -51,17 +51,8 @@ namespace MagicFunction.a.FourierExpansions
 /-- The norm of exp(πiz) for z : ℍ is less than 1.
     Proof: |exp(πiz)| = exp(Re(πiz)) = exp(-π·z.im) < 1 since z.im > 0. -/
 lemma norm_exp_pi_I_z_lt_one (z : ℍ) : ‖Complex.exp (π * Complex.I * z)‖ < 1 := by
-  rw [Complex.norm_exp]
-  -- (π * I * z).re = -π * z.im because I.re = 0, I.im = 1
-  have him : (π * Complex.I * (z : ℂ)).re = -π * z.im := by
-    have h1 : (π * Complex.I : ℂ).re = 0 := by simp [Complex.I_re]
-    have h2 : (π * Complex.I : ℂ).im = π := by simp [Complex.I_im]
-    simp only [mul_re, h1, zero_mul, h2]
-    simp only [UpperHalfPlane.coe_im]
-    ring
-  rw [him]
-  have hneg : -π * z.im < 0 := by nlinarith [Real.pi_pos, z.im_pos]
-  exact Real.exp_lt_one_iff.mpr hneg
+  simpa [Complex.norm_exp, Real.exp_lt_one_iff, Complex.mul_re, UpperHalfPlane.coe_im] using
+    (show -π * z.im < 0 by nlinarith [Real.pi_pos, z.im_pos])
 
 /-! ## Summability Lemmas
 
@@ -114,8 +105,8 @@ def evenCoeff (b : ℕ → ℂ) : ℤ → ℂ := fun k => if Even k then b (k / 
 lemma qexp_eq_fouterm (b : ℕ → ℂ) (x : ℍ) :
     (∑' m : ℕ, b m * cexp (2 * ↑π * Complex.I * ↑m * ↑x))
       = ∑' n : ℕ, fouterm (evenCoeff b) x (↑n + 0) := by
-  have hg : Function.Injective (fun j : ℕ => 2 * j) := fun a b h => by
-    have : 2 * a = 2 * b := h; omega
+  have hg : Function.Injective (fun j : ℕ => 2 * j) :=
+    fun a b h => Nat.mul_left_cancel (n := 2) (m := a) (k := b) (by norm_num) h
   have hsupp : Function.support (fun n : ℕ => fouterm (evenCoeff b) x (↑n + 0)) ⊆
       Set.range (fun j : ℕ => 2 * j) := by
     intro n hn
@@ -188,8 +179,8 @@ lemma g_qexp_nat (z : ℍ) :
 lemma g_eq_fouterm (z : ℍ) :
     E₂ z * E₄ z - E₆ z = ∑' n : ℕ, fouterm (evenCoeff bg) z (↑n + 2) := by
   rw [g_qexp_nat z, qexp_eq_fouterm bg z]
-  have hinj : Function.Injective (fun n : ℕ => n + 2) := fun a b h => by
-    have : a + 2 = b + 2 := h; omega
+  have hinj : Function.Injective (fun n : ℕ => n + 2) :=
+    fun a b h => Nat.add_right_cancel (n := a) (k := b) (m := 2) h
   have hsupp : Function.support (fun n : ℕ => fouterm (evenCoeff bg) z (↑n + 0)) ⊆
       Set.range (fun n : ℕ => n + 2) := by
     intro n hn
@@ -216,9 +207,8 @@ lemma evenCoeff_isBigO {b : ℕ → ℂ} {k : ℕ}
     split
     · rfl
     · simp
-  have htend : Filter.Tendsto (fun j : ℤ => (j / 2).toNat) Filter.atTop Filter.atTop := by
-    rw [Filter.tendsto_atTop_atTop]
-    exact fun N => ⟨2 * N, fun j hj => by omega⟩
+  have htend : Filter.Tendsto (fun j : ℤ => (j / 2).toNat) Filter.atTop Filter.atTop :=
+    Filter.tendsto_atTop_atTop.mpr (fun N => ⟨2 * N, fun j hj => by omega⟩)
   refine (hdom.trans (hb.comp_tendsto htend)).trans ?_
   rw [Asymptotics.isBigO_iff]
   refine ⟨1, Filter.eventually_atTop.mpr ⟨0, fun j hj => ?_⟩⟩
@@ -362,16 +352,14 @@ lemma B_g_pos : 0 < B_g := by
 /-- `E₄` is bounded by `B_E₄` on `im ≥ 1/2`. -/
 lemma norm_E₄_le (z : ℍ) (hz : 1 / 2 ≤ z.im) : ‖E₄ z‖ ≤ B_E₄ := by
   rw [E₄_qexp_nat z]
-  have h := norm_qseries_shift_le (a := bE₄) 0 (summable_norm_mul_exp bE₄_isBigO) z hz
-  simpa [B_E₄] using h
+  simpa [B_E₄] using norm_qseries_shift_le (a := bE₄) 0 (summable_norm_mul_exp bE₄_isBigO) z hz
 
 /-- `E₂E₄ − E₆` decays like `exp(-2π·im)` on `im ≥ 1/2`, with constant `B_g`. -/
 lemma norm_g_le (z : ℍ) (hz : 1 / 2 ≤ z.im) :
     ‖E₂ z * E₄ z - E₆ z‖ ≤ B_g * rexp (-(2 * π) * z.im) := by
   rw [g_qexp_succ z]
-  have h := norm_qseries_shift_le (a := fun m => bg (m + 1)) 1
-    (summable_norm_mul_exp bg_shift_isBigO) z hz
-  simpa [B_g] using h
+  simpa [B_g] using
+    norm_qseries_shift_le (a := fun m => bg (m + 1)) 1 (summable_norm_mul_exp bg_shift_isBigO) z hz
 
 /-! ## Linear quotient bounds
 

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -246,7 +246,7 @@ lemma qexp_eq_fouterm (b : ℕ → ℂ) (x : ℍ) :
   rw [show (↑π * Complex.I * ((2 * j : ℕ) : ℤ) * ↑x : ℂ) = 2 * ↑π * Complex.I * ↑j * ↑x by
     push_cast; ring]
 
-/-! ## Linear factor q-coefficients and fouterm identities (Design B)
+/-! ## Linear factor q-coefficients and fouterm identities
 
 `E₄` and `E₂E₄−E₆` are the *linear* factors of the φ-numerators. Their genuine `q`-coefficients
 are simple (no Cauchy convolution), so via the keystone they have clean `fouterm` expansions. -/
@@ -360,7 +360,58 @@ lemma bE₄_isBigO : bE₄ =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
     Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
   nlinarith [hσ, hm1, pow_nonneg (by linarith : (0:ℝ) ≤ (m:ℝ)) 4]
 
-/-! ## Linear quotient bounds (Design B #3)
+/-! ## Factor norm bounds
+
+Explicit norm bounds on the linear factors, via a `q`-series norm-decay estimate
+(`exp(-2πm·im) ≤ exp(-πm)` for `im ≥ 1/2`), patterned on `isBigO_atImInfty_of_fourier_shift`. -/
+
+/-- A shifted `q`-series `∑ a(m)·q^(m+n₀)` has norm `≤ (∑‖a m‖·exp(-πm))·exp(-2π·n₀·im)`
+    for `im ≥ 1/2`. -/
+lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
+    (ha : Summable fun m : ℕ => ‖a m‖ * rexp (-π * (m : ℝ))) (z : ℍ) (hz : 1 / 2 ≤ z.im) :
+    ‖∑' m : ℕ, a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * (z : ℂ))‖
+      ≤ (∑' m, ‖a m‖ * rexp (-π * (m : ℝ))) * rexp (-(2 * π) * n₀ * z.im) := by
+  have hexp_re (m : ℕ) : (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z).re = -(2 * π) * (m + n₀) * z.im := by
+    simp only [Nat.cast_add, Complex.mul_re, Complex.re_ofNat, Complex.ofReal_re, Complex.im_ofNat,
+      Complex.ofReal_im, mul_zero, sub_zero, Complex.I_re, Complex.mul_im, zero_mul, add_zero,
+      Complex.I_im, mul_one, sub_self, Complex.add_re, Complex.natCast_re, Complex.add_im,
+      Complex.natCast_im, UpperHalfPlane.coe_re, zero_add, UpperHalfPlane.coe_im, zero_sub, neg_mul]
+  have hexp_bound (m : ℕ) :
+      rexp (-(2 * π) * (↑m + ↑n₀) * z.im) ≤ rexp (-π * (m : ℝ)) * rexp (-π * (n₀ : ℝ)) := by
+    rw [← Real.exp_add, Real.exp_le_exp]
+    have hprod : (0:ℝ) ≤ ((m : ℝ) + n₀) * (2 * z.im - 1) :=
+      mul_nonneg (by positivity) (by linarith [hz])
+    nlinarith [Real.pi_pos, hprod]
+  have hsum_norms : Summable fun m => ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ := by
+    refine .of_nonneg_of_le (fun _ => norm_nonneg _) (fun m => ?_) (ha.mul_right (rexp (-π * n₀)))
+    simp only [norm_mul, Complex.norm_exp, hexp_re]
+    calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
+        ≤ ‖a m‖ * (rexp (-π * (m : ℝ)) * rexp (-π * (n₀ : ℝ))) :=
+          mul_le_mul_of_nonneg_left (hexp_bound m) (norm_nonneg _)
+      _ = ‖a m‖ * rexp (-π * (m : ℝ)) * rexp (-π * (n₀ : ℝ)) := by ring
+  have hsum_norms' : Summable fun m => ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im) := by
+    convert hsum_norms using 2 with m; rw [norm_mul, Complex.norm_exp, hexp_re]
+  calc ‖∑' m, a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖
+      ≤ ∑' m, ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ := norm_tsum_le_tsum_norm hsum_norms
+    _ = ∑' m, ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im) := by
+        simp only [norm_mul, Complex.norm_exp, hexp_re]
+    _ ≤ ∑' m, ‖a m‖ * rexp (-π * (m : ℝ)) * rexp (-(2 * π) * n₀ * z.im) := by
+        refine Summable.tsum_le_tsum (fun m => ?_) hsum_norms' (ha.mul_right _)
+        have hsplit : rexp (-(2 * π) * (↑m + ↑n₀) * z.im) =
+            rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by
+          rw [← Real.exp_add]; ring_nf
+        have hexp_m : rexp (-(2 * π) * m * z.im) ≤ rexp (-π * (m : ℝ)) := by
+          rw [Real.exp_le_exp]
+          have hprod : (0:ℝ) ≤ (m : ℝ) * (2 * z.im - 1) := mul_nonneg (by positivity) (by linarith [hz])
+          nlinarith [Real.pi_pos, hprod]
+        calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
+            = ‖a m‖ * rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by rw [hsplit]; ring
+          _ ≤ ‖a m‖ * rexp (-π * (m : ℝ)) * rexp (-(2 * π) * n₀ * z.im) :=
+              mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left hexp_m (norm_nonneg _))
+                (le_of_lt (Real.exp_pos _))
+    _ = (∑' m, ‖a m‖ * rexp (-π * (m : ℝ))) * rexp (-(2 * π) * n₀ * z.im) := tsum_mul_right
+
+/-! ## Linear quotient bounds
 
 Direct `DivDiscBoundOfPolyFourierCoeff` applications using the linear `fouterm` identities. -/
 

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -187,7 +187,7 @@ lemma summable_fouterm_of_poly {c : ℤ → ℂ} {k : ℕ}
     simp only [fouterm, u, r, const, ← Complex.exp_nat_mul, Int.cast_add, Int.cast_natCast]
     rw [show (↑π * Complex.I * (↑i + ↑n₀) * ↑z : ℂ) =
         ↑π * Complex.I * ↑n₀ * ↑z + ↑π * Complex.I * ↑i * ↑z by ring, Complex.exp_add]
-    ring
+    ring_nf
   -- u has polynomial growth: ‖u n‖ = ‖c(n+n₀)‖ * ‖const‖ is O(n^k)
   have hu : u =O[Filter.atTop] (fun n ↦ (↑(n ^ k) : ℝ)) := by
     simp only [u, show ∀ i, c (↑i + n₀) * const = const * c (↑i + n₀) from fun _ => mul_comm _ _]

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -212,6 +212,40 @@ lemma summable_E₄_sq (z : ℍ) :
     Summable fun (i : ℕ) ↦ fouterm c_E₄_sq z (i + 0) :=
   summable_fouterm_of_poly c_E₄_sq_poly z 0
 
+/-! ## Keystone: q-series → fouterm reindex
+
+A `q`-series `∑ₘ b m · qᵐ` (with `q = cexp (2π i z)`, the standard convention) becomes a
+`fouterm` sum (with `r = cexp (π i z)`, the half-`q` convention used by `DivDiscBound`) by placing
+the `m`-th coefficient at the even index `2m` and `0` on odd indices. -/
+
+/-- The even-support `fouterm` coefficient carrying `b` at index `2m`. -/
+def evenCoeff (b : ℕ → ℂ) : ℤ → ℂ := fun k => if Even k then b (k / 2).toNat else 0
+
+/-- **Keystone reindex** (built via `Function.Injective.tsum_eq` along `m ↦ 2m`). -/
+lemma qexp_eq_fouterm (b : ℕ → ℂ) (x : ℍ) :
+    (∑' m : ℕ, b m * cexp (2 * ↑π * Complex.I * ↑m * ↑x))
+      = ∑' n : ℕ, fouterm (evenCoeff b) x (↑n + 0) := by
+  have hg : Function.Injective (fun j : ℕ => 2 * j) := fun a b h => by
+    have : 2 * a = 2 * b := h; omega
+  have hsupp : Function.support (fun n : ℕ => fouterm (evenCoeff b) x (↑n + 0)) ⊆
+      Set.range (fun j : ℕ => 2 * j) := by
+    intro n hn
+    rw [Function.mem_support] at hn
+    have hcn : evenCoeff b (↑n) ≠ 0 := by
+      intro h; exact hn (by simp only [fouterm, add_zero, h, zero_mul])
+    have heven : Even (n : ℤ) := by
+      by_contra hodd
+      exact hcn (by simp only [evenCoeff, if_neg hodd])
+    obtain ⟨j, hj⟩ := (Int.even_coe_nat n).mp heven
+    exact ⟨j, by show 2 * j = n; omega⟩
+  rw [← hg.tsum_eq hsupp]
+  refine tsum_congr (fun j => ?_)
+  have h2j : Even ((2 * j : ℕ) : ℤ) := by exact_mod_cast even_two_mul j
+  simp only [fouterm, add_zero, evenCoeff, if_pos h2j]
+  rw [show (((2 * j : ℕ) : ℤ) / 2).toNat = j by push_cast; omega]
+  rw [show (↑π * Complex.I * ((2 * j : ℕ) : ℤ) * ↑x : ℂ) = 2 * ↑π * Complex.I * ↑j * ↑x by
+    push_cast; ring]
+
 /-! ## Fourier Expansion Identities
 
 These connect the Eisenstein series products to fouterm sums.

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -9,8 +9,6 @@ public import SpherePacking.MagicFunction.PolyFourierCoeffBound
 public import SpherePacking.ForMathlib.SpecificLimits
 public import SpherePacking.ModularForms.FG
 
-@[expose] public section
-
 /-!
 # Fourier expansions and norm bounds for the linear factors of φ₀, φ₂', φ₄'
 
@@ -29,13 +27,16 @@ The standard q-expansion uses `q = exp(2πiz)`, while `fouterm` uses `exp(πinz)
 - `qexp_eq_fouterm`: rewrite a `q`-series into `fouterm` form (even-support reindex)
 - `E₄_eq_fouterm`, `g_eq_fouterm`: the linear factors `E₄` (`n₀=0`) and `E₂E₄ − E₆` (`n₀=2`)
 - `g_div_Δ_bound`, `E₄_div_Δ_bound`: bounds on `‖factor / Δ‖` via `DivDiscBoundOfPolyFourierCoeff`
-- `norm_E₄_le`, `norm_g_le`: explicit norm bounds on the factors (`‖E₄‖ ≤ B_E₄`, decay for `E₂E₄−E₆`)
+- `norm_E₄_le`, `norm_g_le`: explicit factor-norm bounds (`‖E₄‖ ≤ B_E₄`; decay for
+  `E₂E₄ − E₆`)
 
 ## References
 
 - Blueprint Corollaries 7.5-7.7
 - `SpherePacking.ModularForms.FG`: q-expansion identities (`E₂_mul_E₄_sub_E₆`, `E₄_sigma_qexp`)
 -/
+
+@[expose] public section
 
 open Real Complex UpperHalfPlane
 open scoped ArithmeticFunction.sigma
@@ -91,7 +92,7 @@ lemma isBigO_shift {c : ℤ → ℂ} {k : ℕ} (n₀ : ℤ)
     simp only [← Int.cast_natCast (R := ℂ), ← Int.cast_add, Complex.norm_intCast]
     norm_cast
     cases abs_cases (n + n₀ : ℤ) <;> omega
-  calc ‖(n : ℂ) + n₀‖ ^ k ≤ (2 * n) ^ k := by exact pow_le_pow_left₀ (norm_nonneg _) h_bound k
+  calc ‖(n : ℂ) + n₀‖ ^ k ≤ (2 * n) ^ k := pow_le_pow_left₀ (norm_nonneg _) h_bound k
     _ = 2 ^ k * n ^ k := by ring
     _ = 2 ^ k * (n ^ k : ℕ) := by norm_cast
 
@@ -161,7 +162,7 @@ lemma qexp_eq_fouterm (b : ℕ → ℂ) (x : ℍ) :
       by_contra hodd
       exact hcn (by simp only [evenCoeff, if_neg hodd])
     obtain ⟨j, hj⟩ := (Int.even_coe_nat n).mp heven
-    exact ⟨j, by show 2 * j = n; omega⟩
+    exact ⟨j, (two_mul j).trans hj.symm⟩
   rw [← hg.tsum_eq hsupp]
   refine tsum_congr (fun j => ?_)
   have h2j : Even ((2 * j : ℕ) : ℤ) := by exact_mod_cast even_two_mul j
@@ -193,8 +194,8 @@ lemma E₄_qexp_nat (z : ℍ) :
   rw [hsummable.tsum_eq_zero_add, E₄_sigma_qexp]
   congr 1
   · simp [bE₄]
-  · rw [tsum_pnat_eq_tsum_succ (f := fun k : ℕ => (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)),
-      ← tsum_mul_left]
+  · rw [tsum_pnat_eq_tsum_succ
+      (f := fun k : ℕ => (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)), ← tsum_mul_left]
     refine tsum_congr (fun m => ?_)
     have hm : m + 1 ≠ 0 := Nat.succ_ne_zero m
     simp only [bE₄, hm, if_false]
@@ -230,8 +231,8 @@ lemma g_eq_fouterm (z : ℍ) :
     intro n hn
     rw [Function.mem_support] at hn
     have h0 : n ≠ 0 := by rintro rfl; simp [fouterm, evenCoeff, bg] at hn
-    have h1 : n ≠ 1 := by rintro rfl; simp [fouterm, evenCoeff, bg] at hn
-    exact ⟨n - 2, by show n - 2 + 2 = n; omega⟩
+    have h1 : n ≠ 1 := by rintro rfl; simp [fouterm, evenCoeff] at hn
+    exact ⟨n - 2, Nat.sub_add_cancel (by omega)⟩
   rw [← hinj.tsum_eq hsupp]
   refine tsum_congr (fun n => ?_)
   congr 1
@@ -268,7 +269,8 @@ lemma evenCoeff_isBigO {b : ℕ → ℂ} {k : ℕ}
 lemma bg_isBigO : bg =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
   rw [Asymptotics.isBigO_iff]
   refine ⟨720, Filter.Eventually.of_forall fun m => ?_⟩
-  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
+  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by
+    exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
   simp only [bg, norm_mul, Complex.norm_ofNat, Complex.norm_natCast, Real.norm_eq_abs,
     abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
   nlinarith [hσ, Nat.cast_nonneg (α := ℝ) m, pow_nonneg (Nat.cast_nonneg (α := ℝ) m) 4]
@@ -278,7 +280,8 @@ lemma bE₄_isBigO : bE₄ =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
   rw [Asymptotics.isBigO_iff]
   refine ⟨240, Filter.eventually_atTop.mpr ⟨1, fun m hm => ?_⟩⟩
   have hm0 : m ≠ 0 := by omega
-  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
+  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by
+    exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
   have hm1 : (1:ℝ) ≤ (m:ℝ) := by exact_mod_cast hm
   simp only [bE₄, hm0, if_false, norm_mul, Complex.norm_ofNat, Complex.norm_natCast,
     Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
@@ -295,7 +298,8 @@ lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
     (ha : Summable fun m : ℕ => ‖a m‖ * rexp (-π * (m : ℝ))) (z : ℍ) (hz : 1 / 2 ≤ z.im) :
     ‖∑' m : ℕ, a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * (z : ℂ))‖
       ≤ (∑' m, ‖a m‖ * rexp (-π * (m : ℝ))) * rexp (-(2 * π) * n₀ * z.im) := by
-  have hexp_re (m : ℕ) : (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z).re = -(2 * π) * (m + n₀) * z.im := by
+  have hexp_re (m : ℕ) :
+      (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z).re = -(2 * π) * (m + n₀) * z.im := by
     simp only [Nat.cast_add, Complex.mul_re, Complex.re_ofNat, Complex.ofReal_re, Complex.im_ofNat,
       Complex.ofReal_im, mul_zero, sub_zero, Complex.I_re, Complex.mul_im, zero_mul, add_zero,
       Complex.I_im, mul_one, sub_self, Complex.add_re, Complex.natCast_re, Complex.add_im,
@@ -306,7 +310,8 @@ lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
     have hprod : (0:ℝ) ≤ ((m : ℝ) + n₀) * (2 * z.im - 1) :=
       mul_nonneg (by positivity) (by linarith [hz])
     nlinarith [Real.pi_pos, hprod]
-  have hsum_norms : Summable fun m => ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ := by
+  have hsum_norms : Summable fun m =>
+      ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ := by
     refine .of_nonneg_of_le (fun _ => norm_nonneg _) (fun m => ?_) (ha.mul_right (rexp (-π * n₀)))
     simp only [norm_mul, Complex.norm_exp, hexp_re]
     calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
@@ -316,7 +321,8 @@ lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
   have hsum_norms' : Summable fun m => ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im) := by
     convert hsum_norms using 2 with m; rw [norm_mul, Complex.norm_exp, hexp_re]
   calc ‖∑' m, a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖
-      ≤ ∑' m, ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ := norm_tsum_le_tsum_norm hsum_norms
+      ≤ ∑' m, ‖a m * cexp (2 * ↑π * Complex.I * ((m + n₀ : ℕ) : ℂ) * z)‖ :=
+        norm_tsum_le_tsum_norm hsum_norms
     _ = ∑' m, ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im) := by
         simp only [norm_mul, Complex.norm_exp, hexp_re]
     _ ≤ ∑' m, ‖a m‖ * rexp (-π * (m : ℝ)) * rexp (-(2 * π) * n₀ * z.im) := by
@@ -326,10 +332,12 @@ lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ)
           rw [← Real.exp_add]; ring_nf
         have hexp_m : rexp (-(2 * π) * m * z.im) ≤ rexp (-π * (m : ℝ)) := by
           rw [Real.exp_le_exp]
-          have hprod : (0:ℝ) ≤ (m : ℝ) * (2 * z.im - 1) := mul_nonneg (by positivity) (by linarith [hz])
+          have hprod : (0:ℝ) ≤ (m : ℝ) * (2 * z.im - 1) :=
+            mul_nonneg (by positivity) (by linarith [hz])
           nlinarith [Real.pi_pos, hprod]
         calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
-            = ‖a m‖ * rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by rw [hsplit]; ring
+            = ‖a m‖ * rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by
+              rw [hsplit]; ring
           _ ≤ ‖a m‖ * rexp (-π * (m : ℝ)) * rexp (-(2 * π) * n₀ * z.im) :=
               mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left hexp_m (norm_nonneg _))
                 (le_of_lt (Real.exp_pos _))
@@ -364,7 +372,8 @@ lemma bg_shift_isBigO : (fun m : ℕ => bg (m + 1)) =O[Filter.atTop] (fun n : �
 lemma g_qexp_succ (z : ℍ) :
     E₂ z * E₄ z - E₆ z = ∑' m : ℕ, bg (m + 1) * cexp (2 * ↑π * Complex.I * ↑(m + 1) * ↑z) := by
   rw [E₂_mul_E₄_sub_E₆,
-    tsum_pnat_eq_tsum_succ (f := fun k : ℕ => (k : ℂ) * (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)),
+    tsum_pnat_eq_tsum_succ
+      (f := fun k : ℕ => (k : ℂ) * (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)),
     ← tsum_mul_left]
   refine tsum_congr (fun m => ?_)
   simp only [bg]
@@ -384,8 +393,7 @@ lemma B_E₄_pos : 0 < B_E₄ := by
 lemma B_g_pos : 0 < B_g := by
   refine lt_of_lt_of_le ?_
     ((summable_norm_mul_exp bg_shift_isBigO).le_tsum 0 (fun j _ => by positivity))
-  have hσ : (σ 3 1 : ℂ) = 1 := by simp [ArithmeticFunction.sigma_apply, Nat.divisors_one]
-  simp [bg, hσ]
+  simp [bg]
 
 /-- `E₄` is bounded by `B_E₄` on `im ≥ 1/2`. -/
 lemma norm_E₄_le (z : ℍ) (hz : 1 / 2 ≤ z.im) : ‖E₄ z‖ ≤ B_E₄ := by
@@ -421,7 +429,7 @@ lemma E₄_div_Δ_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     (summable_fouterm_of_poly (evenCoeff_isBigO bE₄_isBigO) z 0) 5 (evenCoeff_isBigO bE₄_isBigO)
     (fun x => E₄ x) E₄_eq_fouterm
   convert h using 2
-  push_cast; ring
+  ring_nf
 
 end MagicFunction.a.FourierExpansions
 

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -63,39 +63,6 @@ lemma norm_exp_pi_I_z_lt_one (z : ℍ) : ‖Complex.exp (π * Complex.I * z)‖ 
   have hneg : -π * z.im < 0 := by nlinarith [Real.pi_pos, z.im_pos]
   exact Real.exp_lt_one_iff.mpr hneg
 
-/-- Shifting a function by a constant preserves Big-O growth.
-    For c : ℤ → ℂ with c = O(n^k), the shifted function i ↦ c(i + n₀) is also O(n^k).
-
-    Proof: Following hpoly' in PolyFourierCoeffBound.lean - first show the shifted
-    function is O((n + n₀)^k), then show |n + n₀| ≤ 2n for n ≥ |n₀|. -/
-lemma isBigO_shift {c : ℤ → ℂ} {k : ℕ} (n₀ : ℤ)
-    (hc : c =O[Filter.atTop] (fun n ↦ (n ^ k : ℝ))) :
-    (fun i : ℕ ↦ c (i + n₀)) =O[Filter.atTop] (fun n ↦ (↑(n ^ k) : ℝ)) := by
-  -- First: shift the hypothesis to ℕ
-  have h_shift : (fun n : ℕ => c (n + n₀)) =O[Filter.atTop] (fun n : ℕ => (n + n₀ : ℂ) ^ k) := by
-    simp only [Asymptotics.isBigO_iff, Filter.eventually_atTop] at hc ⊢
-    obtain ⟨C, m, hCa⟩ := hc
-    use C
-    simp only [norm_pow, norm_eq_abs] at hCa ⊢
-    refine ⟨(m - n₀).toNat, fun n hn ↦ ?_⟩
-    have hmn : (n : ℤ) + n₀ ≥ m := by
-      have := Int.self_le_toNat (m - n₀)
-      omega
-    exact_mod_cast hCa (n + n₀) hmn
-  -- Second: (n + n₀)^k = O(n^k) using |n + n₀| ≤ 2n for n ≥ |n₀|
-  refine h_shift.trans ?_
-  simp only [Asymptotics.isBigO_iff, Filter.eventually_atTop]
-  use 2 ^ k
-  simp only [norm_pow, RCLike.norm_natCast]
-  refine ⟨n₀.natAbs, fun n hn => ?_⟩
-  have h_bound : ‖(n + n₀ : ℂ)‖ ≤ 2 * n := by
-    simp only [← Int.cast_natCast (R := ℂ), ← Int.cast_add, Complex.norm_intCast]
-    norm_cast
-    cases abs_cases (n + n₀ : ℤ) <;> omega
-  calc ‖(n : ℂ) + n₀‖ ^ k ≤ (2 * n) ^ k := pow_le_pow_left₀ (norm_nonneg _) h_bound k
-    _ = 2 ^ k * n ^ k := by ring
-    _ = 2 ^ k * (n ^ k : ℕ) := by norm_cast
-
 /-! ## Summability Lemmas
 
 The Fourier series terms are summable because:
@@ -117,22 +84,19 @@ lemma summable_fouterm_of_poly {c : ℤ → ℂ} {k : ℕ}
     (z : ℍ) (n₀ : ℤ) : Summable fun (i : ℕ) ↦ fouterm c z (i + n₀) := by
   -- Key fact: ‖exp(πiz)‖ < 1 for z : ℍ
   have hr : ‖Complex.exp (π * Complex.I * z)‖ < 1 := norm_exp_pi_I_z_lt_one z
-  -- Shifted coefficients have polynomial growth
-  have hshift := isBigO_shift n₀ hpoly
   -- Factor fouterm c z (i + n₀) = u(i) * r^i
-  -- where r = cexp(π * I * z) and u(i) = c(i + n₀) * cexp(π * I * n₀ * z)
+  -- where r = cexp(π * I * z) and u(i) = cexp(π * I * n₀ * z) * c(i + n₀)
   let r := cexp (π * Complex.I * z)
   let const := cexp (π * Complex.I * n₀ * z)
-  let u : ℕ → ℂ := fun i => c (i + n₀) * const
+  let u : ℕ → ℂ := fun i => const * c (i + n₀)
   have h_factor : ∀ i : ℕ, fouterm c z (i + n₀) = u i * r ^ i := fun i => by
     simp only [fouterm, u, r, const, ← Complex.exp_nat_mul, Int.cast_add, Int.cast_natCast]
     rw [show (↑π * Complex.I * (↑i + ↑n₀) * ↑z : ℂ) =
         ↑π * Complex.I * ↑n₀ * ↑z + ↑π * Complex.I * ↑i * ↑z by ring, Complex.exp_add]
     ring_nf
-  -- u has polynomial growth: ‖u n‖ = ‖c(n+n₀)‖ * ‖const‖ is O(n^k)
+  -- u has polynomial growth: ‖u n‖ = ‖const‖ * ‖c(n+n₀)‖ is O(n^k)
   have hu : u =O[Filter.atTop] (fun n ↦ (↑(n ^ k) : ℝ)) := by
-    simp only [u, show ∀ i, c (↑i + n₀) * const = const * c (↑i + n₀) from fun _ => mul_comm _ _]
-    exact hshift.const_mul_left const
+    simpa [u, Nat.cast_pow] using (hpoly' c n₀ k hpoly).const_mul_left const
   -- Apply summability theorem
   simp_rw [h_factor]
   exact Summable.of_norm (summable_real_norm_mul_geometric_of_norm_lt_one hr hu)

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -265,7 +265,7 @@ lemma E₄_qexp_nat (z : ℍ) :
     refine ((sigma3_qexp_summable z).mul_left 240).congr (fun n => ?_)
     have hn : (n : ℕ) ≠ 0 := n.ne_zero
     simp only [bE₄, hn, if_false]
-    push_cast; ring
+    ring
   rw [hsummable.tsum_eq_zero_add, E₄_sigma_qexp]
   congr 1
   · simp [bE₄]
@@ -279,6 +279,38 @@ lemma E₄_qexp_nat (z : ℍ) :
 /-- `E₄` in `fouterm` form (`n₀ = 0`). -/
 lemma E₄_eq_fouterm (z : ℍ) : E₄ z = ∑' n : ℕ, fouterm (evenCoeff bE₄) z (↑n + 0) :=
   (E₄_qexp_nat z).trans (qexp_eq_fouterm bE₄ z)
+
+/-- `E₂E₄ − E₆` as an ℕ-indexed `q`-series with coefficients `bg` (vanishing at `0`). -/
+lemma g_qexp_nat (z : ℍ) :
+    E₂ z * E₄ z - E₆ z = ∑' m : ℕ, bg m * cexp (2 * ↑π * Complex.I * ↑m * ↑z) := by
+  have hsupp : Function.support (fun m : ℕ => bg m * cexp (2 * ↑π * Complex.I * ↑m * ↑z)) ⊆
+      Set.range ((↑·) : ℕ+ → ℕ) := by
+    intro m hm
+    rw [Function.mem_support] at hm
+    have hm0 : m ≠ 0 := by rintro rfl; simp [bg] at hm
+    exact ⟨⟨m, Nat.pos_of_ne_zero hm0⟩, rfl⟩
+  rw [E₂_mul_E₄_sub_E₆, ← tsum_mul_left, ← PNat.coe_injective.tsum_eq
+    (f := fun m : ℕ => bg m * cexp (2 * ↑π * Complex.I * ↑m * ↑z)) hsupp]
+  refine tsum_congr (fun n => ?_)
+  simp only [bg]
+  ring
+
+/-- `E₂E₄ − E₆` in `fouterm` form (`n₀ = 2`; the index-`0,1` terms vanish). -/
+lemma g_eq_fouterm (z : ℍ) :
+    E₂ z * E₄ z - E₆ z = ∑' n : ℕ, fouterm (evenCoeff bg) z (↑n + 2) := by
+  rw [g_qexp_nat z, qexp_eq_fouterm bg z]
+  have hinj : Function.Injective (fun n : ℕ => n + 2) := fun a b h => by
+    have : a + 2 = b + 2 := h; omega
+  have hsupp : Function.support (fun n : ℕ => fouterm (evenCoeff bg) z (↑n + 0)) ⊆
+      Set.range (fun n : ℕ => n + 2) := by
+    intro n hn
+    rw [Function.mem_support] at hn
+    have h0 : n ≠ 0 := by rintro rfl; simp [fouterm, evenCoeff, bg] at hn
+    have h1 : n ≠ 1 := by rintro rfl; simp [fouterm, evenCoeff, bg] at hn
+    exact ⟨n - 2, by show n - 2 + 2 = n; omega⟩
+  rw [← hinj.tsum_eq hsupp]
+  refine tsum_congr (fun n => ?_)
+  congr 1
 
 /-! ## Fourier Expansion Identities
 

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -3,9 +3,13 @@ Copyright (c) 2025 Cameron Freer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
-import SpherePacking.MagicFunction.PolyFourierCoeffBound
-import SpherePacking.ForMathlib.SpecificLimits
-import SpherePacking.ModularForms.FG
+module
+
+public import SpherePacking.MagicFunction.PolyFourierCoeffBound
+public import SpherePacking.ForMathlib.SpecificLimits
+public import SpherePacking.ModularForms.FG
+
+@[expose] public section
 
 /-!
 # Fourier expansions and norm bounds for the linear factors of φ₀, φ₂', φ₄'

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -312,6 +312,54 @@ lemma g_eq_fouterm (z : ℍ) :
   refine tsum_congr (fun n => ?_)
   congr 1
 
+/-! ## Polynomial growth of the linear-factor coefficients
+
+The genuine linear coefficients have the same `O(n⁵)` growth as the old placeholders — no Cauchy
+convolution — so the existing `DivDiscBound` machinery applies directly. -/
+
+/-- General: even-support preserves `O(nᵏ)` growth (the value at `2m` is `b m`). -/
+lemma evenCoeff_isBigO {b : ℕ → ℂ} {k : ℕ}
+    (hb : b =O[Filter.atTop] (fun n : ℕ => (n ^ k : ℝ))) :
+    evenCoeff b =O[Filter.atTop] (fun n : ℤ => (n ^ k : ℝ)) := by
+  have hdom : evenCoeff b =O[Filter.atTop] fun j : ℤ => b (j / 2).toNat := by
+    refine Asymptotics.isBigO_of_le _ (fun j => ?_)
+    simp only [evenCoeff]
+    split
+    · rfl
+    · simp
+  have htend : Filter.Tendsto (fun j : ℤ => (j / 2).toNat) Filter.atTop Filter.atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    exact fun N => ⟨2 * N, fun j hj => by omega⟩
+  refine (hdom.trans (hb.comp_tendsto htend)).trans ?_
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨1, Filter.eventually_atTop.mpr ⟨0, fun j hj => ?_⟩⟩
+  have hjr : (0:ℝ) ≤ (j:ℝ) := by exact_mod_cast hj
+  simp only [Function.comp_apply, one_mul, Real.norm_eq_abs]
+  rw [abs_of_nonneg (pow_nonneg (Nat.cast_nonneg (j / 2).toNat) k),
+      abs_of_nonneg (pow_nonneg hjr k)]
+  gcongr
+  exact_mod_cast (show ((j / 2).toNat : ℤ) ≤ j by omega)
+
+/-- `bg m = 720·m·σ₃(m)` has growth `O(n⁵)`. -/
+lemma bg_isBigO : bg =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨720, Filter.Eventually.of_forall fun m => ?_⟩
+  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
+  simp only [bg, norm_mul, Complex.norm_ofNat, Complex.norm_natCast, Real.norm_eq_abs,
+    abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
+  nlinarith [hσ, Nat.cast_nonneg (α := ℝ) m, pow_nonneg (Nat.cast_nonneg (α := ℝ) m) 4]
+
+/-- `bE₄ m` (`1` at `0`, else `240·σ₃(m)`) has growth `O(n⁵)`. -/
+lemma bE₄_isBigO : bE₄ =O[Filter.atTop] (fun n : ℕ => (n ^ 5 : ℝ)) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨240, Filter.eventually_atTop.mpr ⟨1, fun m hm => ?_⟩⟩
+  have hm0 : m ≠ 0 := by omega
+  have hσ : ((σ 3 m : ℕ) : ℝ) ≤ (m : ℝ) ^ 4 := by exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 m
+  have hm1 : (1:ℝ) ≤ (m:ℝ) := by exact_mod_cast hm
+  simp only [bE₄, hm0, if_false, norm_mul, Complex.norm_ofNat, Complex.norm_natCast,
+    Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ (m:ℝ) ^ 5)]
+  nlinarith [hσ, hm1, pow_nonneg (by linarith : (0:ℝ) ≤ (m:ℝ)) 4]
+
 /-! ## Fourier Expansion Identities
 
 These connect the Eisenstein series products to fouterm sums.

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -246,6 +246,40 @@ lemma qexp_eq_fouterm (b : ℕ → ℂ) (x : ℍ) :
   rw [show (↑π * Complex.I * ((2 * j : ℕ) : ℤ) * ↑x : ℂ) = 2 * ↑π * Complex.I * ↑j * ↑x by
     push_cast; ring]
 
+/-! ## Linear factor q-coefficients and fouterm identities (Design B)
+
+`E₄` and `E₂E₄−E₆` are the *linear* factors of the φ-numerators. Their genuine `q`-coefficients
+are simple (no Cauchy convolution), so via the keystone they have clean `fouterm` expansions. -/
+
+/-- ℕ-indexed `q`-coefficients of `E₄`: `1` at `0`, `240·σ₃(m)` for `m ≥ 1`. -/
+def bE₄ : ℕ → ℂ := fun m => if m = 0 then 1 else 240 * (σ 3 m : ℂ)
+
+/-- ℕ-indexed `q`-coefficients of `E₂E₄ − E₆`: `720·m·σ₃(m)` (vanishes at `0`). -/
+def bg : ℕ → ℂ := fun m => 720 * (m : ℂ) * (σ 3 m : ℂ)
+
+/-- `E₄` as an ℕ-indexed `q`-series with coefficients `bE₄`. -/
+lemma E₄_qexp_nat (z : ℍ) :
+    E₄ z = ∑' m : ℕ, bE₄ m * cexp (2 * ↑π * Complex.I * ↑m * ↑z) := by
+  have hsummable : Summable (fun m : ℕ => bE₄ m * cexp (2 * ↑π * Complex.I * ↑m * ↑z)) := by
+    rw [← summable_pnat_iff_summable_nat]
+    refine ((sigma3_qexp_summable z).mul_left 240).congr (fun n => ?_)
+    have hn : (n : ℕ) ≠ 0 := n.ne_zero
+    simp only [bE₄, hn, if_false]
+    push_cast; ring
+  rw [hsummable.tsum_eq_zero_add, E₄_sigma_qexp]
+  congr 1
+  · simp [bE₄]
+  · rw [tsum_pnat_eq_tsum_succ (f := fun k : ℕ => (σ 3 k : ℂ) * cexp (2 * ↑π * Complex.I * ↑k * ↑z)),
+      ← tsum_mul_left]
+    refine tsum_congr (fun m => ?_)
+    have hm : m + 1 ≠ 0 := Nat.succ_ne_zero m
+    simp only [bE₄, hm, if_false]
+    push_cast; ring
+
+/-- `E₄` in `fouterm` form (`n₀ = 0`). -/
+lemma E₄_eq_fouterm (z : ℍ) : E₄ z = ∑' n : ℕ, fouterm (evenCoeff bE₄) z (↑n + 0) :=
+  (E₄_qexp_nat z).trans (qexp_eq_fouterm bE₄ z)
+
 /-! ## Fourier Expansion Identities
 
 These connect the Eisenstein series products to fouterm sums.

--- a/SpherePacking/MagicFunction/a/FourierExpansions.lean
+++ b/SpherePacking/MagicFunction/a/FourierExpansions.lean
@@ -8,26 +8,24 @@ import SpherePacking.ForMathlib.SpecificLimits
 import SpherePacking.ModularForms.FG
 
 /-!
-# Fourier Expansion Identities for Phi Bounds
+# Fourier expansions and norm bounds for the linear factors of φ₀, φ₂', φ₄'
 
-States the Fourier expansion identities needed to connect the phi functions
-(φ₀, φ₂', φ₄') to the DivDiscBound machinery in PolyFourierCoeffBound.
+Connects the *linear* Eisenstein factors `E₄` and `E₂E₄ − E₆` to the `DivDiscBound` machinery in
+`PolyFourierCoeffBound`, and bounds their norms. The φ-numerators are products/squares of these
+factors, so bounding each factor and its quotient by `Δ` avoids any Cauchy-product coefficients.
 
 ## Convention
 
-The standard q-expansion uses q = exp(2πiz), while `fouterm` uses exp(πinz).
-Since q = exp(2πiz) and setting r = exp(πiz), we have q = r².
+The standard q-expansion uses `q = exp(2πiz)`, while `fouterm` uses `exp(πinz)`. Setting
+`r = exp(πiz)` gives `q = r²`, so a `q`-coefficient at power `m` sits at the even `fouterm` index
+`2m` (and odd indices carry `0`); this is the `evenCoeff`/`qexp_eq_fouterm` reindex.
 
-This means:
-- A q-expansion ∑ aₙ qⁿ becomes ∑ aₙ r^{2n} in the fouterm convention
-- The starting index n₀ in fouterm corresponds to n₀/2 in q-space
+## Main results
 
-## Main Results
-
-- `summable_fouterm_of_poly`: Summability from polynomial growth + exponential decay
-- `E₂E₄E₆_sq_fourier`: (E₂E₄ - E₆)² in fouterm form (n₀ = 4)
-- `E₄_E₂E₄E₆_fourier`: E₄(E₂E₄ - E₆) in fouterm form (n₀ = 2)
-- `E₄_sq_fourier`: E₄² in fouterm form (n₀ = 0)
+- `qexp_eq_fouterm`: rewrite a `q`-series into `fouterm` form (even-support reindex)
+- `E₄_eq_fouterm`, `g_eq_fouterm`: the linear factors `E₄` (`n₀=0`) and `E₂E₄ − E₆` (`n₀=2`)
+- `g_div_Δ_bound`, `E₄_div_Δ_bound`: bounds on `‖factor / Δ‖` via `DivDiscBoundOfPolyFourierCoeff`
+- `norm_E₄_le`, `norm_g_le`: explicit norm bounds on the factors (`‖E₄‖ ≤ B_E₄`, decay for `E₂E₄−E₆`)
 
 ## References
 
@@ -42,68 +40,6 @@ open MagicFunction.PolyFourierCoeffBound
 noncomputable section
 
 namespace MagicFunction.a.FourierExpansions
-
-/-! ## Coefficient Functions
-
-These match the coefficient growth patterns needed for DivDiscBound. -/
-
-/-- Coefficient function with growth O(n^5), used for E₂E₄-E₆ related expansions. -/
-def c_E₂E₄E₆ : ℤ → ℂ := fun n ↦ n * (σ 3 n.toNat)
-
-/-- Coefficient function for E₄(E₂E₄ - E₆), the product (not square).
-    Note: Uses same simplified bound as c_E₂E₄E₆ for this branch. -/
-def c_E₄_E₂E₄E₆ : ℤ → ℂ := fun n ↦ n * (σ 3 n.toNat)
-
-/-- Coefficient function for E₄², with constant term 1. -/
-def c_E₄_sq : ℤ → ℂ := fun n ↦ if n ≤ 0 then 1 else n * (σ 3 n.toNat)
-
-/-- c_E₂E₄E₆ has polynomial growth O(n^5). -/
-lemma c_E₂E₄E₆_poly : c_E₂E₄E₆ =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
-  -- Coefficients n·σ₃(n) grow as O(n) × O(n^4) = O(n^5)
-  let d : ℕ → ℂ := fun n ↦ n * (σ 3 n)
-  have hcd (n : ℕ) : c_E₂E₄E₆ n = d n := by simp [c_E₂E₄E₆, d]
-  have hdpoly : d =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℂ)) := by
-    have h₁ (n : ℕ) : n ^ 5 = n * n ^ 4 := Nat.pow_succ'
-    norm_cast
-    simp only [h₁]
-    push_cast
-    refine Asymptotics.IsBigO.mul (Asymptotics.isBigO_refl _ Filter.atTop) ?_
-    have h := ArithmeticFunction.sigma_asymptotic' 3
-    simp only [Nat.reduceAdd] at h
-    norm_cast at h ⊢
-  simp only [Asymptotics.isBigO_iff, norm_pow, Complex.norm_natCast, Filter.eventually_atTop,
-    ge_iff_le] at hdpoly ⊢
-  obtain ⟨R, m, hR⟩ := hdpoly
-  use R, m
-  intro n hn
-  have hnnonneg : 0 ≤ n := calc 0 ≤ (m : ℤ) := by positivity
-    _ ≤ ↑n := hn
-  have hnnat : n.toNat = n := by simp only [Int.ofNat_toNat, sup_eq_left, hnnonneg]
-  have hmnnat : m ≤ n.toNat := by zify; rw [hnnat]; exact hn
-  specialize hR n.toNat hmnnat
-  rw [← hcd, hnnat] at hR
-  calc norm (c_E₂E₄E₆ n)
-  _ ≤ R * n.toNat ^ 5 := hR
-  _ = R * |↑n| ^ 5 := by
-    simp only [mul_eq_mul_left_iff]; norm_cast; left
-    rw [Nat.cast_pow, hnnat]; simp [hnnonneg, abs_of_nonneg]
-
-/-- c_E₄_E₂E₄E₆ has polynomial growth O(n^5).
-    Note: Same growth as c_E₂E₄E₆ since they have the same simplified definition. -/
-lemma c_E₄_E₂E₄E₆_poly : c_E₄_E₂E₄E₆ =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
-  -- c_E₄_E₂E₄E₆ = c_E₂E₄E₆ definitionally
-  exact c_E₂E₄E₆_poly
-
-/-- c_E₄_sq has polynomial growth O(n^5). -/
-lemma c_E₄_sq_poly : c_E₄_sq =O[Filter.atTop] (fun n ↦ (n ^ 5 : ℝ)) := by
-  have heq : c_E₄_sq =ᶠ[Filter.atTop] c_E₂E₄E₆ := by
-    simp only [Filter.EventuallyEq, Filter.eventually_atTop, ge_iff_le]
-    use 1
-    intro n hn
-    simp only [c_E₄_sq, c_E₂E₄E₆]
-    have h : ¬n ≤ 0 := by omega
-    simp only [h, ↓reduceIte]
-  exact c_E₂E₄E₆_poly.congr' heq.symm Filter.EventuallyEq.rfl
 
 /-! ## Auxiliary lemmas for summability -/
 
@@ -195,22 +131,6 @@ lemma summable_fouterm_of_poly {c : ℤ → ℂ} {k : ℕ}
   -- Apply summability theorem
   simp_rw [h_factor]
   exact Summable.of_norm (summable_real_norm_mul_geometric_of_norm_lt_one hr hu)
-
-/-- Summability for (E₂E₄ - E₆)² expansion (n₀ = 4). -/
-lemma summable_E₂E₄E₆_sq (z : ℍ) :
-    Summable fun (i : ℕ) ↦ fouterm c_E₂E₄E₆ z (i + 4) :=
-  summable_fouterm_of_poly c_E₂E₄E₆_poly z 4
-
-/-- Summability for E₄(E₂E₄ - E₆) expansion (n₀ = 2).
-    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
-lemma summable_E₄_E₂E₄E₆ (z : ℍ) :
-    Summable fun (i : ℕ) ↦ fouterm c_E₄_E₂E₄E₆ z (i + 2) :=
-  summable_fouterm_of_poly c_E₄_E₂E₄E₆_poly z 2
-
-/-- Summability for E₄² expansion (n₀ = 0). -/
-lemma summable_E₄_sq (z : ℍ) :
-    Summable fun (i : ℕ) ↦ fouterm c_E₄_sq z (i + 0) :=
-  summable_fouterm_of_poly c_E₄_sq_poly z 0
 
 /-! ## Keystone: q-series → fouterm reindex
 
@@ -452,6 +372,17 @@ def B_E₄ : ℝ := ∑' m : ℕ, ‖bE₄ m‖ * rexp (-π * (m : ℝ))
 /-- Explicit constant for the `exp(-2π·im)` decay of `‖E₂E₄ − E₆‖`. -/
 def B_g : ℝ := ∑' m : ℕ, ‖bg (m + 1)‖ * rexp (-π * (m : ℝ))
 
+lemma B_E₄_pos : 0 < B_E₄ := by
+  refine lt_of_lt_of_le ?_
+    ((summable_norm_mul_exp bE₄_isBigO).le_tsum 0 (fun j _ => by positivity))
+  simp [bE₄]
+
+lemma B_g_pos : 0 < B_g := by
+  refine lt_of_lt_of_le ?_
+    ((summable_norm_mul_exp bg_shift_isBigO).le_tsum 0 (fun j _ => by positivity))
+  have hσ : (σ 3 1 : ℂ) = 1 := by simp [ArithmeticFunction.sigma_apply, Nat.divisors_one]
+  simp [bg, hσ]
+
 /-- `E₄` is bounded by `B_E₄` on `im ≥ 1/2`. -/
 lemma norm_E₄_le (z : ℍ) (hz : 1 / 2 ≤ z.im) : ‖E₄ z‖ ≤ B_E₄ := by
   rw [E₄_qexp_nat z]
@@ -487,38 +418,6 @@ lemma E₄_div_Δ_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     (fun x => E₄ x) E₄_eq_fouterm
   convert h using 2
   push_cast; ring
-
-/-! ## Fourier Expansion Identities
-
-These connect the Eisenstein series products to fouterm sums.
-The proofs use `E₂_mul_E₄_sub_E₆` and `E₄_sigma_qexp` from `FG.lean`. -/
-
-/-- Fourier expansion of (E₂E₄ - E₆)².
-    In q = exp(2πiz) convention: (E₂E₄ - E₆) = 720·∑_{n≥1} n·σ₃(n)·qⁿ
-    The square starts at q², which is r⁴ in r = exp(πiz) convention. -/
-lemma E₂E₄E₆_sq_fourier (x : ℍ) :
-    ((E₂ x) * (E₄ x) - (E₆ x)) ^ 2 = ∑' (n : ℕ), fouterm c_E₂E₄E₆ x (n + 4) := by
-  -- From E₂_mul_E₄_sub_E₆ and Cauchy product of q-series
-  -- (720 * ∑ n·σ₃(n)·q^n)² = 720² * (∑ n·σ₃(n)·q^n)²
-  -- Cauchy product: (∑ aₙq^n)² = ∑ (∑_{j+k=n} aⱼaₖ) q^n
-  -- Starting at n=1, square starts at n=2 in q-space = index 4 in r-space
-  sorry
-
-/-- Fourier expansion of E₄(E₂E₄ - E₆).
-    Product starts at q¹, which is r² in fouterm convention.
-    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
-lemma E₄_E₂E₄E₆_fourier (x : ℍ) :
-    E₄ x * (E₂ x * E₄ x - E₆ x) = ∑' (n : ℕ), fouterm c_E₄_E₂E₄E₆ x (n + 2) := by
-  -- From E₄_sigma_qexp and E₂_mul_E₄_sub_E₆
-  -- E₄ starts at q⁰, E₂E₄-E₆ starts at q¹, so product starts at q¹ = r²
-  sorry
-
-/-- Fourier expansion of E₄².
-    E₄ = 1 + 240·∑_{n≥1} σ₃(n)·qⁿ, so E₄² starts at constant term 1. -/
-lemma E₄_sq_fourier (x : ℍ) :
-    E₄ x ^ 2 = ∑' (n : ℕ), fouterm c_E₄_sq x (n + 0) := by
-  -- From E₄_sigma_qexp: E₄² = (1 + 240·∑...)² starts at q⁰ = r⁰
-  sorry
 
 end MagicFunction.a.FourierExpansions
 

--- a/SpherePacking/MagicFunction/a/Integrability/ComplexIntegrands.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/ComplexIntegrands.lean
@@ -71,19 +71,18 @@ theorem φ₀''_holo : Holo(φ₀'') := by
   exact hF.div hΔ fun z hz => by
     simp [Function.comp_apply, UpperHalfPlane.ofComplex_apply_of_im_pos hz, Δ_ne_zero]
 
+/-- φ₀'' is continuous on the upper half-plane. -/
+lemma φ₀''_continuous : ContinuousOn φ₀'' ℍ₀ :=
+  φ₀''_holo.continuousOn
+
 theorem Φ₁'_holo : Holo(Φ₁' r) := by
   refine DifferentiableOn.mul ?_ ((Complex.differentiable_exp.comp <| (differentiable_const _).mul
       differentiable_fun_id).differentiableOn)
   refine DifferentiableOn.mul ?_ <| (differentiable_fun_id.differentiableOn.add_const 1).pow 2
   apply φ₀''_holo.comp
-  · apply (differentiableOn_const (-1)).div
-    · rw [differentiableOn_add_const_iff]
-      exact differentiableOn_id
-    · intro z hz hcontra
-      obtain ⟨hre, him⟩ := Complex.ext_iff.mp hcontra
-      simp only [add_im, one_im, add_zero, zero_im] at him
-      have : z.im > 0 := hz
-      linarith
+  · exact (differentiableOn_const (-1)).div (differentiableOn_id.add_const 1) fun z hz =>
+      ne_of_mem_of_not_mem (by simpa using hz : z + 1 ∈ ℍ₀)
+        UpperHalfPlane.zero_not_mem_upperHalfPlaneSet
   · let g : GL (Fin 2) ℝ := Units.mk (!![0, -1; 1, 1]) (!![1, 1; -1, 0])
       (by simp [Matrix.one_fin_two]) (by simp [Matrix.one_fin_two])
     have : ∀ z ∈ ℍ₀, UpperHalfPlane.smulAux' g z = -1 / (z + 1) := fun _ _ ↦ by
@@ -104,14 +103,9 @@ theorem Φ₃'_holo : Holo(Φ₃' r) := by
       differentiable_fun_id).differentiableOn)
   refine DifferentiableOn.mul ?_ <| (differentiable_fun_id.differentiableOn.sub_const 1).pow 2
   apply φ₀''_holo.comp
-  · apply (differentiableOn_const (-1)).div
-    · simp only [sub_eq_add_neg, differentiableOn_add_const_iff]
-      exact differentiableOn_id
-    · intro z hz hcontra
-      obtain ⟨hre, him⟩ := Complex.ext_iff.mp hcontra
-      simp only [sub_im, one_im, sub_zero, zero_im] at him
-      have : z.im > 0 := hz
-      linarith
+  · exact (differentiableOn_const (-1)).div (differentiableOn_id.sub_const 1) fun z hz =>
+      ne_of_mem_of_not_mem (by simpa [sub_eq_add_neg] using hz : z - 1 ∈ ℍ₀)
+        UpperHalfPlane.zero_not_mem_upperHalfPlaneSet
   · let g : GL (Fin 2) ℝ := Units.mk (!![0, -1; 1, -1]) (!![-1, 1; -1, 0])
       (by simp [Matrix.one_fin_two]) (by simp [Matrix.one_fin_two])
     have : ∀ z ∈ ℍ₀, UpperHalfPlane.smulAux' g z = -1 / (z - 1) := fun _ _ ↦ by
@@ -187,15 +181,14 @@ section Corollaries
 theorem φ₀''_differentiable : DifferentiableOn ℂ φ₀'' (Set.univ ×ℂ Ioi 0) := by
   simpa [upperHalfPlaneSet, reProdIm] using φ₀''_holo
 
-/-- φ₀'' is continuous on the upper half-plane. -/
-theorem φ₀''_continuous : ContinuousOn φ₀'' (Set.univ ×ℂ Ioi 0) :=
-  φ₀''_differentiable.continuousOn
-
-/-- φ₀ : ℍ → ℂ is continuous. Follows from φ₀''_holo. -/
+/-- φ₀ : ℍ → ℂ is continuous. -/
 theorem φ₀_continuous : Continuous φ₀ := by
-  have h_eq : φ₀ = φ₀'' ∘ (↑· : ℍ → ℂ) := funext fun z => (φ₀''_coe_upperHalfPlane z).symm
-  rw [h_eq]
-  exact φ₀''_holo.continuousOn.comp_continuous continuous_induced_dom fun z => z.2
+  unfold φ₀
+  exact Continuous.div
+    ((((MDifferentiable.continuous E₂_holo').mul (MDifferentiable.continuous E₄.holo')).sub
+      (MDifferentiable.continuous E₆.holo')).pow 2)
+    (MDifferentiable.continuous Delta.holo')
+    (fun z => Δ_ne_zero z)
 
 end Corollaries
 

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -27,7 +27,7 @@ These lemmas are designed to be reusable for contour integral analysis where:
 ## Main results
 
 ### Asymptotic behavior
-- `tendsto_const_mul_pow_mul_exp_neg_atTop`: C · tⁿ · exp(-a·t) → 0 as t → ∞ for a > 0
+- `tendsto_const_mul_rpow_mul_exp_neg_atTop`: C · t^n · exp(-a·t) → 0 as t → ∞ for a > 0
 
 ### Integrability
 - `integrableOn_exp_mul_Ici`: exp(c*t) is integrable on [1,∞) for c < 0
@@ -50,25 +50,24 @@ section Integrability
 
 /-- exp(c*t) is integrable on [1,∞) for c < 0. -/
 lemma integrableOn_exp_mul_Ici (c : ℝ) (hc : c < 0) :
-    IntegrableOn (fun t => exp (c * t)) (Ici 1) volume :=
+    IntegrableOn (fun t ↦ exp (c * t)) (Ici 1) volume :=
   (integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrableOn_exp_mul_Ioi hc 1)
 
-/-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
-lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :
-    Tendsto (fun t => C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
-  simpa [mul_assoc, Real.rpow_natCast] using
-    (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero (n : ℝ) a ha).const_mul C
+/-- `C · t^n · exp(-a·t) → 0` as `t → ∞` for `a > 0` and any real power `n`. -/
+lemma tendsto_const_mul_rpow_mul_exp_neg_atTop (C a n : ℝ) (ha : 0 < a) :
+    Tendsto (fun t ↦ C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
+  simpa [mul_assoc] using (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero n a ha).const_mul C
 
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
-    IntegrableOn (fun t => t * exp (-a * t)) (Ici 1) volume := by
+    IntegrableOn (fun t ↦ t * exp (-a * t)) (Ici 1) volume := by
   rw [integrableOn_Ici_iff_integrableOn_Ioi]
   simpa [rpow_one] using (integrableOn_rpow_mul_exp_neg_mul_rpow (s := 1) (p := 1)
     (by norm_num) le_rfl ha).mono_set (Set.Ioi_subset_Ioi zero_le_one)
 
 /-- t² * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_sq_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
-    IntegrableOn (fun t => t^2 * exp (-a * t)) (Ici 1) volume := by
+    IntegrableOn (fun t ↦ t^2 * exp (-a * t)) (Ici 1) volume := by
   rw [integrableOn_Ici_iff_integrableOn_Ioi]
   simpa [rpow_one, rpow_two] using (integrableOn_rpow_mul_exp_neg_mul_rpow (s := 2) (p := 1)
     (by norm_num) le_rfl ha).mono_set (Set.Ioi_subset_Ioi zero_le_one)

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -27,9 +27,7 @@ These lemmas are designed to be reusable for contour integral analysis where:
 ## Main results
 
 ### Asymptotic behavior
-- `tendsto_exp_neg_atTop`: exp(-a*t) → 0 as t → ∞ for a > 0
-- `tendsto_mul_exp_neg_atTop`: t * exp(-a*t) → 0 as t → ∞ for a > 0
-- `tendsto_sq_mul_exp_neg_atTop`: t² * exp(-a*t) → 0 as t → ∞ for a > 0
+- `tendsto_const_mul_pow_mul_exp_neg_atTop`: C · tⁿ · exp(-a·t) → 0 as t → ∞ for a > 0
 
 ### Integrability
 - `integrableOn_exp_mul_Ici`: exp(c*t) is integrable on [1,∞) for c < 0
@@ -54,21 +52,6 @@ section Integrability
 lemma integrableOn_exp_mul_Ici (c : ℝ) (hc : c < 0) :
     IntegrableOn (fun t => exp (c * t)) (Ici 1) volume :=
   (integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrableOn_exp_mul_Ioi hc 1)
-
-/-- t * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_mul_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => t * exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_one] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 1 a ha
-
-/-- t² * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_sq_mul_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => t^2 * exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_two] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 2 a ha
-
-/-- exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_zero] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 0 a ha
 
 /-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
 lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -70,6 +70,29 @@ lemma tendsto_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
     Tendsto (fun t => exp (-a * t)) atTop (nhds 0) := by
   simpa [rpow_zero] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 0 a ha
 
+/-- C * exp(-a*t) → 0 as t → ∞ for a > 0. -/
+lemma tendsto_const_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
+    Tendsto (fun t => C * exp (-a * t)) atTop (nhds 0) := by
+  simpa using (tendsto_exp_neg_atTop a ha).const_mul C
+
+/-- C * t * exp(-a*t) → 0 as t → ∞ for a > 0. -/
+lemma tendsto_const_mul_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
+    Tendsto (fun t => C * t * exp (-a * t)) atTop (nhds 0) := by
+  have h := (tendsto_mul_exp_neg_atTop a ha).const_mul C
+  simp only [mul_zero] at h
+  convert h using 1
+  funext t
+  ring
+
+/-- C * t² * exp(-a*t) → 0 as t → ∞ for a > 0. -/
+lemma tendsto_const_mul_sq_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
+    Tendsto (fun t => C * t^2 * exp (-a * t)) atTop (nhds 0) := by
+  have h := (tendsto_sq_mul_exp_neg_atTop a ha).const_mul C
+  simp only [mul_zero] at h
+  convert h using 1
+  funext t
+  ring
+
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
     IntegrableOn (fun t => t * exp (-a * t)) (Ici 1) volume := by

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -70,20 +70,11 @@ lemma tendsto_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
     Tendsto (fun t => exp (-a * t)) atTop (nhds 0) := by
   simpa [rpow_zero] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 0 a ha
 
-/-- C * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_const_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => C * exp (-a * t)) atTop (nhds 0) := by
-  simpa using (tendsto_exp_neg_atTop a ha).const_mul C
-
-/-- C * t * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_const_mul_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => C * t * exp (-a * t)) atTop (nhds 0) := by
-  simpa [mul_assoc] using (tendsto_mul_exp_neg_atTop a ha).const_mul C
-
-/-- C * t² * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_const_mul_sq_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => C * t^2 * exp (-a * t)) atTop (nhds 0) := by
-  simpa [mul_assoc] using (tendsto_sq_mul_exp_neg_atTop a ha).const_mul C
+/-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
+lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :
+    Tendsto (fun t => C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
+  simpa [mul_assoc, Real.rpow_natCast] using
+    (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero (n : ℝ) a ha).const_mul C
 
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -78,20 +78,12 @@ lemma tendsto_const_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
 /-- C * t * exp(-a*t) → 0 as t → ∞ for a > 0. -/
 lemma tendsto_const_mul_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
     Tendsto (fun t => C * t * exp (-a * t)) atTop (nhds 0) := by
-  have h := (tendsto_mul_exp_neg_atTop a ha).const_mul C
-  simp only [mul_zero] at h
-  convert h using 1
-  funext t
-  ring
+  simpa [mul_assoc] using (tendsto_mul_exp_neg_atTop a ha).const_mul C
 
 /-- C * t² * exp(-a*t) → 0 as t → ∞ for a > 0. -/
 lemma tendsto_const_mul_sq_mul_exp_neg_atTop (C a : ℝ) (ha : 0 < a) :
     Tendsto (fun t => C * t^2 * exp (-a * t)) atTop (nhds 0) := by
-  have h := (tendsto_sq_mul_exp_neg_atTop a ha).const_mul C
-  simp only [mul_zero] at h
-  convert h using 1
-  funext t
-  ring
+  simpa [mul_assoc] using (tendsto_sq_mul_exp_neg_atTop a ha).const_mul C
 
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -6,9 +6,24 @@ Authors: Cameron Freer
 import SpherePacking.MagicFunction.a.FourierExpansions
 
 /-!
-# PhiBounds Structure
+# Bounds on φ₀, φ₂', φ₄'
 
-Bundles Corollary 7.5-7.7 bounds on φ₀, φ₂', φ₄' as hypotheses.
+Corollary 7.5-7.7 bounds on the phi functions, stated both with explicit constants
+(using `DivDiscBound`) and as Big O asymptotics.
+
+## Main Results
+
+### Explicit constant bounds (for Im(z) > 1/2)
+
+- `φ₀_bound`: ‖φ₀ z‖ ≤ C₀ · exp(-2π · Im z)
+- `φ₂'_bound`: ‖φ₂' z‖ ≤ C₂
+- `φ₄'_bound`: ‖φ₄' z‖ ≤ C₄ · exp(2π · Im z)
+
+### Big O bounds (as Im(z) → ∞)
+
+- `φ₀_isBigO`: φ₀ = O(exp(-2πt)) along imaginary axis
+- `φ₂'_isBigO`: φ₂' = O(1) along imaginary axis
+- `φ₄'_isBigO`: φ₄' = O(exp(2πt)) along imaginary axis
 
 ## Blueprint references
 
@@ -17,69 +32,112 @@ Bundles Corollary 7.5-7.7 bounds on φ₀, φ₂', φ₄' as hypotheses.
 - **Corollary 7.7**: φ₄' bound with exp(2πt) growth
 -/
 
-open Real UpperHalfPlane
+open Real UpperHalfPlane Asymptotics
+open MagicFunction.PolyFourierCoeffBound
+open MagicFunction.a.FourierExpansions
 
 noncomputable section
 
 namespace MagicFunction.a
 
-/-- Bundle of Corollary 7.5-7.7 bounds as hypotheses.
-    Blueprint states these for Im(z) > 1/2, which is the condition we use. -/
-structure PhiBounds where
-  C₀ : ℝ
-  C₂ : ℝ
-  C₄ : ℝ
-  hC₀_pos : 0 < C₀
-  hC₂_pos : 0 < C₂
-  hC₄_pos : 0 < C₄
-  hφ₀ : ∀ z : ℍ, 1/2 < z.im → ‖φ₀ z‖ ≤ C₀ * Real.exp (-2 * π * z.im)
-  hφ₂ : ∀ z : ℍ, 1/2 < z.im → ‖φ₂' z‖ ≤ C₂
-  hφ₄ : ∀ z : ℍ, 1/2 < z.im → ‖φ₄' z‖ ≤ C₄ * Real.exp (2 * π * z.im)
+/-! ## Explicit Constants
 
-open scoped ArithmeticFunction.sigma
-open ArithmeticFunction
-open MagicFunction.PolyFourierCoeffBound
-open MagicFunction.a.FourierExpansions
+The constants are defined using `DivDiscBound` from the Fourier coefficient machinery. -/
 
-/-- PhiBounds instance from modular forms theory using explicit DivDiscBound constants.
-    This avoids the axiom of choice by using computable bounds directly.
-    The bounds follow from Corollaries 7.5-7.7 which use Ramanujan identities.
-    See FourierExpansions.lean for the q-expansion lemmas. -/
-def phiBounds : PhiBounds where
-  C₀ := DivDiscBound c_E₂E₄E₆ 4
-  C₂ := DivDiscBound c_E₂E₄E₆ 2
-  C₄ := DivDiscBound c_E₄_sq 0
-  hC₀_pos := by
-    refine DivDiscBound_pos c_E₂E₄E₆ 4 ?_ 5 c_E₂E₄E₆_poly
-    simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero, false_or]
-    norm_cast
-  hC₂_pos := by
-    refine DivDiscBound_pos c_E₂E₄E₆ 2 ?_ 5 c_E₂E₄E₆_poly
-    simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero, false_or]
-    norm_cast
-  hC₄_pos := by
-    refine DivDiscBound_pos c_E₄_sq 0 ?_ 5 c_E₄_sq_poly
-    simp only [c_E₄_sq, le_refl, ↓reduceIte, ne_eq, one_ne_zero, not_false_eq_true]
-  hφ₀ := fun z hz => by
-    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 4 (summable_E₂E₄E₆_sq z)
-        5 c_E₂E₄E₆_poly (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) E₂E₄E₆_sq_fourier
-    simp only [φ₀]
-    convert h using 2
-    ring_nf
-  hφ₂ := fun z hz => by
-    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
-        5 c_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
-    simp only [φ₂']
-    calc ‖(E₄ z * (E₂ z * E₄ z - E₆ z)) / Δ z‖
-        ≤ DivDiscBound c_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
-      _ = DivDiscBound c_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
-      _ = DivDiscBound c_E₂E₄E₆ 2 := by simp
-  hφ₄ := fun z hz => by
-    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_sq 0 (summable_E₄_sq z)
-        5 c_E₄_sq_poly (fun z ↦ E₄ z ^ 2) E₄_sq_fourier
-    simp only [φ₄']
-    convert h using 2
-    ring_nf
+/-- Explicit constant for φ₀ bound (Corollary 7.5). -/
+def C_φ₀ : ℝ := DivDiscBound c_E₂E₄E₆ 4
+
+/-- Explicit constant for φ₂' bound (Corollary 7.6). -/
+def C_φ₂' : ℝ := DivDiscBound c_E₂E₄E₆ 2
+
+/-- Explicit constant for φ₄' bound (Corollary 7.7). -/
+def C_φ₄' : ℝ := DivDiscBound c_E₄_sq 0
+
+/-! ## Positivity of Constants -/
+
+lemma C_φ₀_pos : 0 < C_φ₀ := by
+  refine DivDiscBound_pos c_E₂E₄E₆ 4 ?_ 5 c_E₂E₄E₆_poly
+  simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]; norm_cast
+
+lemma C_φ₂'_pos : 0 < C_φ₂' := by
+  refine DivDiscBound_pos c_E₂E₄E₆ 2 ?_ 5 c_E₂E₄E₆_poly
+  simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]; norm_cast
+
+lemma C_φ₄'_pos : 0 < C_φ₄' := by
+  refine DivDiscBound_pos c_E₄_sq 0 ?_ 5 c_E₄_sq_poly
+  simp only [c_E₄_sq, le_refl, ↓reduceIte, ne_eq, one_ne_zero, not_false_eq_true]
+
+/-! ## Explicit Constant Bounds
+
+These are the direct bounds from Corollaries 7.5-7.7. -/
+
+/-- Corollary 7.5: φ₀ decays like exp(-2πt) for Im(z) > 1/2. -/
+theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
+    ‖φ₀ z‖ ≤ C_φ₀ * Real.exp (-2 * π * z.im) := by
+  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 4 (summable_E₂E₄E₆_sq z)
+      5 c_E₂E₄E₆_poly (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) E₂E₄E₆_sq_fourier
+  simp only [φ₀, C_φ₀]; convert h using 2; ring_nf
+
+/-- Corollary 7.6: φ₂' is bounded for Im(z) > 1/2. -/
+theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
+    ‖φ₂' z‖ ≤ C_φ₂' := by
+  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
+      5 c_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
+  simp only [φ₂', C_φ₂']
+  calc ‖(E₄ z * (E₂ z * E₄ z - E₆ z)) / Δ z‖
+      ≤ DivDiscBound c_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
+    _ = DivDiscBound c_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
+    _ = DivDiscBound c_E₂E₄E₆ 2 := by simp
+
+/-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
+theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
+    ‖φ₄' z‖ ≤ C_φ₄' * Real.exp (2 * π * z.im) := by
+  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_sq 0 (summable_E₄_sq z)
+      5 c_E₄_sq_poly (fun z ↦ E₄ z ^ 2) E₄_sq_fourier
+  simp only [φ₄', C_φ₄']; convert h using 2; ring_nf
+
+/-! ## Big O Bounds
+
+These express the same bounds as asymptotic estimates along the imaginary axis
+(z = it as t → ∞). We parametrize by t > 0 and construct the corresponding point in ℍ. -/
+
+/-- Helper to construct a point on the imaginary axis. -/
+def iAxis (t : ℝ) (ht : 0 < t) : ℍ := ⟨Complex.I * t, by simp [ht]⟩
+
+@[simp] lemma iAxis_im (t : ℝ) (ht : 0 < t) : (iAxis t ht).im = t := by
+  simp [iAxis, UpperHalfPlane.im]
+
+/-- φ₀ restricted to imaginary axis as a function of t. -/
+def φ₀_iAxis (t : ℝ) : ℂ := if ht : 0 < t then φ₀ (iAxis t ht) else 0
+
+/-- φ₂' restricted to imaginary axis as a function of t. -/
+def φ₂'_iAxis (t : ℝ) : ℂ := if ht : 0 < t then φ₂' (iAxis t ht) else 0
+
+/-- φ₄' restricted to imaginary axis as a function of t. -/
+def φ₄'_iAxis (t : ℝ) : ℂ := if ht : 0 < t then φ₄' (iAxis t ht) else 0
+
+/-- Corollary 7.5 (Big O form): φ₀ = O(exp(-2πt)) as t → ∞. -/
+theorem φ₀_isBigO : φ₀_iAxis =O[Filter.atTop] (fun t ↦ Real.exp (-2 * π * t)) := by
+  rw [Asymptotics.isBigO_iff]; use C_φ₀
+  filter_upwards [Filter.eventually_gt_atTop (1 / 2 : ℝ)] with t ht
+  have ht' : 0 < t := by linarith
+  simpa [φ₀_iAxis, ht', Real.norm_eq_abs] using
+    φ₀_bound (iAxis t ht') (by simp [iAxis_im]; linarith)
+
+/-- Corollary 7.6 (Big O form): φ₂' = O(1) as t → ∞. -/
+theorem φ₂'_isBigO : φ₂'_iAxis =O[Filter.atTop] (fun _ ↦ (1 : ℝ)) := by
+  rw [Asymptotics.isBigO_iff]; use C_φ₂'
+  filter_upwards [Filter.eventually_gt_atTop (1 / 2 : ℝ)] with t ht
+  have ht' : 0 < t := by linarith
+  simpa [φ₂'_iAxis, ht'] using φ₂'_bound (iAxis t ht') (by simp [iAxis_im]; linarith)
+
+/-- Corollary 7.7 (Big O form): φ₄' = O(exp(2πt)) as t → ∞. -/
+theorem φ₄'_isBigO : φ₄'_iAxis =O[Filter.atTop] (fun t ↦ Real.exp (2 * π * t)) := by
+  rw [Asymptotics.isBigO_iff]; use C_φ₄'
+  filter_upwards [Filter.eventually_gt_atTop (1 / 2 : ℝ)] with t ht
+  have ht' : 0 < t := by linarith
+  simpa [φ₄'_iAxis, ht', Real.norm_eq_abs] using
+    φ₄'_bound (iAxis t ht') (by simp [iAxis_im]; linarith)
 
 end MagicFunction.a
 

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2025 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import SpherePacking.MagicFunction.a.FourierExpansions
+
+/-!
+# PhiBounds Structure
+
+Bundles Corollary 7.5-7.7 bounds on φ₀, φ₂', φ₄' as hypotheses.
+
+## Blueprint references
+
+- **Corollary 7.5**: φ₀ bound with exp(-2πt) decay
+- **Corollary 7.6**: φ₂' bounded (constant)
+- **Corollary 7.7**: φ₄' bound with exp(2πt) growth
+-/
+
+open Real UpperHalfPlane
+
+noncomputable section
+
+namespace MagicFunction.a
+
+/-- Bundle of Corollary 7.5-7.7 bounds as hypotheses.
+    Blueprint states these for Im(z) > 1/2, which is the condition we use. -/
+structure PhiBounds where
+  C₀ : ℝ
+  C₂ : ℝ
+  C₄ : ℝ
+  hC₀_pos : 0 < C₀
+  hC₂_pos : 0 < C₂
+  hC₄_pos : 0 < C₄
+  hφ₀ : ∀ z : ℍ, 1/2 < z.im → ‖φ₀ z‖ ≤ C₀ * Real.exp (-2 * π * z.im)
+  hφ₂ : ∀ z : ℍ, 1/2 < z.im → ‖φ₂' z‖ ≤ C₂
+  hφ₄ : ∀ z : ℍ, 1/2 < z.im → ‖φ₄' z‖ ≤ C₄ * Real.exp (2 * π * z.im)
+
+open scoped ArithmeticFunction.sigma
+open ArithmeticFunction
+open MagicFunction.PolyFourierCoeffBound
+open MagicFunction.a.FourierExpansions
+
+/-- PhiBounds instance from modular forms theory using explicit DivDiscBound constants.
+    This avoids the axiom of choice by using computable bounds directly.
+    The bounds follow from Corollaries 7.5-7.7 which use Ramanujan identities.
+    See FourierExpansions.lean for the q-expansion lemmas. -/
+def phiBounds : PhiBounds where
+  C₀ := DivDiscBound c_E₂E₄E₆ 4
+  C₂ := DivDiscBound c_E₂E₄E₆ 2
+  C₄ := DivDiscBound c_E₄_sq 0
+  hC₀_pos := by
+    refine DivDiscBound_pos c_E₂E₄E₆ 4 ?_ 5 c_E₂E₄E₆_poly
+    simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero, false_or]
+    norm_cast
+  hC₂_pos := by
+    refine DivDiscBound_pos c_E₂E₄E₆ 2 ?_ 5 c_E₂E₄E₆_poly
+    simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero, false_or]
+    norm_cast
+  hC₄_pos := by
+    refine DivDiscBound_pos c_E₄_sq 0 ?_ 5 c_E₄_sq_poly
+    simp only [c_E₄_sq, le_refl, ↓reduceIte, ne_eq, one_ne_zero, not_false_eq_true]
+  hφ₀ := fun z hz => by
+    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 4 (summable_E₂E₄E₆_sq z)
+        5 c_E₂E₄E₆_poly (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) E₂E₄E₆_sq_fourier
+    simp only [φ₀]
+    convert h using 2
+    ring_nf
+  hφ₂ := fun z hz => by
+    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
+        5 c_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
+    simp only [φ₂']
+    calc ‖(E₄ z * (E₂ z * E₄ z - E₆ z)) / Δ z‖
+        ≤ DivDiscBound c_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
+      _ = DivDiscBound c_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
+      _ = DivDiscBound c_E₂E₄E₆ 2 := by simp
+  hφ₄ := fun z hz => by
+    have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_sq 0 (summable_E₄_sq z)
+        5 c_E₄_sq_poly (fun z ↦ E₄ z ^ 2) E₄_sq_fourier
+    simp only [φ₄']
+    convert h using 2
+    ring_nf
+
+end MagicFunction.a
+
+end

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -47,8 +47,9 @@ The constants are defined using `DivDiscBound` from the Fourier coefficient mach
 /-- Explicit constant for φ₀ bound (Corollary 7.5). -/
 def C_φ₀ : ℝ := DivDiscBound c_E₂E₄E₆ 4
 
-/-- Explicit constant for φ₂' bound (Corollary 7.6). -/
-def C_φ₂' : ℝ := DivDiscBound c_E₂E₄E₆ 2
+/-- Explicit constant for φ₂' bound (Corollary 7.6).
+    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
+def C_φ₂' : ℝ := DivDiscBound c_E₄_E₂E₄E₆ 2
 
 /-- Explicit constant for φ₄' bound (Corollary 7.7). -/
 def C_φ₄' : ℝ := DivDiscBound c_E₄_sq 0
@@ -60,8 +61,9 @@ lemma C_φ₀_pos : 0 < C_φ₀ := by
   simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]; norm_cast
 
 lemma C_φ₂'_pos : 0 < C_φ₂' := by
-  refine DivDiscBound_pos c_E₂E₄E₆ 2 ?_ 5 c_E₂E₄E₆_poly
-  simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]; norm_cast
+  refine DivDiscBound_pos c_E₄_E₂E₄E₆ 2 ?_ 5 c_E₄_E₂E₄E₆_poly
+  simp only [c_E₄_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]
+  norm_cast
 
 lemma C_φ₄'_pos : 0 < C_φ₄' := by
   refine DivDiscBound_pos c_E₄_sq 0 ?_ 5 c_E₄_sq_poly
@@ -81,13 +83,14 @@ theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
 /-- Corollary 7.6: φ₂' is bounded for Im(z) > 1/2. -/
 theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₂' z‖ ≤ C_φ₂' := by
-  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
-      5 c_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
+  -- Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient)
+  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
+      5 c_E₄_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
   simp only [φ₂', C_φ₂']
   calc ‖(E₄ z * (E₂ z * E₄ z - E₆ z)) / Δ z‖
-      ≤ DivDiscBound c_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
-    _ = DivDiscBound c_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
-    _ = DivDiscBound c_E₂E₄E₆ 2 := by simp
+      ≤ DivDiscBound c_E₄_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
+    _ = DivDiscBound c_E₄_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
+    _ = DivDiscBound c_E₄_E₂E₄E₆ 2 := by simp
 
 /-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
 theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -78,7 +78,9 @@ theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₀ z‖ ≤ C_φ₀ * Real.exp (-2 * π * z.im) := by
   have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 4 (summable_E₂E₄E₆_sq z)
       5 c_E₂E₄E₆_poly (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) E₂E₄E₆_sq_fourier
-  simp only [φ₀, C_φ₀]; convert h using 2; ring_nf
+  simp only [φ₀, C_φ₀]
+  convert h using 2
+  ring_nf
 
 /-- Corollary 7.6: φ₂' is bounded for Im(z) > 1/2. -/
 theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
@@ -86,14 +88,18 @@ theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
   -- Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient)
   have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
       5 c_E₄_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
-  simp only [φ₂', C_φ₂']; convert h using 2; norm_num
+  simp only [φ₂', C_φ₂']
+  convert h using 2
+  norm_num
 
 /-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
 theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₄' z‖ ≤ C_φ₄' * Real.exp (2 * π * z.im) := by
   have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_sq 0 (summable_E₄_sq z)
       5 c_E₄_sq_poly (fun z ↦ E₄ z ^ 2) E₄_sq_fourier
-  simp only [φ₄', C_φ₄']; convert h using 2; ring_nf
+  simp only [φ₄', C_φ₄']
+  convert h using 2
+  ring_nf
 
 /-! ## Big O Bounds
 

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -33,6 +33,7 @@ Corollary 7.5-7.7 bounds on the phi functions, stated both with explicit constan
 -/
 
 open Real UpperHalfPlane Asymptotics
+open scoped ArithmeticFunction.sigma
 open MagicFunction.PolyFourierCoeffBound
 open MagicFunction.a.FourierExpansions
 
@@ -42,64 +43,67 @@ namespace MagicFunction.a
 
 /-! ## Explicit Constants
 
-The constants are defined using `DivDiscBound` from the Fourier coefficient machinery. -/
+Each constant factors as `(factor-norm bound) · DivDiscBound (linear coefficient)`, reflecting the
+`‖φ‖ = ‖factor‖ · ‖linear/Δ‖` decomposition. -/
 
 /-- Explicit constant for φ₀ bound (Corollary 7.5). -/
-def C_φ₀ : ℝ := DivDiscBound c_E₂E₄E₆ 4
+def C_φ₀ : ℝ := B_g * DivDiscBound (evenCoeff bg) 2
 
-/-- Explicit constant for φ₂' bound (Corollary 7.6).
-    Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient). -/
-def C_φ₂' : ℝ := DivDiscBound c_E₄_E₂E₄E₆ 2
+/-- Explicit constant for φ₂' bound (Corollary 7.6). -/
+def C_φ₂' : ℝ := B_E₄ * DivDiscBound (evenCoeff bg) 2
 
 /-- Explicit constant for φ₄' bound (Corollary 7.7). -/
-def C_φ₄' : ℝ := DivDiscBound c_E₄_sq 0
+def C_φ₄' : ℝ := B_E₄ * DivDiscBound (evenCoeff bE₄) 0
 
 /-! ## Positivity of Constants -/
 
-lemma C_φ₀_pos : 0 < C_φ₀ := by
-  refine DivDiscBound_pos c_E₂E₄E₆ 4 ?_ 5 c_E₂E₄E₆_poly
-  simp only [c_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]; norm_cast
+lemma divDiscBound_bg_pos : 0 < DivDiscBound (evenCoeff bg) 2 := by
+  refine DivDiscBound_pos (evenCoeff bg) 2 ?_ 5 (evenCoeff_isBigO bg_isBigO)
+  have hσ : (σ 3 1 : ℂ) = 1 := by simp [ArithmeticFunction.sigma_apply, Nat.divisors_one]
+  simp [evenCoeff, bg, hσ]
 
-lemma C_φ₂'_pos : 0 < C_φ₂' := by
-  refine DivDiscBound_pos c_E₄_E₂E₄E₆ 2 ?_ 5 c_E₄_E₂E₄E₆_poly
-  simp only [c_E₄_E₂E₄E₆, ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero, Int.cast_eq_zero]
-  norm_cast
+lemma divDiscBound_bE₄_pos : 0 < DivDiscBound (evenCoeff bE₄) 0 := by
+  refine DivDiscBound_pos (evenCoeff bE₄) 0 ?_ 5 (evenCoeff_isBigO bE₄_isBigO)
+  simp [evenCoeff, bE₄]
 
-lemma C_φ₄'_pos : 0 < C_φ₄' := by
-  refine DivDiscBound_pos c_E₄_sq 0 ?_ 5 c_E₄_sq_poly
-  simp only [c_E₄_sq, le_refl, ↓reduceIte, ne_eq, one_ne_zero, not_false_eq_true]
+lemma C_φ₀_pos : 0 < C_φ₀ := mul_pos B_g_pos divDiscBound_bg_pos
+
+lemma C_φ₂'_pos : 0 < C_φ₂' := mul_pos B_E₄_pos divDiscBound_bg_pos
+
+lemma C_φ₄'_pos : 0 < C_φ₄' := mul_pos B_E₄_pos divDiscBound_bE₄_pos
 
 /-! ## Explicit Constant Bounds
 
-These are the direct bounds from Corollaries 7.5-7.7. -/
+Each is `‖φ‖ = ‖factor‖ · ‖linear/Δ‖`, combining a factor-norm bound with a quotient bound. -/
 
 /-- Corollary 7.5: φ₀ decays like exp(-2πt) for Im(z) > 1/2. -/
 theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₀ z‖ ≤ C_φ₀ * Real.exp (-2 * π * z.im) := by
-  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₂E₄E₆ 4 (summable_E₂E₄E₆_sq z)
-      5 c_E₂E₄E₆_poly (fun z ↦ ((E₂ z) * (E₄ z) - (E₆ z)) ^ 2) E₂E₄E₆_sq_fourier
-  simp only [φ₀, C_φ₀]
-  convert h using 2
-  ring_nf
+  have hfact : φ₀ z = (E₂ z * E₄ z - E₆ z) * ((E₂ z * E₄ z - E₆ z) / Δ z) := by
+    simp only [φ₀]; ring
+  rw [hfact, norm_mul, C_φ₀, show (-2 * π * z.im : ℝ) = -(2 * π) * z.im by ring]
+  calc ‖E₂ z * E₄ z - E₆ z‖ * ‖(E₂ z * E₄ z - E₆ z) / Δ z‖
+      ≤ B_g * rexp (-(2 * π) * z.im) * DivDiscBound (evenCoeff bg) 2 :=
+        mul_le_mul (norm_g_le z hz.le) (g_div_Δ_bound z hz) (norm_nonneg _)
+          (mul_nonneg B_g_pos.le (Real.exp_pos _).le)
+    _ = B_g * DivDiscBound (evenCoeff bg) 2 * rexp (-(2 * π) * z.im) := by ring
 
 /-- Corollary 7.6: φ₂' is bounded for Im(z) > 1/2. -/
 theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₂' z‖ ≤ C_φ₂' := by
-  -- Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient)
-  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
-      5 c_E₄_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
-  simp only [φ₂', C_φ₂']
-  convert h using 2
-  norm_num
+  have hfact : φ₂' z = E₄ z * ((E₂ z * E₄ z - E₆ z) / Δ z) := by simp only [φ₂']; ring
+  rw [hfact, norm_mul, C_φ₂']
+  exact mul_le_mul (norm_E₄_le z hz.le) (g_div_Δ_bound z hz) (norm_nonneg _) B_E₄_pos.le
 
 /-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
 theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₄' z‖ ≤ C_φ₄' * Real.exp (2 * π * z.im) := by
-  have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_sq 0 (summable_E₄_sq z)
-      5 c_E₄_sq_poly (fun z ↦ E₄ z ^ 2) E₄_sq_fourier
-  simp only [φ₄', C_φ₄']
-  convert h using 2
-  ring_nf
+  have hfact : φ₄' z = E₄ z * (E₄ z / Δ z) := by simp only [φ₄']; ring
+  rw [hfact, norm_mul, C_φ₄']
+  calc ‖E₄ z‖ * ‖E₄ z / Δ z‖
+      ≤ B_E₄ * (DivDiscBound (evenCoeff bE₄) 0 * Real.exp (2 * π * z.im)) :=
+        mul_le_mul (norm_E₄_le z hz.le) (E₄_div_Δ_bound z hz) (norm_nonneg _) B_E₄_pos.le
+    _ = B_E₄ * DivDiscBound (evenCoeff bE₄) 0 * Real.exp (2 * π * z.im) := by ring
 
 /-! ## Big O Bounds
 

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -79,15 +79,22 @@ lemma C_φ₄'_pos : 0 < C_φ₄' := mul_pos B_E₄_pos divDiscBound_bE₄_pos
 
 Each is `‖φ‖ = ‖factor‖ · ‖linear/Δ‖`, combining a factor-norm bound with a quotient bound. -/
 
+/-- Combine a factor-norm bound with a quotient bound: if `‖a‖ ≤ x` and `‖b‖ ≤ y` (with `0 ≤ x`)
+then `‖a · b‖ ≤ x · y`. Each φ-bound below is an instance with `a = factor`, `b = linear/Δ`. -/
+lemma norm_mul_le_mul {a b : ℂ} {x y : ℝ} (ha : ‖a‖ ≤ x) (hb : ‖b‖ ≤ y) (hx : 0 ≤ x) :
+    ‖a * b‖ ≤ x * y := by
+  rw [norm_mul]
+  exact mul_le_mul ha hb (norm_nonneg _) hx
+
 /-- Corollary 7.5: φ₀ decays like exp(-2πt) for Im(z) > 1/2. -/
 theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₀ z‖ ≤ C_φ₀ * Real.exp (-2 * π * z.im) := by
   have hfact : φ₀ z = (E₂ z * E₄ z - E₆ z) * ((E₂ z * E₄ z - E₆ z) / Δ z) := by
     simp only [φ₀]; ring
-  rw [hfact, norm_mul, C_φ₀, show (-2 * π * z.im : ℝ) = -(2 * π) * z.im by ring]
-  calc ‖E₂ z * E₄ z - E₆ z‖ * ‖(E₂ z * E₄ z - E₆ z) / Δ z‖
+  rw [hfact, C_φ₀, show (-2 * π * z.im : ℝ) = -(2 * π) * z.im by ring]
+  calc ‖(E₂ z * E₄ z - E₆ z) * ((E₂ z * E₄ z - E₆ z) / Δ z)‖
       ≤ B_g * rexp (-(2 * π) * z.im) * DivDiscBound (evenCoeff bg) 2 :=
-        mul_le_mul (norm_g_le z hz.le) (g_div_Δ_bound z hz) (norm_nonneg _)
+        norm_mul_le_mul (norm_g_le z hz.le) (g_div_Δ_bound z hz)
           (mul_nonneg B_g_pos.le (Real.exp_pos _).le)
     _ = B_g * DivDiscBound (evenCoeff bg) 2 * rexp (-(2 * π) * z.im) := by ring
 
@@ -95,17 +102,17 @@ theorem φ₀_bound (z : ℍ) (hz : 1 / 2 < z.im) :
 theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₂' z‖ ≤ C_φ₂' := by
   have hfact : φ₂' z = E₄ z * ((E₂ z * E₄ z - E₆ z) / Δ z) := by simp only [φ₂']; ring
-  rw [hfact, norm_mul, C_φ₂']
-  exact mul_le_mul (norm_E₄_le z hz.le) (g_div_Δ_bound z hz) (norm_nonneg _) B_E₄_pos.le
+  rw [hfact, C_φ₂']
+  exact norm_mul_le_mul (norm_E₄_le z hz.le) (g_div_Δ_bound z hz) B_E₄_pos.le
 
 /-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
 theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
     ‖φ₄' z‖ ≤ C_φ₄' * Real.exp (2 * π * z.im) := by
   have hfact : φ₄' z = E₄ z * (E₄ z / Δ z) := by simp only [φ₄']; ring
-  rw [hfact, norm_mul, C_φ₄']
-  calc ‖E₄ z‖ * ‖E₄ z / Δ z‖
+  rw [hfact, C_φ₄']
+  calc ‖E₄ z * (E₄ z / Δ z)‖
       ≤ B_E₄ * (DivDiscBound (evenCoeff bE₄) 0 * Real.exp (2 * π * z.im)) :=
-        mul_le_mul (norm_E₄_le z hz.le) (E₄_div_Δ_bound z hz) (norm_nonneg _) B_E₄_pos.le
+        norm_mul_le_mul (norm_E₄_le z hz.le) (E₄_div_Δ_bound z hz) B_E₄_pos.le
     _ = B_E₄ * DivDiscBound (evenCoeff bE₄) 0 * Real.exp (2 * π * z.im) := by ring
 
 /-! ## Big O Bounds

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -86,11 +86,7 @@ theorem φ₂'_bound (z : ℍ) (hz : 1 / 2 < z.im) :
   -- Note: Uses c_E₄_E₂E₄E₆ (product coefficient), not c_E₂E₄E₆ (square coefficient)
   have h := DivDiscBoundOfPolyFourierCoeff z hz c_E₄_E₂E₄E₆ 2 (summable_E₄_E₂E₄E₆ z)
       5 c_E₄_E₂E₄E₆_poly (fun z ↦ E₄ z * (E₂ z * E₄ z - E₆ z)) E₄_E₂E₄E₆_fourier
-  simp only [φ₂', C_φ₂']
-  calc ‖(E₄ z * (E₂ z * E₄ z - E₆ z)) / Δ z‖
-      ≤ DivDiscBound c_E₄_E₂E₄E₆ 2 * Real.exp (-π * (2 - 2) * z.im) := h
-    _ = DivDiscBound c_E₄_E₂E₄E₆ 2 * Real.exp 0 := by ring_nf
-    _ = DivDiscBound c_E₄_E₂E₄E₆ 2 := by simp
+  simp only [φ₂', C_φ₂']; convert h using 2; norm_num
 
 /-- Corollary 7.7: φ₄' grows at most like exp(2πt) for Im(z) > 1/2. -/
 theorem φ₄'_bound (z : ℍ) (hz : 1 / 2 < z.im) :

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -7,8 +7,6 @@ module
 
 public import SpherePacking.MagicFunction.a.FourierExpansions
 
-@[expose] public section
-
 /-!
 # Bounds on φ₀, φ₂', φ₄'
 
@@ -35,6 +33,8 @@ Corollary 7.5-7.7 bounds on the phi functions, stated both with explicit constan
 - **Corollary 7.6**: φ₂' bounded (constant)
 - **Corollary 7.7**: φ₄' bound with exp(2πt) growth
 -/
+
+@[expose] public section
 
 open Real UpperHalfPlane Asymptotics
 open scoped ArithmeticFunction.sigma
@@ -63,8 +63,7 @@ def C_φ₄' : ℝ := B_E₄ * DivDiscBound (evenCoeff bE₄) 0
 
 lemma divDiscBound_bg_pos : 0 < DivDiscBound (evenCoeff bg) 2 := by
   refine DivDiscBound_pos (evenCoeff bg) 2 ?_ 5 (evenCoeff_isBigO bg_isBigO)
-  have hσ : (σ 3 1 : ℂ) = 1 := by simp [ArithmeticFunction.sigma_apply, Nat.divisors_one]
-  simp [evenCoeff, bg, hσ]
+  simp [evenCoeff, bg]
 
 lemma divDiscBound_bE₄_pos : 0 < DivDiscBound (evenCoeff bE₄) 0 := by
   refine DivDiscBound_pos (evenCoeff bE₄) 0 ?_ 5 (evenCoeff_isBigO bE₄_isBigO)

--- a/SpherePacking/MagicFunction/a/PhiBounds.lean
+++ b/SpherePacking/MagicFunction/a/PhiBounds.lean
@@ -3,7 +3,11 @@ Copyright (c) 2025 Cameron Freer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
-import SpherePacking.MagicFunction.a.FourierExpansions
+module
+
+public import SpherePacking.MagicFunction.a.FourierExpansions
+
+@[expose] public section
 
 /-!
 # Bounds on φ₀, φ₂', φ₄'

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -312,41 +312,18 @@ lemma integrableOn_φ₀_shifted_Möbius (a b r : ℝ) (hr : 2 < r) :
   apply MeasureTheory.Integrable.mono' hbound_integ
   · -- AEStronglyMeasurable: The integrand is continuous on Ioi 1
     -- For t > 0, Im(a + I*t) = t > 0 so -1/(a+I*t) stays in the upper half plane
-    have h_im_pos : ∀ t : ℝ, 0 < t → 0 < ((-1 : ℂ) / (a + Complex.I * t)).im :=
-      fun t ht => im_neg_inv_pos a t ht
-    -- The path factorizes through UpperHalfPlane via φ₀_continuous
-    let path : {s : ℝ // 0 < s} → UpperHalfPlane := fun s =>
-      ⟨-1 / (a + Complex.I * s), h_im_pos s s.2⟩
-    have h_path_cont : Continuous path := by
-      simp only [path]
-      refine Continuous.upperHalfPlaneMk ?_ _
-      apply Continuous.div continuous_const
-      · exact continuous_const.add
-          (continuous_const.mul (Complex.continuous_ofReal.comp continuous_subtype_val))
-      · intro ⟨s, hs⟩; exact fun h => (ne_of_gt hs) (by simpa using congrArg Complex.im h)
-    have h_comp_cont : Continuous (φ₀ ∘ path) := φ₀_continuous.comp h_path_cont
-    have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (-1 / (a + Complex.I * t))) (Ioi 0) := by
-      intro t ht
-      rw [Set.mem_Ioi] at ht
-      have h_eq : φ₀'' (-1 / (a + Complex.I * t)) = φ₀ (path ⟨t, ht⟩) := by
-        rw [φ₀''_eq _ (h_im_pos t ht)]
-      rw [ContinuousWithinAt, h_eq]
-      have h_at : ContinuousAt (φ₀ ∘ path) ⟨t, ht⟩ := h_comp_cont.continuousAt
-      have h_map_eq : Filter.map (Subtype.val : {s : ℝ // 0 < s} → ℝ) (nhds ⟨t, ht⟩) =
-          nhdsWithin t (Set.Ioi 0) := by convert map_nhds_subtype_val ⟨t, ht⟩
-      rw [← h_map_eq, Filter.tendsto_map'_iff]
-      convert h_at.tendsto using 1
-      funext x
-      simp only [Function.comp_apply, φ₀''_eq _ (h_im_pos x.val x.prop), path]
+    -- `φ₀''` is continuous on `ℍ₀`, and `t ↦ -1/(a+I·t)` maps `Ioi 0` into `ℍ₀`
+    -- (`im_neg_inv_pos`), so the composition is continuous on `Ioi 0`.
+    have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (-1 / (a + Complex.I * t))) (Ioi 0) :=
+      φ₀''_continuous.comp
+        (continuousOn_const.div
+          ((continuous_const.add (continuous_const.mul Complex.continuous_ofReal)).continuousOn)
+          (fun t ht h => (ne_of_gt ht) (by simpa using congrArg Complex.im h)))
+        (fun t ht => im_neg_inv_pos a t ht)
     have h_cont : ContinuousOn (fun t : ℝ => φ₀'' (-1 / (a + Complex.I * t)) *
         (a + Complex.I * t)^2 * Complex.exp (Complex.I * π * r * (b + Complex.I * t))) (Ioi 1) := by
-      refine (h_cont_phi.mono (Ioi_subset_Ioi (by linarith : (0:ℝ) ≤ 1))).mul ?_ |>.mul ?_
-      · exact (continuousOn_const.add
-          (continuousOn_const.mul Complex.continuous_ofReal.continuousOn)).pow _
-      · refine Complex.continuous_exp.comp_continuousOn ?_
-        exact (continuousOn_const.mul continuousOn_const).mul
-          (continuousOn_const.add
-            (continuousOn_const.mul Complex.continuous_ofReal.continuousOn))
+      have hφ := h_cont_phi.mono (Ioi_subset_Ioi (by linarith : (0:ℝ) ≤ 1))
+      fun_prop
     exact h_cont.aestronglyMeasurable measurableSet_Ioi
   · -- Norm bound: dominated by `(a²+1)·verticalBound` (see `norm_shiftedMobiusIntegrand_le`)
     rw [ae_restrict_iff' measurableSet_Ioi]

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -420,11 +420,7 @@ lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
       have h1 := continuousOn_φ₀''_cusp_path
       refine h1.congr fun t ht =>
         congrArg φ₀'' (neg_one_div_I_mul (t : ℂ)).symm
-    refine ((continuousOn_const.mul h_cont_phi).mul ?_).mul ?_
-    · exact (continuousOn_const.mul Complex.continuous_ofReal.continuousOn).pow _
-    · refine Complex.continuous_exp.comp_continuousOn ?_
-      refine (continuousOn_const.mul continuousOn_const).mul ?_
-      exact continuousOn_const.add (continuousOn_const.mul Complex.continuous_ofReal.continuousOn)
+    fun_prop
   have hmeas : AEStronglyMeasurable (fun t => ContourEndpoints.verticalIntegrandX x r t)
       (volume.restrict (Ioc 0 1)) := hcont.aestronglyMeasurable measurableSet_Ioc
   -- Pointwise bound: for t ∈ (0, 1], ‖verticalIntegrandX x r t‖ ≤ C₀ * exp(-2π)

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -452,21 +452,13 @@ lemma integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX (x r : ℝ) (hr : 2 < r)
   (IntegrableOn.const_mul' (integrableOn_verticalIntegrandX_Ioi x r hr)).congr_fun
     (fun _ ht => (hEq ht).symm) measurableSet_Ioi
 
-/-- Helper simp lemma: t*I + 1 = 1 + I*t -/
-@[simp]
-lemma t_mul_I_add_one (t : ℝ) : (t : ℂ) * Complex.I + 1 = (1 : ℂ) + Complex.I * t := by ring
-
-/-- Helper simp lemma: t*I - 1 = -1 + I*t -/
-@[simp]
-lemma t_mul_I_sub_one (t : ℝ) : (t : ℂ) * Complex.I - 1 = (-1 : ℂ) + Complex.I * t := by ring
-
 /-- Integrability for shifted Möbius integrands with exponential phase t*I.
     Factors out the common proof pattern from Goals 3 and 5. -/
 lemma integrableOn_shiftedMöbius (a r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I + a)) * (t * Complex.I + a)^2 *
                           Complex.exp (π * Complex.I * r * (t * Complex.I)))
                  (Ioi 1) volume := by
-  simpa [t_mul_I_add_one, t_mul_I_sub_one, mul_comm, add_comm] using
+  simpa [mul_comm, add_comm, sub_eq_add_neg] using
     integrableOn_φ₀_shifted_Möbius a 0 r hr
 
 /-! ## Specific Instantiations

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -192,19 +192,10 @@ Uses φ₀''_neg_inv_eq_φ₀_S_smul + norm_φ₀_S_smul_le infrastructure from 
     This ensures the Möbius-transformed argument stays in the upper half-plane. -/
 lemma im_neg_inv_pos (a t : ℝ) (ht : 0 < t) :
     0 < ((-1 : ℂ) / (a + Complex.I * t)).im := by
-  -- Im(-1/(a + I*t)) = t/(a² + t²) > 0 since t > 0 and a² + t² > 0
-  have h_denom : a^2 + t^2 > 0 := by positivity
-  have h_normSq : Complex.normSq (↑a + Complex.I * ↑t) = a^2 + t^2 := by
-    rw [mul_comm]; exact Complex.normSq_add_mul_I a t
-  -- Use div_im: (z / w).im = z.im * w.re / normSq w - z.re * w.im / normSq w
-  rw [Complex.div_im, h_normSq]
-  -- For z = -1: z.re = -1, z.im = 0; For w = a + I*t: w.re = a, w.im = t
-  simp only [Complex.neg_im, Complex.one_im, neg_zero, Complex.neg_re, Complex.one_re,
-    Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.ofReal_im,
-    mul_zero, Complex.I_im, sub_zero, Complex.add_im, Complex.mul_im, zero_mul, add_zero]
-  -- Goal: 0 * a / (a² + t²) - (-1) * t / (a² + t²) = t / (a² + t²)
-  ring_nf
-  exact div_pos ht h_denom
+  -- -1/(a+I·t) = (-(a+I·t))⁻¹, and a+I·t ∈ ℍ, so apply `im_inv_neg_coe_pos`.
+  simpa [neg_div, one_div, neg_inv] using
+    UpperHalfPlane.im_inv_neg_coe_pos
+      (⟨a + Complex.I * t, by simp [Complex.add_im]; exact ht⟩ : UpperHalfPlane)
 
 /-- Pointwise norm bound for the shifted-Möbius integrand: for `t ≥ 1` it is dominated by
 `(a²+1)·verticalBound r t`. This is the analytic core reused by the integrability goals. -/

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -393,18 +393,8 @@ lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
       C_φ₀ * Real.exp (-2 * π) := by
     intro t ⟨ht_pos, ht_le⟩
     rw [ContourEndpoints.norm_verticalIntegrandX x r t ht_pos]
-    have hI_div_im : (Complex.I / t).im = 1/t := by simp [Complex.div_ofReal_im]
-    have hI_div_pos : 0 < (Complex.I / t).im := by rw [hI_div_im]; positivity
-    have hφ₀_bound : ‖φ₀'' (Complex.I / t)‖ ≤ C_φ₀ * Real.exp (-2 * π / t) := by
-      rw [φ₀''_eq _ hI_div_pos]
-      have hz : UpperHalfPlane.im ⟨Complex.I / t, hI_div_pos⟩ = 1/t := by simp [UpperHalfPlane.im]
-      have hz_gt : 1/2 < 1/t := by
-        have h1 : 1 ≤ 1/t := one_le_one_div ht_pos ht_le
-        linarith
-      calc ‖φ₀ ⟨Complex.I / ↑t, hI_div_pos⟩‖
-        ≤ C_φ₀ * Real.exp (-2 * π * UpperHalfPlane.im ⟨Complex.I / t, hI_div_pos⟩) :=
-            φ₀_bound _ (by rw [hz]; exact hz_gt)
-        _ = C_φ₀ * Real.exp (-2 * π / t) := by rw [hz]; ring_nf
+    have hφ₀_bound : ‖φ₀'' (Complex.I / t)‖ ≤ C_φ₀ * Real.exp (-2 * π / t) :=
+      norm_φ₀_I_div_t_small C_φ₀ C_φ₀_pos φ₀_bound t ⟨ht_pos, by linarith⟩
     have hr_pos : 0 < r := lt_trans (by norm_num : (0:ℝ) < 2) hr
     have ht2_le : t^2 ≤ 1 := by nlinarith [sq_nonneg t, sq_nonneg (t - 1)]
     have hexp_neg : Real.exp (-π * r * t) ≤ 1 := by

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -507,8 +507,7 @@ lemma integrableOn_goal5 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I - 1)) * (t * Complex.I - 1)^2 *
                           Complex.exp (π * Complex.I * r * (t * Complex.I)))
                  (Ioi (1 : ℝ)) volume := by
-  convert integrableOn_shiftedMöbius (-1) r hr using 2
-  simp [sub_eq_add_neg]
+  simpa [sub_eq_add_neg] using integrableOn_shiftedMöbius (-1) r hr
 
 /-- Goal 6: Integrability of I * (φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(-1 + t*I))) on [0,∞).
     By goal6_eq_verticalIntegrandX, this is verticalIntegrandX (-1) r t. -/

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -46,6 +46,19 @@ namespace MagicFunction.VerticalIntegrability
 lemma φ₀''_eq (z : ℂ) (hz : 0 < z.im) : φ₀'' z = φ₀ ⟨z, hz⟩ := by
   simp only [φ₀'', hz, dite_true]
 
+/-- `-1/(I·z) = I/z`. Marked `@[simp]` so the φ₀'' arguments of the goal integrands
+normalize to the `verticalIntegrandX` form automatically. -/
+@[simp]
+lemma neg_one_div_I_mul (z : ℂ) : (-1 : ℂ) / (Complex.I * z) = Complex.I / z := by
+  rw [div_mul_eq_div_div, Complex.div_I]
+  ring
+
+/-- `-1/(z·I) = I/z` (other multiplication order). -/
+@[simp]
+lemma neg_one_div_mul_I (z : ℂ) : (-1 : ℂ) / (z * Complex.I) = Complex.I / z := by
+  rw [mul_comm, div_mul_eq_div_div, Complex.div_I]
+  ring
+
 /-! ## Thesis Bounds (Lemmas 4.4.3, 4.4.4)
 
 These bounds are the key to proving convergence of the integral in Definition 4.4.2.
@@ -357,8 +370,7 @@ lemma goal1_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
       Complex.exp (Complex.I * π * r * (Complex.I * t)) =
     ContourEndpoints.verticalIntegrandX 0 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [(show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
-  simp only [Complex.ofReal_zero, zero_add]
+  simp only [neg_one_div_I_mul, Complex.ofReal_zero, zero_add]
 
 /-- Goal 2 integrand equals -I * verticalIntegrandX (-1) r t.
 
@@ -369,9 +381,7 @@ lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX (-1) r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I,
-    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
-  simp only [mul_pow, Complex.ofReal_neg, Complex.ofReal_one, neg_mul]
+  simp only [neg_one_div_mul_I, mul_pow, Complex.ofReal_neg, Complex.ofReal_one, neg_mul]
   conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
   ring_nf
 
@@ -383,9 +393,7 @@ lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX 1 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I,
-    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
-  simp only [mul_pow, Complex.ofReal_one, neg_mul]
+  simp only [neg_one_div_mul_I, mul_pow, Complex.ofReal_one, neg_mul]
   conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
   ring_nf
 
@@ -398,8 +406,7 @@ lemma goal6_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX (-1) r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I,
-    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
+  simp only [neg_one_div_mul_I]
   ring_nf
   simp [pow_two]
 
@@ -412,8 +419,7 @@ lemma goal7_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX 1 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I,
-    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
+  simp only [neg_one_div_mul_I]
   ring_nf
   simp [pow_two]
 
@@ -436,8 +442,7 @@ lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
     have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (Complex.I / t)) (Ioi 0) := by
       have h1 := continuousOn_φ₀''_cusp_path
       refine h1.congr fun t ht =>
-        congrArg φ₀'' (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by
-          simp [div_mul_eq_div_div, Complex.div_I]).symm
+        congrArg φ₀'' (neg_one_div_I_mul (t : ℂ)).symm
     refine ((continuousOn_const.mul h_cont_phi).mul ?_).mul ?_
     · exact (continuousOn_const.mul Complex.continuous_ofReal.continuousOn).pow _
     · refine Complex.continuous_exp.comp_continuousOn ?_

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -91,33 +91,12 @@ lemma norm_φ₀_I_div_t_small (C₀ : ℝ) (_hC₀ : 0 < C₀)
     Proof: For t ≤ 4π, we have t² ≤ 4πt ≤ exp(4πt).
     For t > 4π, exp grows much faster than any polynomial. -/
 lemma sq_le_exp_4pi_t (t : ℝ) (ht : 2 ≤ t) : t^2 ≤ Real.exp (4 * π * t) := by
-  have hπ := Real.pi_pos
+  -- exp(4πt) ≥ 1 + 4πt + (4πt)²/2 = 1 + 4πt + 8π²t² ≥ t², uniformly (8π² > 1 since π > 3)
   have ht_pos : 0 < t := by linarith
-  have hx_le : 4 * π * t ≤ Real.exp (4 * π * t) := by
-    have h := Real.add_one_le_exp (4 * π * t); linarith
-  by_cases ht4π : t ≤ 4 * π
-  · -- Case t ≤ 4π: t² ≤ 4πt ≤ exp(4πt)
-    have ht2_le_4πt : t^2 ≤ 4 * π * t := by nlinarith
-    linarith
-  · -- Case t > 4π: exp(4πt) is astronomically larger than t²
-    -- Use Taylor: exp(x) ≥ x²/2 for x > 0, proven via exp(x) ≥ 1 + x + x²/2
-    -- This gives exp(4πt) ≥ (4πt)²/2 = 8π²t² > t²
-    rw [not_le] at ht4π
-    have h4πt_pos : 0 ≤ 4 * π * t := by positivity
-    have hquad := Real.quadratic_le_exp_of_nonneg h4πt_pos
-    -- exp(4πt) ≥ 1 + 4πt + (4πt)²/2 ≥ (4πt)²/2 = 8π²t²
-    -- 8π² > 8 * 9 = 72 > 1 since π > 3
-    have h8π2 : 8 * π^2 > 1 := by
-      have hπ3 : π > 3 := Real.pi_gt_three
-      nlinarith
-    have hcalc : t^2 < Real.exp (4 * π * t) := calc t^2
-        _ < 8 * π^2 * t^2 := by
-            have ht2_pos : 0 < t^2 := by positivity
-            nlinarith
-        _ = (4 * π * t)^2 / 2 := by ring
-        _ ≤ 1 + 4 * π * t + (4 * π * t)^2 / 2 := by linarith [h4πt_pos]
-        _ ≤ Real.exp (4 * π * t) := hquad
-    exact hcalc.le
+  have h4πt_pos : 0 ≤ 4 * π * t := by positivity
+  have hquad := Real.quadratic_le_exp_of_nonneg h4πt_pos
+  have h8π2 : 8 * π ^ 2 > 1 := by nlinarith [Real.pi_gt_three]
+  nlinarith [hquad, h8π2, sq_nonneg t, h4πt_pos]
 
 /-- Helper: exp(-2πt) ≤ (1/t²) * exp(2πt) for t ≥ 2. Used in Thesis Lemma 4.4.4. -/
 lemma exp_neg_le_inv_sq_exp (t : ℝ) (ht : 2 ≤ t) :

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -34,13 +34,17 @@ integrability results needed for Proposition 4.4.6 (the double zeros proof).
 @[expose] public section
 
 open MeasureTheory Set Filter Real Complex TopologicalSpace
-open MagicFunction.a
+open MagicFunction.a MagicFunction.a.ComplexIntegrands
 
 open scoped Interval Real NNReal ENNReal Topology BigOperators
 
 noncomputable section
 
 namespace MagicFunction.VerticalIntegrability
+
+/-- Unfold φ₀'' to φ₀ when the imaginary part is positive. -/
+lemma φ₀''_eq (z : ℂ) (hz : 0 < z.im) : φ₀'' z = φ₀ ⟨z, hz⟩ := by
+  simp only [φ₀'', hz, dite_true]
 
 /-! ## Thesis Bounds (Lemmas 4.4.3, 4.4.4)
 
@@ -85,7 +89,7 @@ lemma sq_le_exp_4pi_t (t : ℝ) (ht : 2 ≤ t) : t^2 ≤ Real.exp (4 * π * t) :
   · -- Case t > 4π: exp(4πt) is astronomically larger than t²
     -- Use Taylor: exp(x) ≥ x²/2 for x > 0, proven via exp(x) ≥ 1 + x + x²/2
     -- This gives exp(4πt) ≥ (4πt)²/2 = 8π²t² > t²
-    push_neg at ht4π
+    rw [not_le] at ht4π
     have h4πt_pos : 0 ≤ 4 * π * t := by positivity
     have hquad := Real.quadratic_le_exp_of_nonneg h4πt_pos
     -- exp(4πt) ≥ 1 + 4πt + (4πt)²/2 ≥ (4πt)²/2 = 8π²t²
@@ -251,7 +255,8 @@ lemma integrableOn_φ₀_shifted_Möbius (a b r : ℝ) (hr : 2 < r) :
     let path : {s : ℝ // 0 < s} → UpperHalfPlane := fun s =>
       ⟨-1 / (a + Complex.I * s), h_im_pos s s.2⟩
     have h_path_cont : Continuous path := by
-      refine Continuous.subtype_mk ?_ _
+      simp only [path]
+      refine Continuous.upperHalfPlaneMk ?_ _
       apply Continuous.div continuous_const
       · exact continuous_const.add
           (continuous_const.mul (Complex.continuous_ofReal.comp continuous_subtype_val))
@@ -354,24 +359,25 @@ lemma I_mul_t_sq (t : ℝ) : (Complex.I * t : ℂ)^2 = -(t^2) := by
   simp [mul_pow, Complex.I_sq, ← Complex.ofReal_neg, ← Complex.ofReal_pow]
 
 /-- Goal 1 integrand equals verticalIntegrandX 0 r t. -/
-lemma goal1_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+lemma goal1_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
     Complex.I * φ₀'' (-1 / (Complex.I * t)) * (Complex.I * t)^2 *
       Complex.exp (Complex.I * π * r * (Complex.I * t)) =
     ContourEndpoints.verticalIntegrandX 0 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [neg_one_div_I_mul t ht]
+  rw [(show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
   simp only [Complex.ofReal_zero, zero_add]
 
 /-- Goal 2 integrand equals -I * verticalIntegrandX (-1) r t.
 
 Proof sketch: Both sides reduce to φ₀''(I/t) * (-t²) * cexp(I*π*r*(-1 + I*t))
 after using -1/(I*t) = I/t and (I*t)² = -t². -/
-lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
     φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX (-1) r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  rw [mul_comm (t : ℂ) Complex.I,
+    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
   simp only [mul_pow, Complex.ofReal_neg, Complex.ofReal_one, neg_mul]
   conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
   ring_nf
@@ -379,12 +385,13 @@ lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
 /-- Goal 4 integrand equals -I * verticalIntegrandX 1 r t.
 
 Proof sketch: Same as Goal 2 but with +1 in the exponential phase. -/
-lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
     φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX 1 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  rw [mul_comm (t : ℂ) Complex.I,
+    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
   simp only [mul_pow, Complex.ofReal_one, neg_mul]
   conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
   ring_nf
@@ -393,12 +400,13 @@ lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
 
 Proof sketch: Goal 6 = I * Goal 2 = I * (-I) * verticalIntegrandX (-1) r t
 = verticalIntegrandX (-1) r t since I * (-I) = 1. -/
-lemma goal6_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+lemma goal6_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
     Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX (-1) r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  rw [mul_comm (t : ℂ) Complex.I,
+    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
   ring_nf
   simp [pow_two]
 
@@ -406,12 +414,13 @@ lemma goal6_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
 
 Proof sketch: Goal 7 = I * Goal 4 = I * (-I) * verticalIntegrandX 1 r t
 = verticalIntegrandX 1 r t since I * (-I) = 1. -/
-lemma goal7_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+lemma goal7_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
     Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX 1 r t := by
   unfold ContourEndpoints.verticalIntegrandX
-  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  rw [mul_comm (t : ℂ) Complex.I,
+    (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by simp [div_mul_eq_div_div, Complex.div_I])]
   ring_nf
   simp [pow_two]
 
@@ -434,7 +443,8 @@ lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
     have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (Complex.I / t)) (Ioi 0) := by
       have h1 := continuousOn_φ₀''_cusp_path
       refine h1.congr fun t ht =>
-        congrArg φ₀'' (neg_one_div_I_mul t (ne_of_gt (mem_Ioi.mp ht))).symm
+        congrArg φ₀'' (show (-1 : ℂ) / (I * (t : ℂ)) = I / (t : ℂ) by
+          simp [div_mul_eq_div_div, Complex.div_I]).symm
     refine ((continuousOn_const.mul h_cont_phi).mul ?_).mul ?_
     · exact (continuousOn_const.mul Complex.continuous_ofReal.continuousOn).pow _
     · refine Complex.continuous_exp.comp_continuousOn ?_

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -132,12 +132,7 @@ lemma exp_neg_le_inv_sq_exp (t : ℝ) (ht : 2 ≤ t) :
 
 /-- Helper: t ≤ exp(2πt) for t ≥ 0. Used for 1/t ≤ (1/t²) * exp(2πt). -/
 lemma t_le_exp_two_pi_t (t : ℝ) (ht : 0 ≤ t) : t ≤ Real.exp (2 * π * t) := by
-  have hπ := Real.pi_pos
-  have h := Real.add_one_le_exp (2 * π * t)
-  have h2πminus1 : 1 ≤ 2 * π - 1 := by linarith [Real.pi_gt_three]
-  calc t ≤ t + 1 := le_add_of_nonneg_right (by linarith)
-    _ ≤ 2 * π * t + 1 := by nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 2 * π - 1) ht]
-    _ ≤ Real.exp (2 * π * t) := h
+  nlinarith [Real.add_one_le_exp (2 * π * t), Real.pi_gt_three]
 
 /-- Thesis Lemma 4.4.4 (Blueprint Cor 7.13): For large t ≥ 2, φ₀(i/t) grows at most
     like t⁻² e^{2πt}. Uses the S-transform formula (4.1.5) and bounds from Cor 7.5-7.7.

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -56,8 +56,8 @@ lemma neg_one_div_I_mul (z : ℂ) : (-1 : ℂ) / (Complex.I * z) = Complex.I / z
 /-- `-1/(z·I) = I/z` (other multiplication order). -/
 @[simp]
 lemma neg_one_div_mul_I (z : ℂ) : (-1 : ℂ) / (z * Complex.I) = Complex.I / z := by
-  rw [mul_comm, div_mul_eq_div_div, Complex.div_I]
-  ring
+  rw [mul_comm z Complex.I]
+  exact neg_one_div_I_mul z
 
 /-! ## Thesis Bounds (Lemmas 4.4.3, 4.4.4)
 

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -1,0 +1,625 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+module
+
+public import SpherePacking.MagicFunction.a.ContourEndpoints
+public import SpherePacking.ModularForms.PhiTransform
+public import Mathlib.Analysis.Real.Pi.Bounds
+
+/-!
+# Vertical Contour Integrability
+
+Integrability lemmas for vertical ray integrands involving φ₀.
+Provides bounds from Lemmas 4.4.3-4.4.4 of Sidharth Hariharan's thesis and general
+integrability results needed for Proposition 4.4.6 (the double zeros proof).
+
+## Main results
+
+### Thesis Bounds (Section 4.4.1)
+- `norm_φ₀_I_div_t_small`: Lemma 4.4.3 - For t ∈ (0, 2), |φ₀(i/t)| ≤ C₀ e^{-2π/t}
+- `norm_φ₀_I_div_t_large`: Lemma 4.4.4 - For t ≥ 2, |φ₀(i/t)| ≤ C t⁻² e^{2πt}
+
+### Integrability Goals (Proposition 4.4.6)
+- `integrableOn_goal1` through `integrableOn_goal7`: Seven specific integrands
+
+## References
+
+- Sid's M4R Thesis, Section 4.4.1 (Proposition 4.4.6)
+- Blueprint Corollaries 7.5-7.7, 7.13
+-/
+
+@[expose] public section
+
+open MeasureTheory Set Filter Real Complex TopologicalSpace
+open MagicFunction.a
+
+open scoped Interval Real NNReal ENNReal Topology BigOperators
+
+noncomputable section
+
+namespace MagicFunction.VerticalIntegrability
+
+/-! ## Thesis Bounds (Lemmas 4.4.3, 4.4.4)
+
+These bounds are the key to proving convergence of the integral in Definition 4.4.2.
+-/
+
+/-- Lemma 4.4.3: For small t ∈ (0, 2), φ₀(i/t) has super-exponential decay.
+    This follows from the cusp bound (4.2.1) with z = i/t. -/
+lemma norm_φ₀_I_div_t_small (C₀ : ℝ) (_hC₀ : 0 < C₀)
+    (hbound : ∀ z : UpperHalfPlane, 1/2 < z.im → ‖φ₀ z‖ ≤ C₀ * Real.exp (-2 * π * z.im)) :
+    ∀ t ∈ Ioo (0 : ℝ) 2, ‖φ₀'' (Complex.I / t)‖ ≤ C₀ * Real.exp (-2 * π / t) := by
+  intro t ⟨ht_pos, ht_lt⟩
+  -- i/t has imaginary part 1/t > 1/2 for t < 2
+  have hI_div_pos : 0 < (Complex.I / t).im := by simp [Complex.div_ofReal_im]; positivity
+  have hI_div_gt : 1/2 < (Complex.I / t).im := by
+    simp only [Complex.div_ofReal_im, Complex.I_im]
+    rw [one_div_lt_one_div (by norm_num : (0:ℝ) < 2) ht_pos]
+    linarith
+  -- φ₀'' equals φ₀ on upper half-plane, apply the bound
+  rw [φ₀''_eq _ hI_div_pos]
+  have h := hbound ⟨Complex.I / t, hI_div_pos⟩ hI_div_gt
+  -- The bound hbound gives us the inequality for z.im = 1/t
+  -- UpperHalfPlane.im ⟨I/t, _⟩ = (I/t).im = 1/t
+  have him : UpperHalfPlane.im ⟨Complex.I / t, hI_div_pos⟩ = 1/t := by
+    simp [UpperHalfPlane.im]
+  simp only [him] at h
+  convert h using 2
+  field_simp
+
+/-- Helper: t² ≤ exp(4πt) for t ≥ 2. Used in Thesis Lemma 4.4.4.
+    Proof: For t ≤ 4π, we have t² ≤ 4πt ≤ exp(4πt).
+    For t > 4π, exp grows much faster than any polynomial. -/
+lemma sq_le_exp_4pi_t (t : ℝ) (ht : 2 ≤ t) : t^2 ≤ Real.exp (4 * π * t) := by
+  have hπ := Real.pi_pos
+  have ht_pos : 0 < t := by linarith
+  have hx_le : 4 * π * t ≤ Real.exp (4 * π * t) := by
+    have h := Real.add_one_le_exp (4 * π * t); linarith
+  by_cases ht4π : t ≤ 4 * π
+  · -- Case t ≤ 4π: t² ≤ 4πt ≤ exp(4πt)
+    have ht2_le_4πt : t^2 ≤ 4 * π * t := by nlinarith
+    linarith
+  · -- Case t > 4π: exp(4πt) is astronomically larger than t²
+    -- Use Taylor: exp(x) ≥ x²/2 for x > 0, proven via exp(x) ≥ 1 + x + x²/2
+    -- This gives exp(4πt) ≥ (4πt)²/2 = 8π²t² > t²
+    push_neg at ht4π
+    have h4πt_pos : 0 ≤ 4 * π * t := by positivity
+    have hquad := Real.quadratic_le_exp_of_nonneg h4πt_pos
+    -- exp(4πt) ≥ 1 + 4πt + (4πt)²/2 ≥ (4πt)²/2 = 8π²t²
+    -- 8π² > 8 * 9 = 72 > 1 since π > 3
+    have h8π2 : 8 * π^2 > 1 := by
+      have hπ3 : π > 3 := Real.pi_gt_three
+      nlinarith
+    have hcalc : t^2 < Real.exp (4 * π * t) := calc t^2
+        _ < 8 * π^2 * t^2 := by
+            have ht2_pos : 0 < t^2 := by positivity
+            nlinarith
+        _ = (4 * π * t)^2 / 2 := by ring
+        _ ≤ 1 + 4 * π * t + (4 * π * t)^2 / 2 := by linarith [h4πt_pos]
+        _ ≤ Real.exp (4 * π * t) := hquad
+    exact hcalc.le
+
+/-- Helper: exp(-2πt) ≤ (1/t²) * exp(2πt) for t ≥ 2. Used in Thesis Lemma 4.4.4. -/
+lemma exp_neg_le_inv_sq_exp (t : ℝ) (ht : 2 ≤ t) :
+    Real.exp (-2 * π * t) ≤ (1 / t^2) * Real.exp (2 * π * t) := by
+  have ht_pos : 0 < t := by linarith
+  have ht2_le_exp := sq_le_exp_4pi_t t ht
+  calc Real.exp (-2 * π * t) = Real.exp (2 * π * t) / Real.exp (4 * π * t) := by
+          rw [← Real.exp_sub]; ring_nf
+    _ ≤ Real.exp (2 * π * t) / t^2 := by
+        apply div_le_div_of_nonneg_left (le_of_lt (Real.exp_pos _)) (by positivity) ht2_le_exp
+    _ = (1 / t^2) * Real.exp (2 * π * t) := by rw [one_div, div_eq_mul_inv, mul_comm]
+
+/-- Helper: t ≤ exp(2πt) for t ≥ 0. Used for 1/t ≤ (1/t²) * exp(2πt). -/
+lemma t_le_exp_two_pi_t (t : ℝ) (ht : 0 ≤ t) : t ≤ Real.exp (2 * π * t) := by
+  have hπ := Real.pi_pos
+  have h := Real.add_one_le_exp (2 * π * t)
+  have h2πminus1 : 1 ≤ 2 * π - 1 := by linarith [Real.pi_gt_three]
+  calc t ≤ t + 1 := le_add_of_nonneg_right (by linarith)
+    _ ≤ 2 * π * t + 1 := by nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 2 * π - 1) ht]
+    _ ≤ Real.exp (2 * π * t) := h
+
+/-- Thesis Lemma 4.4.4 (Blueprint Cor 7.13): For large t ≥ 2, φ₀(i/t) grows at most
+    like t⁻² e^{2πt}. Uses the S-transform formula (4.1.5) and bounds from Cor 7.5-7.7.
+
+    Strategy: The three-term bound from norm_φ₀''_I_div_t_le can each be bounded by
+    (constant) * t^(-2) * exp(2πt), which gives an overall bound of this form. -/
+lemma norm_φ₀_I_div_t_large :
+    ∀ t : ℝ, 2 ≤ t → ‖φ₀'' (Complex.I / t)‖ ≤
+      (C_φ₀ + 12 * C_φ₂' / π + 36 * C_φ₄' / π ^ 2) *
+        t ^ (-2 : ℤ) * Real.exp (2 * π * t) := by
+  intro t ht
+  have ht_pos : 0 < t := by linarith
+  have ht_ge_1 : 1 ≤ t := by linarith
+  -- Use the existing Blueprint Corollary 7.13 bound from ContourEndpoints
+  have h := ContourEndpoints.norm_φ₀''_I_div_t_le t ht_ge_1
+  -- Each of the three terms can be bounded by its coefficient * t^(-2) * exp(2πt)
+  -- Key inequalities:
+  -- (1) exp(-2πt) ≤ t^(-2) * exp(2πt)  [since t² ≤ exp(4πt) for t ≥ 2]
+  -- (2) 1/t ≤ t^(-2) * exp(2πt)  [since t ≤ exp(2πt)]
+  -- (3) 1/t² * exp(2πt) = t^(-2) * exp(2πt)  [exact equality]
+  have hπ := Real.pi_pos
+  have hexp_pos := Real.exp_pos (2 * π * t)
+  -- Rewrite t^(-2 : ℤ) as 1/t²
+  have hpow : t ^ (-2 : ℤ) = 1 / t^2 := by
+    rw [zpow_neg, zpow_ofNat]
+    field_simp
+  rw [hpow]
+  -- Bound term 1: C₀ * exp(-2πt) ≤ C₀ * (1/t²) * exp(2πt)
+  have h1 : C_φ₀ * Real.exp (-2 * π * t) ≤
+      C_φ₀ * (1 / t^2) * Real.exp (2 * π * t) := by
+    have hexp_bound := exp_neg_le_inv_sq_exp t ht
+    calc C_φ₀ * Real.exp (-2 * π * t)
+        ≤ C_φ₀ * ((1 / t^2) * Real.exp (2 * π * t)) :=
+            mul_le_mul_of_nonneg_left hexp_bound C_φ₀_pos.le
+      _ = C_φ₀ * (1 / t^2) * Real.exp (2 * π * t) := by ring
+  -- Bound term 2: (12/(πt)) * C₂ ≤ (12*C₂/π) * (1/t²) * exp(2πt)
+  -- Need: 1/t ≤ (1/t²) * exp(2πt), i.e., t ≤ exp(2πt)
+  have h2 : (12 / (π * t)) * C_φ₂' ≤
+      (12 * C_φ₂' / π) * (1 / t^2) * Real.exp (2 * π * t) := by
+    have ht_le_exp := t_le_exp_two_pi_t t (by linarith)
+    -- 1/t ≤ (1/t²) * exp(2πt) is equivalent to t ≤ exp(2πt) (after multiplying by t² and dividing)
+    have h_t_inv : 1 / t ≤ (1 / t^2) * Real.exp (2 * π * t) := by
+      have ht2_pos : 0 < t^2 := sq_pos_of_pos ht_pos
+      have ht2_nonneg : 0 ≤ t^2 := ht2_pos.le
+      -- 1/t ≤ exp(2πt)/t² is equivalent to t ≤ exp(2πt)
+      have hexp_ge_t : t ≤ Real.exp (2 * π * t) := ht_le_exp
+      -- Simplify: 1/t = t/t² and exp/t² ≥ t/t² iff exp ≥ t
+      calc 1 / t = t / t^2 := by field_simp
+        _ ≤ Real.exp (2 * π * t) / t^2 := div_le_div_of_nonneg_right hexp_ge_t ht2_nonneg
+        _ = (1 / t^2) * Real.exp (2 * π * t) := by ring
+    calc (12 / (π * t)) * C_φ₂'
+        = 12 * C_φ₂' / π * (1 / t) := by field_simp
+      _ ≤ 12 * C_φ₂' / π * ((1 / t^2) * Real.exp (2 * π * t)) := by
+          apply mul_le_mul_of_nonneg_left h_t_inv
+          apply div_nonneg (by nlinarith [C_φ₂'_pos.le]) hπ.le
+      _ = (12 * C_φ₂' / π) * (1 / t^2) * Real.exp (2 * π * t) := by ring
+  -- Bound term 3: (36/(π²*t²)) * C₄ * exp(2πt) = (36*C₄/π²) * (1/t²) * exp(2πt)  [exact]
+  have h3 : (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t) =
+            (36 * C_φ₄' / π^2) * (1 / t^2) * Real.exp (2 * π * t) := by
+    field_simp
+  -- Combine the bounds
+  calc ‖φ₀'' (Complex.I / t)‖
+      ≤ C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂' +
+        (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t) := h
+    _ ≤ C_φ₀ * (1 / t^2) * Real.exp (2 * π * t) +
+        (12 * C_φ₂' / π) * (1 / t^2) * Real.exp (2 * π * t) +
+        (36 * C_φ₄' / π^2) * (1 / t^2) * Real.exp (2 * π * t) := by linarith [h1, h2, h3.le]
+    _ = (C_φ₀ + 12 * C_φ₂' / π + 36 * C_φ₄' / π^2) *
+        (1 / t^2) * Real.exp (2 * π * t) := by ring
+
+/-! ## General Shifted Möbius Integrability
+
+A unified lemma that handles all six integrability goals via parameter instantiation.
+Uses φ₀''_neg_inv_eq_φ₀_S_smul + norm_φ₀_S_smul_le infrastructure from ContourEndpoints.
+-/
+
+/-- For z = a + I*t with t > 0, we have Im(-1/z) = t/(a² + t²) > 0.
+    This ensures the Möbius-transformed argument stays in the upper half-plane. -/
+lemma im_neg_inv_pos (a t : ℝ) (ht : 0 < t) :
+    0 < ((-1 : ℂ) / (a + Complex.I * t)).im := by
+  -- Im(-1/(a + I*t)) = t/(a² + t²) > 0 since t > 0 and a² + t² > 0
+  have h_denom : a^2 + t^2 > 0 := by positivity
+  have h_normSq : Complex.normSq (↑a + Complex.I * ↑t) = a^2 + t^2 := by
+    rw [mul_comm]; exact Complex.normSq_add_mul_I a t
+  -- Use div_im: (z / w).im = z.im * w.re / normSq w - z.re * w.im / normSq w
+  rw [Complex.div_im, h_normSq]
+  -- For z = -1: z.re = -1, z.im = 0; For w = a + I*t: w.re = a, w.im = t
+  simp only [Complex.neg_im, Complex.one_im, neg_zero, Complex.neg_re, Complex.one_re,
+    Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.ofReal_im,
+    mul_zero, Complex.I_im, sub_zero, Complex.add_im, Complex.mul_im, zero_mul, add_zero]
+  -- Goal: 0 * a / (a² + t²) - (-1) * t / (a² + t²) = t / (a² + t²)
+  ring_nf
+  exact div_pos ht h_denom
+
+/-- General integrability for φ₀''(-1/(a + I*t)) * (a + I*t)² * cexp(I*π*r*(b + I*t)) on Ioi 1.
+
+    This unified lemma covers all six integrability goals from Proposition 4.4.6:
+    - Goals 1, 2, 4, 6: Use a = 0 (Category A, reduces to verticalIntegrandX)
+    - Goals 3, 5: Use a = ±1 (Category B, shifted Möbius)
+
+    The proof uses:
+    1. φ₀''_neg_inv_eq_φ₀_S_smul: φ₀''(-1/z) = φ₀(S•w) for suitable w ∈ ℍ
+    2. norm_φ₀_S_smul_le: |φ₀(S•z)| ≤ C₀ exp(-2π·im(S•z)) for im(z) ≥ 1
+    3. Exponential decay for r > 2 dominates polynomial growth -/
+lemma integrableOn_φ₀_shifted_Möbius (a b r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / ((a : ℂ) + Complex.I * t)) *
+      ((a : ℂ) + Complex.I * t)^2 *
+      Complex.exp (Complex.I * π * r * ((b : ℂ) + Complex.I * t)))
+                 (Ioi 1) volume := by
+  -- Strategy: Bound by C * verticalBound r t where C = a² + 1
+  -- Key steps:
+  -- 1. For t > 1, z = a + I*t has Im(z) = t > 1
+  -- 2. Apply φ₀''_neg_inv_eq_φ₀_S_smul to get φ₀(S•w)
+  -- 3. Use norm_φ₀_S_smul_le to bound the φ₀ term (uses ‖z‖ ≥ t)
+  -- 4. |z²| = a² + t² ≤ (a² + 1) * t² for t ≥ 1
+  -- 5. |exp(...)| = exp(-πrt) independent of b
+  -- 6. Combined bound ≤ (a² + 1) * verticalBound
+  have hbound_integ : IntegrableOn (fun t => (a^2 + 1) * ContourEndpoints.verticalBound r t)
+      (Ioi 1) volume := by
+    refine IntegrableOn.mono_set ?_ (Ioi_subset_Ici_self (a := 1))
+    exact (ContourEndpoints.integrableOn_verticalBound r hr).const_mul (a^2 + 1)
+  apply MeasureTheory.Integrable.mono' hbound_integ
+  · -- AEStronglyMeasurable: The integrand is continuous on Ioi 1
+    -- For t > 0, Im(a + I*t) = t > 0 so -1/(a+I*t) stays in the upper half plane
+    have h_im_pos : ∀ t : ℝ, 0 < t → 0 < ((-1 : ℂ) / (a + Complex.I * t)).im :=
+      fun t ht => im_neg_inv_pos a t ht
+    -- The path factorizes through UpperHalfPlane via φ₀_continuous
+    let path : {s : ℝ // 0 < s} → UpperHalfPlane := fun s =>
+      ⟨-1 / (a + Complex.I * s), h_im_pos s s.2⟩
+    have h_path_cont : Continuous path := by
+      refine Continuous.subtype_mk ?_ _
+      apply Continuous.div continuous_const
+      · exact continuous_const.add
+          (continuous_const.mul (Complex.continuous_ofReal.comp continuous_subtype_val))
+      · intro ⟨s, hs⟩; exact fun h => (ne_of_gt hs) (by simpa using congrArg Complex.im h)
+    have h_comp_cont : Continuous (φ₀ ∘ path) := φ₀_continuous.comp h_path_cont
+    have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (-1 / (a + Complex.I * t))) (Ioi 0) := by
+      intro t ht
+      rw [Set.mem_Ioi] at ht
+      have h_eq : φ₀'' (-1 / (a + Complex.I * t)) = φ₀ (path ⟨t, ht⟩) := by
+        rw [φ₀''_eq _ (h_im_pos t ht)]
+      rw [ContinuousWithinAt, h_eq]
+      have h_at : ContinuousAt (φ₀ ∘ path) ⟨t, ht⟩ := h_comp_cont.continuousAt
+      have h_map_eq : Filter.map (Subtype.val : {s : ℝ // 0 < s} → ℝ) (nhds ⟨t, ht⟩) =
+          nhdsWithin t (Set.Ioi 0) := by convert map_nhds_subtype_val ⟨t, ht⟩
+      rw [← h_map_eq, Filter.tendsto_map'_iff]
+      convert h_at.tendsto using 1
+      funext x
+      simp only [Function.comp_apply, φ₀''_eq _ (h_im_pos x.val x.prop), path]
+    have h_cont : ContinuousOn (fun t : ℝ => φ₀'' (-1 / (a + Complex.I * t)) *
+        (a + Complex.I * t)^2 * Complex.exp (Complex.I * π * r * (b + Complex.I * t))) (Ioi 1) := by
+      refine (h_cont_phi.mono (Ioi_subset_Ioi (by linarith : (0:ℝ) ≤ 1))).mul ?_ |>.mul ?_
+      · exact (continuousOn_const.add
+          (continuousOn_const.mul Complex.continuous_ofReal.continuousOn)).pow _
+      · refine Complex.continuous_exp.comp_continuousOn ?_
+        exact (continuousOn_const.mul continuousOn_const).mul
+          (continuousOn_const.add
+            (continuousOn_const.mul Complex.continuous_ofReal.continuousOn))
+    exact h_cont.aestronglyMeasurable measurableSet_Ioi
+  · -- Norm bound: ‖integrand‖ ≤ (a² + 1) * verticalBound hb r t a.e.
+    rw [ae_restrict_iff' measurableSet_Ioi]
+    apply ae_of_all
+    intro t ht
+    simp only [mem_Ioi] at ht
+    have ht_ge_1 : 1 ≤ t := le_of_lt ht
+    have ht_pos : 0 < t := lt_of_lt_of_le one_pos ht_ge_1
+    -- Use the S-transform bound
+    let z : ℂ := a + Complex.I * t
+    have hz_im : z.im = t := by simp [z]
+    have hz_im_pos : 0 < z.im := by rw [hz_im]; exact ht_pos
+    let w : UpperHalfPlane := ⟨z, hz_im_pos⟩
+    have hw_im : w.im = t := hz_im
+    have hw_im_ge : 1 ≤ w.im := by rw [hw_im]; exact ht_ge_1
+    -- Step 1: φ₀''(-1/z) = φ₀(S•w)
+    have hφ₀_eq : φ₀'' (-1 / z) = φ₀ (ModularGroup.S • w) :=
+      ContourEndpoints.φ₀''_neg_inv_eq_φ₀_S_smul a t ht_pos
+    -- Step 2: Get the S-transform bound
+    have hS_bound := ContourEndpoints.norm_φ₀_S_smul_le w hw_im_ge
+    -- Step 3: Bound ‖z²‖ ≤ (a² + 1) * t² for t ≥ 1
+    have hz_sq_bound : ‖z^2‖ ≤ (a^2 + 1) * t^2 := by
+      simp only [z, norm_pow, ← Complex.normSq_eq_norm_sq, mul_comm Complex.I,
+        Complex.normSq_add_mul_I]
+      nlinarith [sq_nonneg a, sq_nonneg (t - 1), sq_nonneg (a * (t - 1))]
+    -- Step 4: Exponential norm
+    have hexp_norm : ‖Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖ =
+        Real.exp (-π * r * t) := ContourEndpoints.norm_cexp_verticalPhase b r t
+    -- Step 5: Combine bounds
+    calc ‖φ₀'' (-1 / z) * z^2 * Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖
+        = ‖φ₀'' (-1 / z)‖ * ‖z^2‖ * Real.exp (-π * r * t) := by
+          rw [norm_mul, norm_mul, hexp_norm]
+      _ ≤ ‖φ₀'' (-1 / z)‖ * ((a^2 + 1) * t^2) * Real.exp (-π * r * t) := by
+          apply mul_le_mul_of_nonneg_right
+          · apply mul_le_mul_of_nonneg_left hz_sq_bound (norm_nonneg _)
+          · exact (Real.exp_pos _).le
+      _ = (a^2 + 1) * (‖φ₀'' (-1 / z)‖ * t^2 * Real.exp (-π * r * t)) := by ring
+      _ = (a^2 + 1) * (‖φ₀ (ModularGroup.S • w)‖ * t^2 * Real.exp (-π * r * t)) := by
+          rw [hφ₀_eq]
+      _ ≤ (a^2 + 1) * (ContourEndpoints.verticalBound r t) := by
+          apply mul_le_mul_of_nonneg_left _ (by nlinarith)
+          -- Show ‖φ₀(S•w)‖ * t² * exp(-πrt) ≤ verticalBound using ‖w‖ ≥ t
+          -- Strategy: Use hS_bound with ‖w‖ ≥ t to replace 1/‖w‖ terms with 1/t
+          have hw_norm_ge : t ≤ ‖(w : ℂ)‖ := by
+            simpa [hw_im, abs_of_pos ht_pos] using abs_im_le_norm (w : ℂ)
+          -- Strengthen hS_bound using ‖w‖ ≥ t
+          have hS_bound' : ‖φ₀ (ModularGroup.S • w)‖ ≤
+              C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
+              + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t) := by
+            rw [hw_im] at hS_bound
+            refine hS_bound.trans ?_
+            gcongr <;> [exact C_φ₂'_pos.le; exact C_φ₄'_pos.le]
+          -- Multiply by t² * exp(-πrt) and simplify to verticalBound
+          calc ‖φ₀ (ModularGroup.S • w)‖ * t^2 * Real.exp (-π * r * t)
+              ≤ (C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
+                  + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t))
+                * t^2 * Real.exp (-π * r * t) := by gcongr
+            _ = C_φ₀ * t^2 * (Real.exp (-2 * π * t) * Real.exp (-π * r * t))
+                + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
+                + (36 * C_φ₄' / π^2) * (Real.exp (2 * π * t) * Real.exp (-π * r * t)) := by
+                  field_simp
+            _ = ContourEndpoints.verticalBound r t := by
+                  simp only [ContourEndpoints.verticalBound, ← Real.exp_add]; ring_nf
+
+/-! ## Relationship to verticalIntegrandX
+
+The Category A goals (1, 2, 4, 6) are scalar multiples of `verticalIntegrandX`.
+-/
+
+/-- Helper: (I*t)² = -t². Useful for clearing I² in integrands. -/
+@[simp]
+lemma I_mul_t_sq (t : ℝ) : (Complex.I * t : ℂ)^2 = -(t^2) := by
+  simp [mul_pow, Complex.I_sq, ← Complex.ofReal_neg, ← Complex.ofReal_pow]
+
+/-- Goal 1 integrand equals verticalIntegrandX 0 r t. -/
+lemma goal1_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+    Complex.I * φ₀'' (-1 / (Complex.I * t)) * (Complex.I * t)^2 *
+      Complex.exp (Complex.I * π * r * (Complex.I * t)) =
+    ContourEndpoints.verticalIntegrandX 0 r t := by
+  unfold ContourEndpoints.verticalIntegrandX
+  rw [neg_one_div_I_mul t ht]
+  simp only [Complex.ofReal_zero, zero_add]
+
+/-- Goal 2 integrand equals -I * verticalIntegrandX (-1) r t.
+
+Proof sketch: Both sides reduce to φ₀''(I/t) * (-t²) * cexp(I*π*r*(-1 + I*t))
+after using -1/(I*t) = I/t and (I*t)² = -t². -/
+lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+    φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+      Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)) =
+    -Complex.I * ContourEndpoints.verticalIntegrandX (-1) r t := by
+  unfold ContourEndpoints.verticalIntegrandX
+  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  simp only [mul_pow, Complex.ofReal_neg, Complex.ofReal_one, neg_mul]
+  conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
+  ring_nf
+
+/-- Goal 4 integrand equals -I * verticalIntegrandX 1 r t.
+
+Proof sketch: Same as Goal 2 but with +1 in the exponential phase. -/
+lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+    φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+      Complex.exp (π * Complex.I * r * (1 + t * Complex.I)) =
+    -Complex.I * ContourEndpoints.verticalIntegrandX 1 r t := by
+  unfold ContourEndpoints.verticalIntegrandX
+  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  simp only [mul_pow, Complex.ofReal_one, neg_mul]
+  conv_rhs => rw [show (I : ℂ) ^ 2 = -1 from Complex.I_sq]
+  ring_nf
+
+/-- Goal 6 integrand equals verticalIntegrandX (-1) r t.
+
+Proof sketch: Goal 6 = I * Goal 2 = I * (-I) * verticalIntegrandX (-1) r t
+= verticalIntegrandX (-1) r t since I * (-I) = 1. -/
+lemma goal6_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+    Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+      Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))) =
+    ContourEndpoints.verticalIntegrandX (-1) r t := by
+  unfold ContourEndpoints.verticalIntegrandX
+  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  ring_nf
+  simp [pow_two]
+
+/-- Goal 7 integrand equals verticalIntegrandX 1 r t.
+
+Proof sketch: Goal 7 = I * Goal 4 = I * (-I) * verticalIntegrandX 1 r t
+= verticalIntegrandX 1 r t since I * (-I) = 1. -/
+lemma goal7_eq_verticalIntegrandX (r t : ℝ) (ht : t ≠ 0) :
+    Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+      Complex.exp (π * Complex.I * r * (1 + t * Complex.I))) =
+    ContourEndpoints.verticalIntegrandX 1 r t := by
+  unfold ContourEndpoints.verticalIntegrandX
+  rw [mul_comm (t : ℂ) Complex.I, neg_one_div_I_mul t ht]
+  ring_nf
+  simp [pow_two]
+
+/-! ## Helper lemmas for integrability proofs -/
+
+/-- Wrapper for integrability on Ioi 1 (avoids repeated mono_set). -/
+lemma integrableOn_verticalIntegrandX_Ioi (x r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t => ContourEndpoints.verticalIntegrandX x r t) (Ioi 1) volume :=
+  (ContourEndpoints.integrableOn_verticalIntegrandX x r hr).mono_set Ioi_subset_Ici_self
+
+/-- Integrability of verticalIntegrandX on Ioc 0 1.
+    For t ∈ (0, 1], Im(I/t) = 1/t ≥ 1, so the cusp bound ‖φ₀(z)‖ ≤ C₀ exp(-2π·Im(z)) applies.
+    Combined with t² ≤ 1 and exp(-πrt) ≤ 1, we get ‖integrand‖ ≤ C₀ exp(-2π). -/
+lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t => ContourEndpoints.verticalIntegrandX x r t) (Ioc 0 1) volume := by
+  -- Continuity on (0, 1] for AEStronglyMeasurable
+  have hcont : ContinuousOn (fun t => ContourEndpoints.verticalIntegrandX x r t) (Ioc 0 1) := by
+    apply ContinuousOn.mono _ (Ioc_subset_Ioi_self)
+    unfold ContourEndpoints.verticalIntegrandX
+    have h_cont_phi : ContinuousOn (fun t : ℝ => φ₀'' (Complex.I / t)) (Ioi 0) := by
+      have h1 := continuousOn_φ₀''_cusp_path
+      refine h1.congr fun t ht =>
+        congrArg φ₀'' (neg_one_div_I_mul t (ne_of_gt (mem_Ioi.mp ht))).symm
+    refine ((continuousOn_const.mul h_cont_phi).mul ?_).mul ?_
+    · exact (continuousOn_const.mul Complex.continuous_ofReal.continuousOn).pow _
+    · refine Complex.continuous_exp.comp_continuousOn ?_
+      refine (continuousOn_const.mul continuousOn_const).mul ?_
+      exact continuousOn_const.add (continuousOn_const.mul Complex.continuous_ofReal.continuousOn)
+  have hmeas : AEStronglyMeasurable (fun t => ContourEndpoints.verticalIntegrandX x r t)
+      (volume.restrict (Ioc 0 1)) := hcont.aestronglyMeasurable measurableSet_Ioc
+  -- Pointwise bound: for t ∈ (0, 1], ‖verticalIntegrandX x r t‖ ≤ C₀ * exp(-2π)
+  have hbound : ∀ t ∈ Ioc 0 1, ‖ContourEndpoints.verticalIntegrandX x r t‖ ≤
+      C_φ₀ * Real.exp (-2 * π) := by
+    intro t ⟨ht_pos, ht_le⟩
+    rw [ContourEndpoints.norm_verticalIntegrandX x r t ht_pos]
+    have hI_div_im : (Complex.I / t).im = 1/t := by simp [Complex.div_ofReal_im]
+    have hI_div_pos : 0 < (Complex.I / t).im := by rw [hI_div_im]; positivity
+    have hφ₀_bound : ‖φ₀'' (Complex.I / t)‖ ≤ C_φ₀ * Real.exp (-2 * π / t) := by
+      rw [φ₀''_eq _ hI_div_pos]
+      have hz : UpperHalfPlane.im ⟨Complex.I / t, hI_div_pos⟩ = 1/t := by simp [UpperHalfPlane.im]
+      have hz_gt : 1/2 < 1/t := by
+        have h1 : 1 ≤ 1/t := one_le_one_div ht_pos ht_le
+        linarith
+      calc ‖φ₀ ⟨Complex.I / ↑t, hI_div_pos⟩‖
+        ≤ C_φ₀ * Real.exp (-2 * π * UpperHalfPlane.im ⟨Complex.I / t, hI_div_pos⟩) :=
+            φ₀_bound _ (by rw [hz]; exact hz_gt)
+        _ = C_φ₀ * Real.exp (-2 * π / t) := by rw [hz]; ring_nf
+    have hr_pos : 0 < r := lt_trans (by norm_num : (0:ℝ) < 2) hr
+    have ht2_le : t^2 ≤ 1 := by nlinarith [sq_nonneg t, sq_nonneg (t - 1)]
+    have hexp_neg : Real.exp (-π * r * t) ≤ 1 := by
+      rw [Real.exp_le_one_iff]; have := mul_pos (mul_pos Real.pi_pos hr_pos) ht_pos; linarith
+    have hexp_bound : Real.exp (-2 * π / t) ≤ Real.exp (-2 * π) := by
+      apply Real.exp_le_exp_of_le
+      have h1t : 1 ≤ 1 / t := by rw [le_div_iff₀ ht_pos]; linarith
+      have hπ := Real.pi_pos
+      have h2πt : 2 * π ≤ 2 * π / t := by
+        calc 2 * π = 2 * π * 1 := by ring
+          _ ≤ 2 * π * (1 / t) := by nlinarith
+          _ = 2 * π / t := by ring
+      have hneg : -(2 * π / t) ≤ -(2 * π) := neg_le_neg h2πt
+      calc -2 * π / t = -(2 * π / t) := by ring
+        _ ≤ -(2 * π) := hneg
+        _ = -2 * π := by ring
+    calc t^2 * ‖φ₀'' (Complex.I / ↑t)‖ * Real.exp (-π * r * t)
+        ≤ 1 * (C_φ₀ * Real.exp (-2 * π / t)) * 1 := by
+          have h1 : t^2 * ‖φ₀'' (Complex.I / ↑t)‖ ≤ 1 * (C_φ₀ * Real.exp (-2 * π / t)) :=
+            mul_le_mul ht2_le hφ₀_bound (norm_nonneg _) zero_le_one
+          have h2 : 0 ≤ 1 * (C_φ₀ * Real.exp (-2 * π / t)) :=
+            mul_nonneg (by norm_num) (mul_nonneg C_φ₀_pos.le (Real.exp_pos _).le)
+          exact mul_le_mul h1 hexp_neg (Real.exp_pos _).le h2
+      _ ≤ C_φ₀ * Real.exp (-2 * π) := by
+          simp only [one_mul, mul_one]
+          exact mul_le_mul_of_nonneg_left hexp_bound C_φ₀_pos.le
+  -- Construct IntegrableOn from AEStronglyMeasurable + bounded + finite measure
+  rw [IntegrableOn, Integrable]
+  refine ⟨hmeas, ?_⟩
+  rw [hasFiniteIntegral_def]
+  have h_bound_ae : ∀ᵐ t ∂(volume.restrict (Ioc 0 1)),
+      (‖ContourEndpoints.verticalIntegrandX x r t‖₊ : ℝ≥0∞) ≤
+      ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal := by
+    rw [ae_restrict_iff' measurableSet_Ioc]
+    apply ae_of_all
+    intro t ht
+    rw [ENNReal.coe_le_coe]
+    have hle := hbound t ht
+    have h1 : ‖ContourEndpoints.verticalIntegrandX x r t‖₊ =
+        ‖ContourEndpoints.verticalIntegrandX x r t‖.toNNReal := by simp
+    rw [h1]
+    exact Real.toNNReal_le_toNNReal hle
+  calc ∫⁻ t, ↑‖ContourEndpoints.verticalIntegrandX x r t‖₊ ∂(volume.restrict (Ioc 0 1))
+      ≤ ∫⁻ _t, ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal ∂(volume.restrict (Ioc 0 1)) :=
+        lintegral_mono_ae h_bound_ae
+    _ = ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal * volume (Ioc (0 : ℝ) 1) := by
+        rw [lintegral_const, Measure.restrict_apply MeasurableSet.univ, univ_inter]
+    _ < ⊤ := by
+        rw [ENNReal.mul_lt_top_iff]
+        left
+        exact ⟨ENNReal.coe_lt_top, measure_Ioc_lt_top⟩
+
+/-- IntegrableOn is preserved by constant multiplication. -/
+lemma IntegrableOn.const_mul' {c : ℂ} {f : ℝ → ℂ} {s : Set ℝ}
+    (hf : IntegrableOn f s volume) : IntegrableOn (fun t => c * f t) s volume := by
+  rw [IntegrableOn] at hf ⊢
+  exact hf.smul c
+
+/-- Integrability on [0,∞) for functions equal to verticalIntegrandX on (0,∞).
+    Factors out the common proof pattern from Goals 1, 6, and 7. -/
+lemma integrableOn_Ici_of_eqOn_verticalIntegrandX (x r : ℝ) (hr : 2 < r) {f : ℝ → ℂ}
+    (hEq : EqOn f (fun t => ContourEndpoints.verticalIntegrandX x r t) (Ioi 0)) :
+    IntegrableOn f (Ici 0) volume := by
+  rw [integrableOn_Ici_iff_integrableOn_Ioi, ← Ioc_union_Ioi_eq_Ioi zero_le_one, integrableOn_union]
+  constructor
+  · exact (integrableOn_verticalIntegrandX_Ioc x r hr).congr_fun
+      (hEq.mono Ioc_subset_Ioi_self).symm measurableSet_Ioc
+  · exact (integrableOn_verticalIntegrandX_Ioi x r hr).congr_fun
+      (hEq.mono (Ioi_subset_Ioi (by norm_num : (0:ℝ) ≤ 1))).symm measurableSet_Ioi
+
+/-- Integrability on (1,∞) for functions equal to -I * verticalIntegrandX on (1,∞).
+    Factors out the common proof pattern from Goals 2 and 4. -/
+lemma integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX (x r : ℝ) (hr : 2 < r) {f : ℝ → ℂ}
+    (hEq : EqOn f (fun t => -Complex.I * ContourEndpoints.verticalIntegrandX x r t) (Ioi 1)) :
+    IntegrableOn f (Ioi 1) volume :=
+  (IntegrableOn.const_mul' (integrableOn_verticalIntegrandX_Ioi x r hr)).congr_fun
+    (fun _ ht => (hEq ht).symm) measurableSet_Ioi
+
+/-- Helper simp lemma: t*I + 1 = 1 + I*t -/
+@[simp]
+lemma t_mul_I_add_one (t : ℝ) : (t : ℂ) * Complex.I + 1 = (1 : ℂ) + Complex.I * t := by ring
+
+/-- Helper simp lemma: t*I - 1 = -1 + I*t -/
+@[simp]
+lemma t_mul_I_sub_one (t : ℝ) : (t : ℂ) * Complex.I - 1 = (-1 : ℂ) + Complex.I * t := by ring
+
+/-- Integrability for shifted Möbius integrands with exponential phase t*I.
+    Factors out the common proof pattern from Goals 3 and 5. -/
+lemma integrableOn_shiftedMöbius (a r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I + a)) * (t * Complex.I + a)^2 *
+                          Complex.exp (π * Complex.I * r * (t * Complex.I)))
+                 (Ioi 1) volume := by
+  simpa [t_mul_I_add_one, t_mul_I_sub_one, mul_comm, add_comm] using
+    integrableOn_φ₀_shifted_Möbius a 0 r hr
+
+/-! ## Specific Instantiations
+
+The seven integrability goals from Proposition 4.4.6.
+-/
+
+/-- Goal 1: Integrability of I * φ₀''(-1/(I*t)) * (I*t)² * cexp(I*π*r*(I*t)) on [0,∞).
+    Note: -1/(I*t) = I/t, so this is verticalIntegrandX 0 r t. -/
+lemma integrableOn_goal1 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => Complex.I * φ₀'' (-1 / (Complex.I * t)) * (Complex.I * t)^2 *
+                          Complex.exp (Complex.I * π * r * (Complex.I * t)))
+                 (Ici (0 : ℝ)) volume :=
+  integrableOn_Ici_of_eqOn_verticalIntegrandX 0 r hr fun t ht =>
+    goal1_eq_verticalIntegrandX r t (ne_of_gt ht)
+
+/-- Goal 2: Integrability of φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(-1 + t*I)) on (1,∞).
+    By goal2_eq_neg_I_verticalIntegrandX, this is -I * verticalIntegrandX (-1) r t. -/
+lemma integrableOn_goal2 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+                          Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)))
+                 (Ioi (1 : ℝ)) volume :=
+  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX (-1) r hr fun {t} ht =>
+    goal2_eq_neg_I_verticalIntegrandX r t (ne_of_gt (lt_trans one_pos ht))
+
+/-- Goal 3: Integrability of φ₀''(-1/(t*I + 1)) * (t*I+1)² * cexp(π*I*r*(t*I)) on (1,∞).
+    Category B: Shifted Möbius argument at +1. Derived from integrableOn_shiftedMöbius. -/
+lemma integrableOn_goal3 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I + 1)) * (t * Complex.I + 1)^2 *
+                          Complex.exp (π * Complex.I * r * (t * Complex.I)))
+                 (Ioi (1 : ℝ)) volume :=
+  integrableOn_shiftedMöbius 1 r hr
+
+/-- Goal 4: Integrability of φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(1 + t*I)) on (1,∞).
+    By goal4_eq_neg_I_verticalIntegrandX, this is -I * verticalIntegrandX 1 r t. -/
+lemma integrableOn_goal4 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+                          Complex.exp (π * Complex.I * r * (1 + t * Complex.I)))
+                 (Ioi (1 : ℝ)) volume :=
+  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX 1 r hr fun {t} ht =>
+    goal4_eq_neg_I_verticalIntegrandX r t (ne_of_gt (lt_trans one_pos ht))
+
+/-- Goal 5: Integrability of φ₀''(-1/(t*I - 1)) * (t*I-1)² * cexp(π*I*r*(t*I)) on (1,∞).
+    Category B: Shifted Möbius argument at -1. Derived from integrableOn_shiftedMöbius. -/
+lemma integrableOn_goal5 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I - 1)) * (t * Complex.I - 1)^2 *
+                          Complex.exp (π * Complex.I * r * (t * Complex.I)))
+                 (Ioi (1 : ℝ)) volume := by
+  convert integrableOn_shiftedMöbius (-1) r hr using 2
+  simp [sub_eq_add_neg]
+
+/-- Goal 6: Integrability of I * (φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(-1 + t*I))) on [0,∞).
+    By goal6_eq_verticalIntegrandX, this is verticalIntegrandX (-1) r t. -/
+lemma integrableOn_goal6 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+                          Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))))
+                 (Ici (0 : ℝ)) volume :=
+  integrableOn_Ici_of_eqOn_verticalIntegrandX (-1) r hr fun t ht =>
+    goal6_eq_verticalIntegrandX r t (ne_of_gt ht)
+
+/-- Goal 7: Integrability of I * (φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(1 + t*I))) on [0,∞).
+    By goal7_eq_verticalIntegrandX, this is verticalIntegrandX 1 r t. -/
+lemma integrableOn_goal7 (r : ℝ) (hr : 2 < r) :
+    IntegrableOn (fun t : ℝ => Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
+                          Complex.exp (π * Complex.I * r * (1 + t * Complex.I))))
+                 (Ici (0 : ℝ)) volume :=
+  integrableOn_Ici_of_eqOn_verticalIntegrandX 1 r hr fun t ht =>
+    goal7_eq_verticalIntegrandX r t (ne_of_gt ht)
+
+
+end MagicFunction.VerticalIntegrability

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -219,16 +219,66 @@ lemma im_neg_inv_pos (a t : ℝ) (ht : 0 < t) :
   ring_nf
   exact div_pos ht h_denom
 
+/-- Pointwise norm bound for the shifted-Möbius integrand: for `t ≥ 1` it is dominated by
+`(a²+1)·verticalBound r t`. This is the analytic core reused by the integrability goals. -/
+lemma norm_shiftedMobiusIntegrand_le (a b r t : ℝ) (ht : 1 ≤ t) :
+    ‖φ₀'' (-1 / ((a : ℂ) + Complex.I * t)) * ((a : ℂ) + Complex.I * t) ^ 2 *
+        Complex.exp (Complex.I * π * r * ((b : ℂ) + Complex.I * t))‖ ≤
+      (a ^ 2 + 1) * ContourEndpoints.verticalBound r t := by
+  have ht_pos : 0 < t := lt_of_lt_of_le one_pos ht
+  let z : ℂ := a + Complex.I * t
+  have hz_im : z.im = t := by simp [z]
+  have hz_im_pos : 0 < z.im := by rw [hz_im]; exact ht_pos
+  let w : UpperHalfPlane := ⟨z, hz_im_pos⟩
+  have hw_im : w.im = t := hz_im
+  have hw_im_ge : 1 ≤ w.im := by rw [hw_im]; exact ht
+  have hφ₀_eq : φ₀'' (-1 / z) = φ₀ (ModularGroup.S • w) :=
+    ContourEndpoints.φ₀''_neg_inv_eq_φ₀_S_smul a t ht_pos
+  have hS_bound := ContourEndpoints.norm_φ₀_S_smul_le w hw_im_ge
+  have hz_sq_bound : ‖z ^ 2‖ ≤ (a ^ 2 + 1) * t ^ 2 := by
+    simp only [z, norm_pow, ← Complex.normSq_eq_norm_sq, mul_comm Complex.I,
+      Complex.normSq_add_mul_I]
+    nlinarith [sq_nonneg a, sq_nonneg (t - 1), sq_nonneg (a * (t - 1))]
+  have hexp_norm : ‖Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖ =
+      Real.exp (-π * r * t) := ContourEndpoints.norm_cexp_verticalPhase b r t
+  calc ‖φ₀'' (-1 / z) * z ^ 2 * Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖
+      = ‖φ₀'' (-1 / z)‖ * ‖z ^ 2‖ * Real.exp (-π * r * t) := by
+        rw [norm_mul, norm_mul, hexp_norm]
+    _ ≤ ‖φ₀'' (-1 / z)‖ * ((a ^ 2 + 1) * t ^ 2) * Real.exp (-π * r * t) := by
+        apply mul_le_mul_of_nonneg_right
+        · apply mul_le_mul_of_nonneg_left hz_sq_bound (norm_nonneg _)
+        · exact (Real.exp_pos _).le
+    _ = (a ^ 2 + 1) * (‖φ₀'' (-1 / z)‖ * t ^ 2 * Real.exp (-π * r * t)) := by ring
+    _ = (a ^ 2 + 1) * (‖φ₀ (ModularGroup.S • w)‖ * t ^ 2 * Real.exp (-π * r * t)) := by
+        rw [hφ₀_eq]
+    _ ≤ (a ^ 2 + 1) * ContourEndpoints.verticalBound r t := by
+        apply mul_le_mul_of_nonneg_left _ (by nlinarith)
+        have hw_norm_ge : t ≤ ‖(w : ℂ)‖ := by
+          simpa [hw_im, abs_of_pos ht_pos] using abs_im_le_norm (w : ℂ)
+        have hS_bound' : ‖φ₀ (ModularGroup.S • w)‖ ≤
+            C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
+            + (36 / (π ^ 2 * t ^ 2)) * C_φ₄' * Real.exp (2 * π * t) := by
+          rw [hw_im] at hS_bound
+          refine hS_bound.trans ?_
+          gcongr <;> [exact C_φ₂'_pos.le; exact C_φ₄'_pos.le]
+        calc ‖φ₀ (ModularGroup.S • w)‖ * t ^ 2 * Real.exp (-π * r * t)
+            ≤ (C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
+                + (36 / (π ^ 2 * t ^ 2)) * C_φ₄' * Real.exp (2 * π * t))
+              * t ^ 2 * Real.exp (-π * r * t) := by gcongr
+          _ = C_φ₀ * t ^ 2 * (Real.exp (-2 * π * t) * Real.exp (-π * r * t))
+              + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
+              + (36 * C_φ₄' / π ^ 2) * (Real.exp (2 * π * t) * Real.exp (-π * r * t)) := by
+                field_simp
+          _ = ContourEndpoints.verticalBound r t := by
+                simp only [ContourEndpoints.verticalBound, ← Real.exp_add]; ring_nf
+
 /-- General integrability for φ₀''(-1/(a + I*t)) * (a + I*t)² * cexp(I*π*r*(b + I*t)) on Ioi 1.
 
     This unified lemma covers all six integrability goals from Proposition 4.4.6:
     - Goals 1, 2, 4, 6: Use a = 0 (Category A, reduces to verticalIntegrandX)
     - Goals 3, 5: Use a = ±1 (Category B, shifted Möbius)
 
-    The proof uses:
-    1. φ₀''_neg_inv_eq_φ₀_S_smul: φ₀''(-1/z) = φ₀(S•w) for suitable w ∈ ℍ
-    2. norm_φ₀_S_smul_le: |φ₀(S•z)| ≤ C₀ exp(-2π·im(S•z)) for im(z) ≥ 1
-    3. Exponential decay for r > 2 dominates polynomial growth -/
+    The proof reduces to `norm_shiftedMobiusIntegrand_le` for the dominating bound. -/
 lemma integrableOn_φ₀_shifted_Möbius (a b r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => φ₀'' (-1 / ((a : ℂ) + Complex.I * t)) *
       ((a : ℂ) + Complex.I * t)^2 *
@@ -285,68 +335,11 @@ lemma integrableOn_φ₀_shifted_Möbius (a b r : ℝ) (hr : 2 < r) :
           (continuousOn_const.add
             (continuousOn_const.mul Complex.continuous_ofReal.continuousOn))
     exact h_cont.aestronglyMeasurable measurableSet_Ioi
-  · -- Norm bound: ‖integrand‖ ≤ (a² + 1) * verticalBound hb r t a.e.
+  · -- Norm bound: dominated by `(a²+1)·verticalBound` (see `norm_shiftedMobiusIntegrand_le`)
     rw [ae_restrict_iff' measurableSet_Ioi]
-    apply ae_of_all
-    intro t ht
+    refine ae_of_all _ fun t ht => ?_
     simp only [mem_Ioi] at ht
-    have ht_ge_1 : 1 ≤ t := le_of_lt ht
-    have ht_pos : 0 < t := lt_of_lt_of_le one_pos ht_ge_1
-    -- Use the S-transform bound
-    let z : ℂ := a + Complex.I * t
-    have hz_im : z.im = t := by simp [z]
-    have hz_im_pos : 0 < z.im := by rw [hz_im]; exact ht_pos
-    let w : UpperHalfPlane := ⟨z, hz_im_pos⟩
-    have hw_im : w.im = t := hz_im
-    have hw_im_ge : 1 ≤ w.im := by rw [hw_im]; exact ht_ge_1
-    -- Step 1: φ₀''(-1/z) = φ₀(S•w)
-    have hφ₀_eq : φ₀'' (-1 / z) = φ₀ (ModularGroup.S • w) :=
-      ContourEndpoints.φ₀''_neg_inv_eq_φ₀_S_smul a t ht_pos
-    -- Step 2: Get the S-transform bound
-    have hS_bound := ContourEndpoints.norm_φ₀_S_smul_le w hw_im_ge
-    -- Step 3: Bound ‖z²‖ ≤ (a² + 1) * t² for t ≥ 1
-    have hz_sq_bound : ‖z^2‖ ≤ (a^2 + 1) * t^2 := by
-      simp only [z, norm_pow, ← Complex.normSq_eq_norm_sq, mul_comm Complex.I,
-        Complex.normSq_add_mul_I]
-      nlinarith [sq_nonneg a, sq_nonneg (t - 1), sq_nonneg (a * (t - 1))]
-    -- Step 4: Exponential norm
-    have hexp_norm : ‖Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖ =
-        Real.exp (-π * r * t) := ContourEndpoints.norm_cexp_verticalPhase b r t
-    -- Step 5: Combine bounds
-    calc ‖φ₀'' (-1 / z) * z^2 * Complex.exp (Complex.I * π * r * (b + Complex.I * t))‖
-        = ‖φ₀'' (-1 / z)‖ * ‖z^2‖ * Real.exp (-π * r * t) := by
-          rw [norm_mul, norm_mul, hexp_norm]
-      _ ≤ ‖φ₀'' (-1 / z)‖ * ((a^2 + 1) * t^2) * Real.exp (-π * r * t) := by
-          apply mul_le_mul_of_nonneg_right
-          · apply mul_le_mul_of_nonneg_left hz_sq_bound (norm_nonneg _)
-          · exact (Real.exp_pos _).le
-      _ = (a^2 + 1) * (‖φ₀'' (-1 / z)‖ * t^2 * Real.exp (-π * r * t)) := by ring
-      _ = (a^2 + 1) * (‖φ₀ (ModularGroup.S • w)‖ * t^2 * Real.exp (-π * r * t)) := by
-          rw [hφ₀_eq]
-      _ ≤ (a^2 + 1) * (ContourEndpoints.verticalBound r t) := by
-          apply mul_le_mul_of_nonneg_left _ (by nlinarith)
-          -- Show ‖φ₀(S•w)‖ * t² * exp(-πrt) ≤ verticalBound using ‖w‖ ≥ t
-          -- Strategy: Use hS_bound with ‖w‖ ≥ t to replace 1/‖w‖ terms with 1/t
-          have hw_norm_ge : t ≤ ‖(w : ℂ)‖ := by
-            simpa [hw_im, abs_of_pos ht_pos] using abs_im_le_norm (w : ℂ)
-          -- Strengthen hS_bound using ‖w‖ ≥ t
-          have hS_bound' : ‖φ₀ (ModularGroup.S • w)‖ ≤
-              C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
-              + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t) := by
-            rw [hw_im] at hS_bound
-            refine hS_bound.trans ?_
-            gcongr <;> [exact C_φ₂'_pos.le; exact C_φ₄'_pos.le]
-          -- Multiply by t² * exp(-πrt) and simplify to verticalBound
-          calc ‖φ₀ (ModularGroup.S • w)‖ * t^2 * Real.exp (-π * r * t)
-              ≤ (C_φ₀ * Real.exp (-2 * π * t) + (12 / (π * t)) * C_φ₂'
-                  + (36 / (π^2 * t^2)) * C_φ₄' * Real.exp (2 * π * t))
-                * t^2 * Real.exp (-π * r * t) := by gcongr
-            _ = C_φ₀ * t^2 * (Real.exp (-2 * π * t) * Real.exp (-π * r * t))
-                + (12 * C_φ₂' / π) * t * Real.exp (-π * r * t)
-                + (36 * C_φ₄' / π^2) * (Real.exp (2 * π * t) * Real.exp (-π * r * t)) := by
-                  field_simp
-            _ = ContourEndpoints.verticalBound r t := by
-                  simp only [ContourEndpoints.verticalBound, ← Real.exp_add]; ring_nf
+    exact norm_shiftedMobiusIntegrand_le a b r t ht.le
 
 /-! ## Relationship to verticalIntegrandX
 

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -365,7 +365,7 @@ lemma I_mul_t_sq (t : ℝ) : (Complex.I * t : ℂ)^2 = -(t^2) := by
   simp [mul_pow, Complex.I_sq, ← Complex.ofReal_neg, ← Complex.ofReal_pow]
 
 /-- Goal 1 integrand equals verticalIntegrandX 0 r t. -/
-lemma goal1_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
+lemma goal1_eq_verticalIntegrandX (r t : ℝ) :
     Complex.I * φ₀'' (-1 / (Complex.I * t)) * (Complex.I * t)^2 *
       Complex.exp (Complex.I * π * r * (Complex.I * t)) =
     ContourEndpoints.verticalIntegrandX 0 r t := by
@@ -376,7 +376,7 @@ lemma goal1_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
 
 Proof sketch: Both sides reduce to φ₀''(I/t) * (-t²) * cexp(I*π*r*(-1 + I*t))
 after using -1/(I*t) = I/t and (I*t)² = -t². -/
-lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
+lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) :
     φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX (-1) r t := by
@@ -388,7 +388,7 @@ lemma goal2_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
 /-- Goal 4 integrand equals -I * verticalIntegrandX 1 r t.
 
 Proof sketch: Same as Goal 2 but with +1 in the exponential phase. -/
-lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
+lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) :
     φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I)) =
     -Complex.I * ContourEndpoints.verticalIntegrandX 1 r t := by
@@ -401,7 +401,7 @@ lemma goal4_eq_neg_I_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
 
 Proof sketch: Goal 6 = I * Goal 2 = I * (-I) * verticalIntegrandX (-1) r t
 = verticalIntegrandX (-1) r t since I * (-I) = 1. -/
-lemma goal6_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
+lemma goal6_eq_verticalIntegrandX (r t : ℝ) :
     Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX (-1) r t := by
@@ -414,7 +414,7 @@ lemma goal6_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
 
 Proof sketch: Goal 7 = I * Goal 4 = I * (-I) * verticalIntegrandX 1 r t
 = verticalIntegrandX 1 r t since I * (-I) = 1. -/
-lemma goal7_eq_verticalIntegrandX (r t : ℝ) (_ht : t ≠ 0) :
+lemma goal7_eq_verticalIntegrandX (r t : ℝ) :
     Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
       Complex.exp (π * Complex.I * r * (1 + t * Complex.I))) =
     ContourEndpoints.verticalIntegrandX 1 r t := by
@@ -573,8 +573,8 @@ lemma integrableOn_goal1 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => Complex.I * φ₀'' (-1 / (Complex.I * t)) * (Complex.I * t)^2 *
                           Complex.exp (Complex.I * π * r * (Complex.I * t)))
                  (Ici (0 : ℝ)) volume :=
-  integrableOn_Ici_of_eqOn_verticalIntegrandX 0 r hr fun t ht =>
-    goal1_eq_verticalIntegrandX r t (ne_of_gt ht)
+  integrableOn_Ici_of_eqOn_verticalIntegrandX 0 r hr fun t _ =>
+    goal1_eq_verticalIntegrandX r t
 
 /-- Goal 2: Integrability of φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(-1 + t*I)) on (1,∞).
     By goal2_eq_neg_I_verticalIntegrandX, this is -I * verticalIntegrandX (-1) r t. -/
@@ -582,8 +582,8 @@ lemma integrableOn_goal2 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
                           Complex.exp (π * Complex.I * r * (-1 + t * Complex.I)))
                  (Ioi (1 : ℝ)) volume :=
-  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX (-1) r hr fun {t} ht =>
-    goal2_eq_neg_I_verticalIntegrandX r t (ne_of_gt (lt_trans one_pos ht))
+  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX (-1) r hr fun {t} _ =>
+    goal2_eq_neg_I_verticalIntegrandX r t
 
 /-- Goal 3: Integrability of φ₀''(-1/(t*I + 1)) * (t*I+1)² * cexp(π*I*r*(t*I)) on (1,∞).
     Category B: Shifted Möbius argument at +1. Derived from integrableOn_shiftedMöbius. -/
@@ -599,8 +599,8 @@ lemma integrableOn_goal4 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
                           Complex.exp (π * Complex.I * r * (1 + t * Complex.I)))
                  (Ioi (1 : ℝ)) volume :=
-  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX 1 r hr fun {t} ht =>
-    goal4_eq_neg_I_verticalIntegrandX r t (ne_of_gt (lt_trans one_pos ht))
+  integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX 1 r hr fun {t} _ =>
+    goal4_eq_neg_I_verticalIntegrandX r t
 
 /-- Goal 5: Integrability of φ₀''(-1/(t*I - 1)) * (t*I-1)² * cexp(π*I*r*(t*I)) on (1,∞).
     Category B: Shifted Möbius argument at -1. Derived from integrableOn_shiftedMöbius. -/
@@ -617,8 +617,8 @@ lemma integrableOn_goal6 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
                           Complex.exp (π * Complex.I * r * (-1 + t * Complex.I))))
                  (Ici (0 : ℝ)) volume :=
-  integrableOn_Ici_of_eqOn_verticalIntegrandX (-1) r hr fun t ht =>
-    goal6_eq_verticalIntegrandX r t (ne_of_gt ht)
+  integrableOn_Ici_of_eqOn_verticalIntegrandX (-1) r hr fun t _ =>
+    goal6_eq_verticalIntegrandX r t
 
 /-- Goal 7: Integrability of I * (φ₀''(-1/(t*I)) * (t*I)² * cexp(π*I*r*(1 + t*I))) on [0,∞).
     By goal7_eq_verticalIntegrandX, this is verticalIntegrandX 1 r t. -/
@@ -626,8 +626,8 @@ lemma integrableOn_goal7 (r : ℝ) (hr : 2 < r) :
     IntegrableOn (fun t : ℝ => Complex.I * (φ₀'' (-1 / (t * Complex.I)) * (t * Complex.I)^2 *
                           Complex.exp (π * Complex.I * r * (1 + t * Complex.I))))
                  (Ici (0 : ℝ)) volume :=
-  integrableOn_Ici_of_eqOn_verticalIntegrandX 1 r hr fun t ht =>
-    goal7_eq_verticalIntegrandX r t (ne_of_gt ht)
+  integrableOn_Ici_of_eqOn_verticalIntegrandX 1 r hr fun t _ =>
+    goal7_eq_verticalIntegrandX r t
 
 
 end MagicFunction.VerticalIntegrability

--- a/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
+++ b/SpherePacking/MagicFunction/a/VerticalIntegrability.lean
@@ -432,30 +432,9 @@ lemma integrableOn_verticalIntegrandX_Ioc (x r : ℝ) (hr : 2 < r) :
           simp only [one_mul, mul_one]
           exact mul_le_mul_of_nonneg_left hexp_bound C_φ₀_pos.le
   -- Construct IntegrableOn from AEStronglyMeasurable + bounded + finite measure
-  rw [IntegrableOn, Integrable]
-  refine ⟨hmeas, ?_⟩
-  rw [hasFiniteIntegral_def]
-  have h_bound_ae : ∀ᵐ t ∂(volume.restrict (Ioc 0 1)),
-      (‖ContourEndpoints.verticalIntegrandX x r t‖₊ : ℝ≥0∞) ≤
-      ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal := by
+  exact IntegrableOn.of_bound measure_Ioc_lt_top hmeas (C_φ₀ * Real.exp (-2 * π)) <| by
     rw [ae_restrict_iff' measurableSet_Ioc]
-    apply ae_of_all
-    intro t ht
-    rw [ENNReal.coe_le_coe]
-    have hle := hbound t ht
-    have h1 : ‖ContourEndpoints.verticalIntegrandX x r t‖₊ =
-        ‖ContourEndpoints.verticalIntegrandX x r t‖.toNNReal := by simp
-    rw [h1]
-    exact Real.toNNReal_le_toNNReal hle
-  calc ∫⁻ t, ↑‖ContourEndpoints.verticalIntegrandX x r t‖₊ ∂(volume.restrict (Ioc 0 1))
-      ≤ ∫⁻ _t, ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal ∂(volume.restrict (Ioc 0 1)) :=
-        lintegral_mono_ae h_bound_ae
-    _ = ↑(C_φ₀ * Real.exp (-2 * π)).toNNReal * volume (Ioc (0 : ℝ) 1) := by
-        rw [lintegral_const, Measure.restrict_apply MeasurableSet.univ, univ_inter]
-    _ < ⊤ := by
-        rw [ENNReal.mul_lt_top_iff]
-        left
-        exact ⟨ENNReal.coe_lt_top, measure_Ioc_lt_top⟩
+    exact ae_of_all _ hbound
 
 /-- IntegrableOn is preserved by constant multiplication. -/
 lemma IntegrableOn.const_mul' {c : ℂ} {f : ℝ → ℂ} {s : Set ℝ}


### PR DESCRIPTION
## Summary
Add VerticalIntegrability.lean with integrability lemmas for the double zeros proof.

This file proves that the seven integrands from Proposition 4.4.6 are integrable on their respective domains, using the thesis bounds (Lemmas 4.4.3-4.4.4) and the shifted Möbius transform technique.

> **Depends on [#304](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/304) and [#296](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/296), which must merge first** (in that order). The φ-bounds (`φ₀_bound`, `φ₂'_bound`, `φ₄'_bound`) come from #304's standalone `PhiBounds.lean`; `ContourEndpoints` comes from #296.

### File Added

**VerticalIntegrability.lean**

**Thesis bounds (Lemmas 4.4.3-4.4.4)**:
- `norm_φ₀_I_div_t_small`: For t ∈ (0,2), ‖φ₀(i/t)‖ ≤ C₀·e^{-2π/t} (super-exponential decay)
- `norm_φ₀_I_div_t_large`: For t ≥ 2, ‖φ₀(i/t)‖ ≤ C·t⁻²·e^{2πt} (polynomial growth)

**Core integrability**:
- `integrableOn_φ₀_shifted_Möbius`: General integrability for φ₀''(-1/(a+I·t))·(a+I·t)²·e^{iπr(b+I·t)} on (1,∞)

**Seven integrability goals (Proposition 4.4.6)**:
- `integrableOn_goal1` through `integrableOn_goal7`: The specific integrands needed for the contour deformation, covering both Category A (reduces to verticalIntegrandX) and Category B (shifted Möbius at ±1)
- `goal1_eq_verticalIntegrandX`, `goal2_eq_neg_I_verticalIntegrandX`, etc.: Rewrite lemmas relating goals to verticalIntegrandX

**Helper lemmas**:
- `integrableOn_verticalIntegrandX_Ioc`: Integrability on (0,1]
- `integrableOn_verticalIntegrandX_Ioi`: Integrability on (1,∞)
- `integrableOn_Ici_of_eqOn_verticalIntegrandX`, `integrableOn_Ioi_of_eqOn_neg_I_verticalIntegrandX`: Factor out common EqOn patterns
- `integrableOn_shiftedMöbius`: Unified helper for shifted Möbius integrands

## PR Stack (merge in order)
1. [#288](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/288) ← CuspPath, RealDecay ✅ merged
2. [#304](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/304) ← FourierExpansions + PhiBounds (φ-bound lemmas)
3. [#296](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/296) ← ContourEndpoints (depends on #288 + #304)
4. **#297** ← VerticalIntegrability (this PR, depends on #296)
5. [#298](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/298) ← VerticalVanishing (depends on #296, parallel with #297)
6. [#229](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/229) ← Double zeros proof (depends on #297 + #298)

## Test plan
- [x] `lake build` passes
- [x] No sorries in VerticalIntegrability.lean
- [x] φ-bounds are now the sorry-free standalone lemmas from #304 (no `phiBounds` placeholder)
