### PR TITLE
golf: shorten proofs in BoundaryControl.lean

### DIFF
--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -519,15 +519,11 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   have hcubeShell : cubeShellErr L = shellVol / volCube := by
     simp [cubeShellErr, shellVol, volCube]
   have hvolCube_ne0 : volCube ≠ 0 := by
-    have hvol : volCube = (ENNReal.ofReal L) ^ d := by
-      simpa [volCube] using (PeriodicConstant.volume_coordCube (d := d) (L := L))
-    have hL' : (ENNReal.ofReal L) ≠ 0 := by
-      exact (ne_of_gt (by simpa [ENNReal.ofReal_pos] using hLpos))
-    simpa [hvol] using pow_ne_zero d hL'
-  have hvolCube_ne_top : volCube ≠ ∞ := by
-    have hbounded : IsBounded (coordCube (d := d) L) :=
-      PeriodicConstant.isBounded_coordCube (d := d) L hLpos
-    simpa [volCube] using (hbounded.measure_lt_top (μ := volume)).ne
+    have : volCube = (ENNReal.ofReal L) ^ d := by
+      simpa [volCube] using PeriodicConstant.volume_coordCube (d := d) (L := L)
+    simpa [this] using pow_ne_zero d (ENNReal.ofReal_pos.mpr hLpos).ne'
+  have hvolCube_ne_top : volCube ≠ ∞ :=
+    (PeriodicConstant.isBounded_coordCube (d := d) L hLpos).measure_lt_top.ne
   -- Convert `hcR` to a strict inequality involving `encard` of centers in `ball 0 (R+r)`.
   have hcR' :
       c <
@@ -578,24 +574,11 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     -PeriodicConstantApprox.coordCubeCover (d := d) L hLpos x
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := by
     intro x hx
-    have hx_mem : x ∈ S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁ := by
-      simpa [s] using (hX.mem_toFinset.1 hx)
-    have hx_ball : x ∈ ball 0 R₁ := hx_mem.2
-    have hx_gball :
-        (f x : EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R₁ + C) :=
-      PeriodicConstantApprox.neg_coordCubeCover_mem_ball L hLpos hC hx_ball
-    have : f x ∈ {g : cubeLattice (d := d) L hLpos |
-        (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R₁ + C)} := by
-      simpa using hx_gball
-    exact htSet.mem_toFinset.2 this
-  have ht_nonempty : t.Nonempty := by
-    refine ⟨0, ?_⟩
-    have hpos : 0 < R₁ + C := by
-      dsimp [R₁, r]
-      nlinarith [hRpos, hCpos]
-    have : (0 : cubeLattice (d := d) L hLpos) ∈ htSet.toFinset :=
-      htSet.mem_toFinset.2 (by simp [Metric.mem_ball, hpos])
-    simpa [t] using this
+    have hx_mem := hX.mem_toFinset.1 (show x ∈ s from hx)
+    exact htSet.mem_toFinset.2 (show (f x : EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R₁ + C) from
+      PeriodicConstantApprox.neg_coordCubeCover_mem_ball L hLpos hC hx_mem.2)
+  have ht_nonempty : t.Nonempty :=
+    ⟨0, htSet.mem_toFinset.2 (by simp [Metric.mem_ball]; positivity)⟩
   let fiber : cubeLattice (d := d) L hLpos → ℕ := fun g =>
     (s.filter fun x : EuclideanSpace ℝ (Fin d) => f x = g).card
   rcases Finset.exists_max_image t fiber ht_nonempty with ⟨g0, hg0t, hg0max⟩

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -56,7 +56,9 @@ lemma neg_coordCubeCover_mem_ball {C R : ℝ}
     have : g + x ∈ coordCube (d := d) L := by
       simpa [Submodule.vadd_def, vadd_eq_add] using coordCubeCover_spec (d := d) L hL x
     simpa [mem_ball_zero_iff] using hC this
-  rw [mem_ball_zero_iff]; change ‖-g‖ < R + C; rw [norm_neg]
+  rw [mem_ball_zero_iff]
+  change ‖-g‖ < R + C
+  rw [norm_neg]
   have htri := norm_sub_le (g + x) x
   simp [add_sub_cancel_right] at htri
   linarith
@@ -66,7 +68,7 @@ lemma mem_vadd_coordCube_iff_eq_neg_coordCubeCover (g : cubeLattice (d := d) L h
     x ∈ g +ᵥ coordCube (d := d) L ↔ g = -coordCubeCover (d := d) L hL x := by
   constructor
   · intro hx
-    rw [show g = -(-g) from (neg_neg g).symm, coordCubeCover_unique (d := d) L hL x (-g)
+    rw [← neg_neg g, coordCubeCover_unique (d := d) L hL x (-g)
       (by simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hx)]
   · rintro rfl; exact mem_neg_coordCubeCover_vadd_coordCube (d := d) L hL x
 
@@ -155,7 +157,8 @@ lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
   · refine (Set.mem_vadd_set_iff_neg_vadd_mem).2 ?_
     simp only [coordCubeInner, coordCube, constVec, Set.mem_setOf_eq, vadd_eq_add] at hx_cube ⊢
     intro i
-    have hxi := hx_cube i; have hyi_le := abs_le.mp (hyi i).le
+    have hxi := hx_cube i
+    have hyi_le := abs_le.mp (hyi i).le
     refine ⟨?_, ?_⟩
     · have : (0 : ℝ) ≤ x i + y i + (1 / 2 : ℝ) := by linarith [hxi.1, hyi_le.1]
       simpa [add_assoc, add_left_comm, add_comm] using this
@@ -268,10 +271,10 @@ lemma volume_cubeShell_eq (L : ℝ) :
         (shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0 :=
     coordCubeInner_one_subset_shell (d := d) L
   have hmeas_inner : MeasurableSet (coordCubeInner (d := d) L 1) := by
+    have hmp : MeasurePreserving (fun x : EuclideanSpace ℝ (Fin d) => x.ofLp) := by
+      simpa using PiLp.volume_preserving_ofLp (ι := Fin d)
     simpa [PeriodicConstant.coordCubeInner_eq_preimage_ofLp (d := d) (L := L) (r := (1 : ℝ))] using
-      (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
-        (show MeasurePreserving (fun x : EuclideanSpace ℝ (Fin d) => x.ofLp) from
-          by simpa using PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
+      (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage hmp.measurable
   simpa [measure_vadd, shellVec] using
     measure_diff (μ := volume) hsub hmeas_inner.nullMeasurableSet
       (by simp [PeriodicConstant.volume_coordCubeInner])
@@ -396,7 +399,8 @@ lemma tendsto_cubeShell_ratio_zero :
       fun L : ℝ => (1 + L⁻¹) ^ d - (1 - 2 * L⁻¹) ^ d := by
     filter_upwards [eventually_gt_atTop (0 : ℝ)] with L hLpos
     have hL : L ≠ 0 := ne_of_gt hLpos
-    rw [sub_div]; congr 1 <;> rw [← div_pow] <;> congr 1 <;> field_simp
+    rw [sub_div]
+    congr 1 <;> rw [← div_pow] <;> congr 1 <;> field_simp
   exact hdiff.congr' hEq.symm
 
 lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
@@ -420,13 +424,18 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
     have hL1 : 0 ≤ L + 1 := by linarith
     have hL2' : 0 ≤ L - 2 := by linarith
     have hLdpos : 0 < L ^ d := pow_pos (by linarith) d
-    rw [show volume (((shellVec d _) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-        coordCubeInner (d := d) L 1) = _ from by simpa using volume_cubeShell_eq_pow (d := d) (L := L),
-      show volume (coordCube (d := d) L) = _ from by simpa using PeriodicConstant.volume_coordCube (d := d) (L := L)]
-    rw [← ENNReal.ofReal_pow hL1, ← ENNReal.ofReal_pow hL2', ← ENNReal.ofReal_pow hL0,
-      show ENNReal.ofReal ((L + 1) ^ d) - ENNReal.ofReal ((L - 2) ^ d) =
-        ENNReal.ofReal ((L + 1) ^ d - (L - 2) ^ d) from by
-          simpa using (ENNReal.ofReal_sub _ (pow_nonneg hL2' d)).symm]
+    have hshell : volume (((shellVec d (-(1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
+        coordCubeInner (d := d) L 1) =
+          (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
+      simpa using volume_cubeShell_eq_pow (d := d) (L := L)
+    have hcube : volume (coordCube (d := d) L) = (ENNReal.ofReal L) ^ d := by
+      simpa using PeriodicConstant.volume_coordCube (d := d) (L := L)
+    rw [hshell, hcube, ← ENNReal.ofReal_pow hL1, ← ENNReal.ofReal_pow hL2',
+      ← ENNReal.ofReal_pow hL0]
+    have hsub : ENNReal.ofReal ((L + 1) ^ d) - ENNReal.ofReal ((L - 2) ^ d) =
+        ENNReal.ofReal ((L + 1) ^ d - (L - 2) ^ d) := by
+      simpa using (ENNReal.ofReal_sub _ (pow_nonneg hL2' d)).symm
+    rw [hsub]
     simpa [f] using (ENNReal.ofReal_div_of_pos (x := (L + 1) ^ d - (L - 2) ^ d) hLdpos).symm
   exact hof.congr' hEq.symm
 
@@ -442,7 +451,8 @@ variable {d : ℕ}
 lemma div_mul_div_cancel_right {a b c : ℝ≥0∞} (hb0 : b ≠ 0) (hb : b ≠ ∞) :
     ((a * b) / c) / b = a / c := by
   simp only [div_eq_mul_inv]
-  rw [show a * b * c⁻¹ * b⁻¹ = a * c⁻¹ * (b * b⁻¹) from by ring]
+  have h : a * b * c⁻¹ * b⁻¹ = a * c⁻¹ * (b * b⁻¹) := by ring
+  rw [h]
   simp [ENNReal.mul_inv_cancel hb0 hb]
 
 theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < d)
@@ -525,9 +535,9 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     -PeriodicConstantApprox.coordCubeCover (d := d) L hLpos x
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := by
     intro x hx
-    have hx_mem := hX.mem_toFinset.1 (show x ∈ s from hx)
-    exact htSet.mem_toFinset.2 (show (f x : EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R₁ + C) from
-      PeriodicConstantApprox.neg_coordCubeCover_mem_ball L hLpos hC hx_mem.2)
+    have hx_mem := (hX.mem_toFinset.1 hx)
+    exact htSet.mem_toFinset.2
+      (PeriodicConstantApprox.neg_coordCubeCover_mem_ball L hLpos hC hx_mem.2)
   have ht_nonempty : t.Nonempty :=
     ⟨0, htSet.mem_toFinset.2 (by simp [Metric.mem_ball]; positivity)⟩
   let fiber : cubeLattice (d := d) L hLpos → ℕ := fun g =>
@@ -563,9 +573,9 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
         (d := d) (hL := hLpos) (R := R₁) (C := C) hC)
   have hs_enc :
       ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) = s.card := by
-    simpa [s] using congrArg (fun n : ENat => (n : ℝ≥0∞))
-      ((show (S.centers ∩ ball 0 (R + r)).Finite by
-        simpa [R₁, r, add_assoc, add_left_comm, add_comm] using hX).encard_eq_coe_toFinset_card)
+    have hfin : (S.centers ∩ ball 0 (R + r)).Finite := by
+      simpa [R₁, r, add_assoc, add_left_comm, add_comm] using hX
+    simpa [s] using congrArg (fun n : ENat => (n : ℝ≥0∞)) hfin.encard_eq_coe_toFinset_card
   have hR2 : R + Cshift = R₁ + 2 * C := by simp [Cshift, R₁, r, add_left_comm, add_comm]
   have hs_mul :
       ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube ≤
@@ -574,9 +584,10 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
         = (s.card : ℝ≥0∞) * volCube := by rw [hs_enc]
       _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
           have h := mul_le_mul_right hs_le volCube
-          rwa [show volCube * (s.card : ℝ≥0∞) = (s.card : ℝ≥0∞) * volCube from mul_comm _ _,
-            show volCube * ((t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞)) =
-              (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube from by ac_rfl] at h
+          have h1 : volCube * (s.card : ℝ≥0∞) = (s.card : ℝ≥0∞) * volCube := mul_comm _ _
+          have h2 : volCube * ((t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞)) =
+              (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by ac_rfl
+          rwa [h1, h2] at h
       _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volCube) := by ac_rfl
       _ ≤ _ := mul_le_mul_right (by simpa [hR2, volCube] using ht_vol) _
   have hsg_density :
@@ -590,11 +601,15 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     have hb3 : ((S.centers ∩ ball 0 (R + r)).encard : ℝ≥0∞) * volBall / V ≤
         (sg.card : ℝ≥0∞) * volBall / volCube := by
       have := mul_le_mul_left hdiv₁ volBall
-      rwa [show (↑(S.centers ∩ ball 0 (R + r)).encard / V) * volBall =
-          ↑(S.centers ∩ ball 0 (R + r)).encard * volBall / V from by
-            simp [div_eq_mul_inv]; ac_rfl,
-        show ((sg.card : ℝ≥0∞) / volCube) * volBall = (sg.card : ℝ≥0∞) * volBall / volCube from by
-            simp [div_eq_mul_inv]; ac_rfl] at this
+      have h1 : (↑(S.centers ∩ ball 0 (R + r)).encard / V) * volBall =
+          ↑(S.centers ∩ ball 0 (R + r)).encard * volBall / V := by
+        simp [div_eq_mul_inv]
+        ac_rfl
+      have h2 : ((sg.card : ℝ≥0∞) / volCube) * volBall =
+          (sg.card : ℝ≥0∞) * volBall / volCube := by
+        simp [div_eq_mul_inv]
+        ac_rfl
+      rwa [h1, h2] at this
     exact (hRratio.trans hc_ratio).trans_le hb3
   -- Periodize the interior points `F`.
   let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ coordCubeInner (d := d) L r
@@ -602,17 +617,25 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
   let sb : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∉ innerSet
   have hF_centers : ∀ x ∈ F, x ∈ S.centers := fun x hx => by
-    have := hx; dsimp [F] at this; exact hsg_centers x (Finset.mem_filter.1 this).1
+    have := hx
+    dsimp [F] at this
+    exact hsg_centers x (Finset.mem_filter.1 this).1
   have hF_inner : ∀ x ∈ F, x ∈ g0 +ᵥ coordCubeInner (d := d) L r := fun x hx => by
-    have := hx; dsimp [F] at this; simpa [innerSet] using (Finset.mem_filter.1 this).2
+    have := hx
+    dsimp [F] at this
+    simpa [innerSet] using (Finset.mem_filter.1 this).2
   have hsb_centers : ∀ x ∈ sb, x ∈ S.centers := fun x hx => by
-    have := hx; dsimp [sb] at this; exact hsg_centers x (Finset.mem_filter.1 this).1
+    have := hx
+    dsimp [sb] at this
+    exact hsg_centers x (Finset.mem_filter.1 this).1
   have hsb_boundary :
       ∀ x ∈ sb, x ∈ (g0 +ᵥ coordCube (d := d) L) \ (g0 +ᵥ coordCubeInner (d := d) L (1 / 2)) := by
     intro x hx
-    have hx_sb := hx; dsimp [sb] at hx_sb
+    have hx_sb := hx
+    dsimp [sb] at hx_sb
     have hx_mem := Finset.mem_filter.1 hx_sb
-    exact ⟨hsg_memCube x hx_mem.1, by simpa [innerSet, show r = (1 / 2 : ℝ) from by norm_num] using hx_mem.2⟩
+    have hr : r = (1 / 2 : ℝ) := by norm_num
+    exact ⟨hsg_memCube x hx_mem.1, by simpa [innerSet, hr] using hx_mem.2⟩
   have hsb_vol :
       (sb.card : ℝ≥0∞) * volBall ≤ shellVol := by
     simpa [volBall, shellVol, r] using

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -66,10 +66,8 @@ lemma mem_vadd_coordCube_iff_eq_neg_coordCubeCover (g : cubeLattice (d := d) L h
     x ∈ g +ᵥ coordCube (d := d) L ↔ g = -coordCubeCover (d := d) L hL x := by
   constructor
   · intro hx
-    have : (-g : cubeLattice (d := d) L hL) = coordCubeCover (d := d) L hL x :=
-      coordCubeCover_unique (d := d) L hL x (-g)
-        (by simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hx)
-    simpa using congrArg (fun t : cubeLattice (d := d) L hL => -t) this
+    rw [show g = -(-g) from (neg_neg g).symm, coordCubeCover_unique (d := d) L hL x (-g)
+      (by simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hx)]
   · rintro rfl; exact mem_neg_coordCubeCover_vadd_coordCube (d := d) L hL x
 
 end CoordCubeCover
@@ -256,14 +254,10 @@ lemma coordCubeInner_one_subset_shell (L : ℝ) :
     coordCubeInner (d := d) L 1 ⊆
       (shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0 := by
   intro x hx
-  refine (Set.mem_vadd_set_iff_neg_vadd_mem).2 ?_
-  have hx' : ∀ i : Fin d, x.ofLp i ∈ Set.Icc (1 : ℝ) (L - 1) := by
-    simpa [coordCubeInner, Set.mem_setOf_eq] using hx
+  refine (Set.mem_vadd_set_iff_neg_vadd_mem).2 fun i => ?_
   simp only [coordCubeInner, Set.mem_setOf_eq, shellVec, vadd_eq_add, one_div, WithLp.ofLp_add,
-    WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg]
-  exact fun i => by
-    let hxi := hx' i
-    refine ⟨by linarith [hxi.1], by linarith [hxi.2]⟩
+    WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg] at hx ⊢
+  exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
 
 lemma volume_cubeShell_eq (L : ℝ) :
     volume (((shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
@@ -364,29 +358,17 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   let P : PeriodicSpherePacking d :=
     periodize_to_periodicSpherePacking (d := d) S (Λ := Λ) D Fset
       (hD_unique_covers := PeriodicConstantApprox.coordCube_unique_covers_vadd (d := d) L hL g)
-      (hF_centers := by
-        assumption)
-      (hF_ball := by
-        intro x hx
-        have hx' : x ∈ F := by simpa [Fset] using hx
-        have hxInner : x ∈ g +ᵥ coordCubeInner (d := d) L (S.separation / 2) := by
-          simpa [hSsep] using (hF_inner x hx')
-        exact ball_subset_vadd_coordCube_of_mem_vadd_inner hL hxInner)
+      (hF_centers := by assumption)
+      (hF_ball := fun x hx => ball_subset_vadd_coordCube_of_mem_vadd_inner hL
+        (by simpa [hSsep] using hF_inner x (by simpa [Fset] using hx)))
   have hPsep : P.separation = 1 := by simpa [P, hSsep]
   refine ⟨P, hPsep, ?_⟩
-  have hD_bounded : IsBounded D := by
-    simpa [D, Submodule.vadd_def, vadd_eq_add] using
-      (PeriodicConstant.isBounded_coordCube (d := d) L hL).vadd (g : EuclideanSpace ℝ (Fin d))
-  have hD_unique : ∀ x, ∃! g0 : (cubeLattice (d := d) L hL), g0 +ᵥ x ∈ D :=
-    PeriodicConstantApprox.coordCube_unique_covers_vadd (d := d) L hL g
-  have hF_sub : Fset ⊆ D := by
-    intro x hx
-    have hx' : x ∈ F := by simpa [Fset] using hx
-    rcases (hF_inner x hx') with ⟨a, ha, rfl⟩
-    have ha' : a ∈ coordCube (d := d) L :=
-      PeriodicConstant.coordCubeInner_subset_coordCube (d := d) (L := L) (r := (2⁻¹ : ℝ))
-        (by norm_num) ha
-    exact ⟨a, ha', rfl⟩
+  have hD_bounded : IsBounded D := by simpa [D, Submodule.vadd_def, vadd_eq_add] using
+    (PeriodicConstant.isBounded_coordCube (d := d) L hL).vadd (g : EuclideanSpace ℝ (Fin d))
+  have hD_unique := PeriodicConstantApprox.coordCube_unique_covers_vadd (d := d) L hL g
+  have hF_sub : Fset ⊆ D := fun x hx => by
+    rcases hF_inner x (by simpa [Fset] using hx) with ⟨a, ha, rfl⟩
+    exact ⟨a, PeriodicConstant.coordCubeInner_subset_coordCube (by norm_num) ha, rfl⟩
   have hcenters_inter :
       P.centers ∩ D = Fset := by
     simpa [P, periodize_to_periodicSpherePacking, Fset] using
@@ -640,13 +622,11 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
       hF_centers hF_inner with ⟨P, hPsep, hPdens⟩
   -- Rewrite `P.density` with denominator `volCube`.
   have hden :
-      (Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) : ℝ≥0∞) = volCube :=
-      by
-    have : Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) =
-        volCube.toNNReal := by
-      simpa [volCube] using (PeriodicConstantApprox.toNNReal_covolume_cubeLattice
-        (d := d) (L := L) hLpos)
-    simp [this, ENNReal.coe_toNNReal hvolCube_ne_top]
+      (Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) : ℝ≥0∞) = volCube := by
+    rw [show Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) =
+      volCube.toNNReal from by simpa [volCube] using
+        PeriodicConstantApprox.toNNReal_covolume_cubeLattice (d := d) (L := L) hLpos]
+    exact ENNReal.coe_toNNReal hvolCube_ne_top
   have hPdens' : P.density = (F.card : ℝ≥0∞) * volBall / volCube := by
     simpa [hden, volBall] using hPdens
   refine ⟨P, hPsep, ?_⟩

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -634,108 +634,41 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     simpa [volCube, R₁, r, t, htSet] using
       (PeriodicConstantApprox.card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball
         (d := d) (hL := hLpos) (R := R₁) (C := C) hC)
+  have hs_enc :
+      ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) = s.card := by
+    simpa [s] using congrArg (fun n : ENat => (n : ℝ≥0∞))
+      ((show (S.centers ∩ ball 0 (R + r)).Finite by
+        simpa [R₁, r, add_assoc, add_left_comm, add_comm] using hX).encard_eq_coe_toFinset_card)
+  have hR2 : R + Cshift = R₁ + 2 * C := by simp [Cshift, R₁, r, add_left_comm, add_comm]
   have hs_mul :
       ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube ≤
         (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := by
-    have hs_enc :
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) = s.card := by
-      -- `s` is the `toFinset` of this set
-      have hfin : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).Finite := by
-        simpa [R₁, r, add_assoc, add_left_comm, add_comm] using hX
-      simpa [s] using congrArg (fun n : ENat => (n : ℝ≥0∞)) (hfin.encard_eq_coe_toFinset_card)
-    have hs1 :
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube ≤
-          (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
-      have hs1' :
-          volCube * (s.card : ℝ≥0∞) ≤ volCube * ((t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞)) :=
-        mul_le_mul_right hs_le volCube
-      have hL : volCube * (s.card : ℝ≥0∞) = (s.card : ℝ≥0∞) * volCube := by
-        ac_rfl
-      have hR :
-          volCube * ((t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞)) =
-            (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
-        ac_rfl
-      have hs1'' :
-          (s.card : ℝ≥0∞) * volCube ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
-        simpa [hL, hR] using hs1'
-      simpa [hs_enc] using hs1''
-    have hR2 : R + Cshift = R₁ + 2 * C := by
-      simp [Cshift, R₁, r, add_left_comm, add_comm]
-    have ht_vol' :
-        (t.card : ℝ≥0∞) * volCube ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := by
-      simpa [hR2, volCube] using ht_vol
-    have hs2 :
-        (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube ≤
-          (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := by
-      have hs2' :
-          (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volCube) ≤
-            (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) :=
-        mul_le_mul_right ht_vol' (sg.card : ℝ≥0∞)
-      have hL :
-          (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volCube) =
-            (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
-        ac_rfl
-      simpa [hL] using hs2'
-    exact hs1.trans hs2
+    calc ((S.centers ∩ ball _ (R + r)).encard : ℝ≥0∞) * volCube
+        = (s.card : ℝ≥0∞) * volCube := by rw [hs_enc]
+      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube := by
+          have h := mul_le_mul_right hs_le volCube
+          rwa [show volCube * (s.card : ℝ≥0∞) = (s.card : ℝ≥0∞) * volCube from mul_comm _ _,
+            show volCube * ((t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞)) =
+              (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volCube from by ac_rfl] at h
+      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volCube) := by ac_rfl
+      _ ≤ _ := mul_le_mul_right (by simpa [hR2, volCube] using ht_vol) _
   have hsg_density :
       b + cubeShellErr L < (sg.card : ℝ≥0∞) * volBall / volCube := by
-    have hb1 : b + cubeShellErr L < c * ratio R := hRratio
-    have hb2 : c * ratio R <
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
-          volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := hc_ratio
-    have hb3 :
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
-          volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≤
-          (sg.card : ℝ≥0∞) * volBall / volCube := by
-      -- First compare `encard / volR2 ≤ sg.card / volCube` using `hs_mul`
-      -- then multiply by `volBall`.
-      have hdiv₁ :
-          ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) /
-              volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≤
-            (sg.card : ℝ≥0∞) / volCube := by
-        have h₁ :
-            (((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube) /
-                volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≤
-              (sg.card : ℝ≥0∞) :=
-          ENNReal.div_le_of_le_mul hs_mul
-        have h₂ :
-            ((((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube) /
-                    volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) /
-                volCube ≤
-              (sg.card : ℝ≥0∞) / volCube :=
-          ENNReal.div_le_div_right h₁ volCube
-        have hcancel :
-            ((((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volCube) /
-                    volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) /
-                volCube =
-              ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) /
-                volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) :=
-          div_mul_div_cancel_right hvolCube_ne0 hvolCube_ne_top
-        simpa [hcancel] using h₂
-      have hdiv₂ :
-          (((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) /
-                volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) *
-              volBall ≤
-            ((sg.card : ℝ≥0∞) / volCube) * volBall := mul_le_mul_left hdiv₁ volBall
-      have hL :
-          ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
-              volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) =
-            (((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) /
-                  volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) *
-                volBall := by
-        simp [div_eq_mul_inv]
-        ac_rfl
-      have hR :
-          (sg.card : ℝ≥0∞) * volBall / volCube = ((sg.card : ℝ≥0∞) / volCube) * volBall := by
-        simp [div_eq_mul_inv]
-        ac_rfl
-      simpa [hL, hR] using hdiv₂
-    have hb12 :
-        b + cubeShellErr L <
-          ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
-            volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) :=
-      lt_trans hb1 hb2
-    exact lt_of_lt_of_le hb12 hb3
+    set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
+    -- encard / V ≤ sg.card / volCube, derived from hs_mul
+    have hdiv₁ : ((S.centers ∩ ball 0 (R + r)).encard : ℝ≥0∞) / V ≤ (sg.card : ℝ≥0∞) / volCube := by
+      have h := ENNReal.div_le_div_right (ENNReal.div_le_of_le_mul hs_mul) volCube
+      rwa [div_mul_div_cancel_right hvolCube_ne0 hvolCube_ne_top] at h
+    -- Multiply both sides by volBall, rewrite a/b * c = a*c/b
+    have hb3 : ((S.centers ∩ ball 0 (R + r)).encard : ℝ≥0∞) * volBall / V ≤
+        (sg.card : ℝ≥0∞) * volBall / volCube := by
+      have := mul_le_mul_left hdiv₁ volBall
+      rwa [show (↑(S.centers ∩ ball 0 (R + r)).encard / V) * volBall =
+          ↑(S.centers ∩ ball 0 (R + r)).encard * volBall / V from by
+            simp [div_eq_mul_inv]; ac_rfl,
+        show ((sg.card : ℝ≥0∞) / volCube) * volBall = (sg.card : ℝ≥0∞) * volBall / volCube from by
+            simp [div_eq_mul_inv]; ac_rfl] at this
+    exact (hRratio.trans hc_ratio).trans_le hb3
   -- Periodize the interior points `F`.
   let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ coordCubeInner (d := d) L r
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
@@ -760,18 +693,9 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   have hsb_boundary :
       ∀ x ∈ sb, x ∈ (g0 +ᵥ coordCube (d := d) L) \ (g0 +ᵥ coordCubeInner (d := d) L (1 / 2)) := by
     intro x hx
-    have hx_sb := hx
-    dsimp [sb] at hx_sb
+    have hx_sb := hx; dsimp [sb] at hx_sb
     have hx_mem := Finset.mem_filter.1 hx_sb
-    have hx_sg : x ∈ sg := hx_mem.1
-    have hxCube : x ∈ g0 +ᵥ coordCube (d := d) L := hsg_memCube x hx_sg
-    have hxnot : x ∉ innerSet := hx_mem.2
-    have hr : (r : ℝ) = (1 / 2 : ℝ) := by
-      dsimp [r]
-      norm_num
-    have hxnot' : x ∉ g0 +ᵥ coordCubeInner (d := d) L (1 / 2) := by
-      simpa [innerSet, hr] using hxnot
-    exact ⟨hxCube, hxnot'⟩
+    exact ⟨hsg_memCube x hx_mem.1, by simpa [innerSet, show r = (1 / 2 : ℝ) from by norm_num] using hx_mem.2⟩
   have hsb_vol :
       (sb.card : ℝ≥0∞) * volBall ≤ shellVol := by
     simpa [volBall, shellVol, r] using
@@ -798,32 +722,18 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     Finset.card_filter_add_card_filter_not fun x => x ∈ innerSet
   have hP_lower :
       (sg.card : ℝ≥0∞) * volBall / volCube - cubeShellErr L ≤ P.density := by
-    -- show `sgDensity ≤ P.density + cubeShellErr L`, then rewrite with `tsub_le_iff_right`
-    have hsg_eq :
-        (sg.card : ℝ≥0∞) * volBall =
-          (F.card : ℝ≥0∞) * volBall + (sb.card : ℝ≥0∞) * volBall := by
+    have hsg_eq : (sg.card : ℝ≥0∞) * volBall =
+        (F.card : ℝ≥0∞) * volBall + (sb.card : ℝ≥0∞) * volBall := by
       have : (sg.card : ℝ≥0∞) = (F.card : ℝ≥0∞) + (sb.card : ℝ≥0∞) := by
         exact_mod_cast hF_card_add.symm
       simp [this, add_mul]
-    have hsg_le :
-        (sg.card : ℝ≥0∞) * volBall ≤ (F.card : ℝ≥0∞) * volBall + shellVol := by
-      have h_add :
-          (F.card : ℝ≥0∞) * volBall + (sb.card : ℝ≥0∞) * volBall ≤
-            (F.card : ℝ≥0∞) * volBall + shellVol :=
-        add_le_add_right hsb_vol ((F.card : ℝ≥0∞) * volBall)
-      simpa [hsg_eq] using h_add
-    have hsg_div :
-        (sg.card : ℝ≥0∞) * volBall / volCube ≤
-          (F.card : ℝ≥0∞) * volBall / volCube + cubeShellErr L := by
-      have hdiv := ENNReal.div_le_div_right hsg_le volCube
-      have hdiv' :
-          (sg.card : ℝ≥0∞) * volBall / volCube ≤
-            (F.card : ℝ≥0∞) * volBall / volCube + shellVol / volCube := by
-        simpa [div_eq_mul_inv, mul_add, add_mul, mul_assoc] using hdiv
-      simpa [hcubeShell, shellVol] using hdiv'
-    have hmain : (sg.card : ℝ≥0∞) * volBall / volCube ≤ P.density + cubeShellErr L := by
-      simpa [hPdens'] using hsg_div
-    exact (tsub_le_iff_right).2 (by simpa using hmain)
+    have hsg_le : (sg.card : ℝ≥0∞) * volBall ≤ (F.card : ℝ≥0∞) * volBall + shellVol := by
+      simpa [hsg_eq] using add_le_add_right hsb_vol _
+    have hsg_div : (sg.card : ℝ≥0∞) * volBall / volCube ≤
+        (F.card : ℝ≥0∞) * volBall / volCube + cubeShellErr L := by
+      have := ENNReal.div_le_div_right hsg_le volCube
+      simpa [div_eq_mul_inv, mul_add, add_mul, mul_assoc, hcubeShell, shellVol] using this
+    exact tsub_le_iff_right.2 (by simpa [hPdens'] using hsg_div)
   exact hb_lt.trans_le hP_lower
 
 end SpherePacking

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -646,9 +646,10 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   -- Rewrite `P.density` with denominator `volCube`.
   have hden :
       (Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) : ℝ≥0∞) = volCube := by
-    rw [show Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) =
-      volCube.toNNReal from by simpa [volCube] using
-        PeriodicConstantApprox.toNNReal_covolume_cubeLattice (d := d) (L := L) hLpos]
+    have h : Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) =
+        volCube.toNNReal := by
+      simpa [volCube] using PeriodicConstantApprox.toNNReal_covolume_cubeLattice (d := d) (L := L) hLpos
+    rw [h]
     exact ENNReal.coe_toNNReal hvolCube_ne_top
   have hPdens' : P.density = (F.card : ℝ≥0∞) * volBall / volCube := by
     simpa [hden, volBall] using hPdens

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -601,16 +601,9 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
     -- `card_eq_sum_card_fiberwise` counts elements fiberwise over `t`.
     simpa [fiber] using (Finset.card_eq_sum_card_fiberwise (f := f) (s := s) (t := t) hf_maps)
   have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
-    -- bound the sum of fibers by `t.card * maxFiber`
-    have hsum_le :
-        Finset.sum t (fun g => (s.filter fun x => f x = g).card) ≤
-          Finset.sum t (fun _g => sg.card) := Finset.sum_le_sum hg0max
-    have hsum_eq : Finset.sum t (fun _g => sg.card) = t.card * sg.card := by
-      simp [Finset.sum_const]
-    have hs_le_nat : s.card ≤ t.card * sg.card := by
-      -- all the quantities here are naturals
-      simpa [hs_sum, hsum_eq] using hsum_le
-    exact_mod_cast hs_le_nat
+    have : s.card ≤ t.card * sg.card := by
+      simpa [hs_sum, Finset.sum_const] using Finset.sum_le_sum hg0max
+    exact_mod_cast this
   have ht_vol :
       ((t.card : ℝ≥0∞) * volCube) ≤
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) := by
@@ -657,22 +650,12 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
   let sb : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∉ innerSet
-  have hF_centers : ∀ x ∈ F, x ∈ S.centers := by
-    intro x hx
-    have hx' := hx
-    dsimp [F] at hx'
-    exact hsg_centers x (Finset.mem_filter.1 hx').1
-  have hF_inner : ∀ x ∈ F, x ∈ g0 +ᵥ coordCubeInner (d := d) L r := by
-    intro x hx
-    have hx' := hx
-    dsimp [F] at hx'
-    have hx' : x ∈ innerSet := (Finset.mem_filter.1 hx').2
-    simpa [innerSet] using hx'
-  have hsb_centers : ∀ x ∈ sb, x ∈ S.centers := by
-    intro x hx
-    have hx' := hx
-    dsimp [sb] at hx'
-    exact hsg_centers x (Finset.mem_filter.1 hx').1
+  have hF_centers : ∀ x ∈ F, x ∈ S.centers := fun x hx => by
+    have := hx; dsimp [F] at this; exact hsg_centers x (Finset.mem_filter.1 this).1
+  have hF_inner : ∀ x ∈ F, x ∈ g0 +ᵥ coordCubeInner (d := d) L r := fun x hx => by
+    have := hx; dsimp [F] at this; simpa [innerSet] using (Finset.mem_filter.1 this).2
+  have hsb_centers : ∀ x ∈ sb, x ∈ S.centers := fun x hx => by
+    have := hx; dsimp [sb] at this; exact hsg_centers x (Finset.mem_filter.1 this).1
   have hsb_boundary :
       ∀ x ∈ sb, x ∈ (g0 +ᵥ coordCube (d := d) L) \ (g0 +ᵥ coordCubeInner (d := d) L (1 / 2)) := by
     intro x hx
@@ -743,17 +726,8 @@ public theorem periodic_constant_eq_constant (hd : 0 < d) :
           hPsep).trans ?_
     exact le_iSup (fun S : SpherePacking d ↦ ⨆ (_ : S.separation = 1), S.density) P.toSpherePacking
   · -- general ≤ periodic: approximate any packing by a periodic one
-    refine iSup₂_le ?_
-    intro S hSsep
-    -- show `S.density ≤ sup_{periodic, sep=1} density` by approximation from below
-    refine le_of_forall_lt ?_
-    intro a ha
-    -- choose `b` strictly between `a` and `S.density`
+    refine iSup₂_le fun S hSsep => le_of_forall_lt fun a ha => ?_
     rcases exists_between ha with ⟨b, hab, hbS⟩
-    -- Approximate `S` by a periodic packing with (normalized) separation `= 1`.
     rcases SpherePacking.exists_periodicSpherePacking_sep_one_density_gt_of_lt_density
-      (d := d) hd S hSsep hbS with
-      ⟨P, hPsep, hbP⟩
-    have hb_lt_sup : b < ⨆ (P : PeriodicSpherePacking d) (_ : P.separation = 1), P.density :=
-      lt_of_lt_of_le hbP (le_iSup_of_le P (le_iSup_of_le hPsep le_rfl))
-    exact hab.trans hb_lt_sup
+      (d := d) hd S hSsep hbS with ⟨P, hPsep, hbP⟩
+    exact hab.trans (hbP.trans_le (le_iSup_of_le P (le_iSup_of_le hPsep le_rfl)))

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -50,24 +50,16 @@ lemma neg_coordCubeCover_mem_ball {C R : ℝ}
     {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
     ((-coordCubeCover (d := d) L hL x : cubeLattice (d := d) L hL) :
         EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
+  set g := (coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d))
   have hx0 : ‖x‖ < R := by simpa [mem_ball_zero_iff] using hx
-  have hxgC : ‖(coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d)) + x‖ < C := by
-    have hmem :
-        (coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d)) + x ∈ coordCube (d := d) L := by
+  have hgx : ‖g + x‖ < C := by
+    have : g + x ∈ coordCube (d := d) L := by
       simpa [Submodule.vadd_def, vadd_eq_add] using coordCubeCover_spec (d := d) L hL x
-    simpa [mem_ball_zero_iff] using (hC hmem)
-  have htri :
-      ‖(coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d))‖ ≤
-        ‖(coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d)) + x‖ + ‖x‖ := by
-    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc] using
-      (norm_sub_le (a := (coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d)) + x) (b := x))
-  have :
-      ‖(- (coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d)))‖ < R + C := by
-    have : ‖(coordCubeCover (d := d) L hL x : EuclideanSpace ℝ (Fin d))‖ < C + R := by
-      refine lt_of_le_of_lt htri ?_
-      simpa [add_comm, add_left_comm, add_assoc] using add_lt_add hxgC hx0
-    simpa [norm_neg, add_comm, add_left_comm, add_assoc] using this
-  simpa [mem_ball_zero_iff] using this
+    simpa [mem_ball_zero_iff] using hC this
+  rw [mem_ball_zero_iff]; change ‖-g‖ < R + C; rw [norm_neg]
+  have htri := norm_sub_le (g + x) x
+  simp [add_sub_cancel_right] at htri
+  linarith
 
 lemma mem_vadd_coordCube_iff_eq_neg_coordCubeCover (g : cubeLattice (d := d) L hL)
     (x : EuclideanSpace ℝ (Fin d)) :
@@ -93,14 +85,9 @@ lemma vadd_coordCube_subset_ball {L : ℝ} (hL : 0 < L) {R C : ℝ}
     g +ᵥ coordCube (d := d) L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C)) := by
   intro y hy
   rcases hy with ⟨x, hx, rfl⟩
-  have hx' : ‖x‖ < C := by
-    simpa [mem_ball_zero_iff] using hC hx
-  have hg' : ‖(g : EuclideanSpace ℝ (Fin d))‖ < R + C := by
-    simpa [mem_ball_zero_iff] using hg
-  have : ‖(g : EuclideanSpace ℝ (Fin d)) + x‖ < R + (2 * C) := by
-    refine (lt_of_le_of_lt (norm_add_le _ _) ?_)
-    simpa [two_mul, add_assoc, add_left_comm, add_comm] using add_lt_add hg' hx'
-  simpa [Submodule.vadd_def, vadd_eq_add, mem_ball_zero_iff] using this
+  simp only [vadd_eq_add, mem_ball_zero_iff]
+  linarith [norm_add_le (g : EuclideanSpace ℝ (Fin d)) x,
+    mem_ball_zero_iff.mp (hC hx), mem_ball_zero_iff.mp hg]
 
 lemma iUnion_finset_vadd_coordCube_subset_ball {L : ℝ} (hL : 0 < L) {R C : ℝ}
     (hC : coordCube (d := d) L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
@@ -124,27 +111,21 @@ lemma card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball {L : ℝ} 
     (t.card : ℝ≥0∞) * volume (coordCube (d := d) L) ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
   intro htSet t
-  have hdisj :
-      Set.PairwiseDisjoint (↑t : Set (cubeLattice (d := d) L hL))
-        (fun g : cubeLattice (d := d) L hL => g +ᵥ coordCube (d := d) L) := by
-    intro g _ h _ hgh
-    exact disjoint_vadd_of_unique_covers (d := d)
+  have hdisj : Set.PairwiseDisjoint (↑t : Set (cubeLattice (d := d) L hL))
+      (fun g : cubeLattice (d := d) L hL => g +ᵥ coordCube (d := d) L) :=
+    fun g _ h _ hgh => disjoint_vadd_of_unique_covers (d := d)
       (Λ := cubeLattice (d := d) L hL) (D := coordCube (d := d) L)
       (PeriodicConstant.coordCube_unique_covers (d := d) L hL) hgh
-  have hmeas :
-      ∀ g ∈ t, MeasurableSet (g +ᵥ coordCube (d := d) L) := by
+  have hmeas : ∀ g ∈ t, MeasurableSet (g +ᵥ coordCube (d := d) L) := by
     intro g _; simpa using
-      (MeasurableSet.const_vadd (PeriodicConstant.measurableSet_coordCube (d := d) L hL) g)
-  have hvol_union :
-      volume (⋃ g ∈ t, g +ᵥ coordCube (d := d) L) =
-        ∑ g ∈ t, volume (g +ᵥ coordCube (d := d) L) :=
-    measure_biUnion_finset (μ := volume) hdisj hmeas
-  have hsub :
-      (⋃ g ∈ t, g +ᵥ coordCube (d := d) L) ⊆
-        ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C)) :=
-    iUnion_finset_vadd_coordCube_subset_ball (d := d) (hL := hL) (R := R) (C := C) hC
-  have hle := volume.mono hsub
-  simp_all
+      MeasurableSet.const_vadd (PeriodicConstant.measurableSet_coordCube (d := d) L hL) g
+  calc (↑t.card : ℝ≥0∞) * volume (coordCube (d := d) L)
+      = ∑ g ∈ t, volume (g +ᵥ coordCube (d := d) L) := by
+          simp [measure_vadd, Finset.sum_const]
+    _ = volume (⋃ g ∈ t, g +ᵥ coordCube (d := d) L) :=
+          (measure_biUnion_finset (μ := volume) hdisj hmeas).symm
+    _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) :=
+          volume.mono (iUnion_finset_vadd_coordCube_subset_ball (d := d) (hL := hL) hC)
 
 end CoverVolumeBound
 
@@ -170,50 +151,26 @@ lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
   intro z hz
   rcases hz with ⟨x, hx, y, hy, rfl⟩
   have hx_cube : x ∈ coordCube (d := d) L := hx.1
+  have hy' : ‖y‖ < (1 / 2 : ℝ) := by simpa [mem_ball_zero_iff] using hy
+  have hyi : ∀ i : Fin d, |y i| < (1 / 2 : ℝ) := fun i => abs_coord_lt_of_norm_lt (d := d) hy' i
   refine ⟨?_, ?_⟩
-  · have hy' : ‖y‖ < (1 / 2 : ℝ) := by
-      simpa [mem_ball_zero_iff] using hy
-    refine (Set.mem_vadd_set_iff_neg_vadd_mem).2 ?_
+  · refine (Set.mem_vadd_set_iff_neg_vadd_mem).2 ?_
     simp only [coordCubeInner, coordCube, constVec, Set.mem_setOf_eq, vadd_eq_add] at hx_cube ⊢
     intro i
-    have hxi : x i ∈ Set.Ico (0 : ℝ) L := hx_cube i
-    have hyi : |y i| < (1 / 2 : ℝ) := abs_coord_lt_of_norm_lt (d := d) hy' i
-    have hyi_le : -(1 / 2 : ℝ) ≤ y i ∧ y i ≤ (1 / 2 : ℝ) := by
-      have : |y i| ≤ (1 / 2 : ℝ) := le_of_lt hyi
-      simpa [abs_le] using this
+    have hxi := hx_cube i; have hyi_le := abs_le.mp (hyi i).le
     refine ⟨?_, ?_⟩
     · have : (0 : ℝ) ≤ x i + y i + (1 / 2 : ℝ) := by linarith [hxi.1, hyi_le.1]
       simpa [add_assoc, add_left_comm, add_comm] using this
     · have : x i + y i + (1 / 2 : ℝ) ≤ L + 1 := by linarith [hxi.2.le, hyi_le.2]
       simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using this
-  · have hx_notInner : x ∉ coordCubeInner (d := d) L (1 / 2) := hx.2
-    have hy' : ‖y‖ < (1 / 2 : ℝ) := by
-      simpa [mem_ball_zero_iff] using hy
-    have hy_abs : ∀ i : Fin d, |y i| < (1 / 2 : ℝ) := fun i =>
-      abs_coord_lt_of_norm_lt (d := d) hy' i
-    have : ∃ i : Fin d, x i < (1 / 2 : ℝ) ∨ (L - 1 / 2 : ℝ) < x i := by
-      have : ∃ i : Fin d, ¬ x i ∈ Set.Icc (1 / 2 : ℝ) (L - 1 / 2) := by
-        simpa [coordCubeInner, Set.mem_setOf_eq] using (not_forall.mp hx_notInner)
-      rcases this with ⟨i, hi⟩
-      have hi' : x i < (1 / 2 : ℝ) ∨ (L - 1 / 2 : ℝ) < x i := by
-        have : ¬ ((1 / 2 : ℝ) ≤ x i ∧ x i ≤ (L - 1 / 2 : ℝ)) := by
-          simpa [Set.mem_Icc] using hi
-        have : ¬ (1 / 2 : ℝ) ≤ x i ∨ ¬ x i ≤ (L - 1 / 2 : ℝ) := not_and_or.mp this
-        exact this.imp (fun h => lt_of_not_ge h) (fun h => lt_of_not_ge h)
-      exact ⟨i, hi'⟩
-    rcases this with ⟨i, hxi⟩
+  · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (1 / 2 : ℝ) (L - 1 / 2) := by
+      simpa [coordCubeInner, Set.mem_setOf_eq] using not_forall.mp hx.2
+    rw [Set.mem_Icc, not_and_or] at hi
     intro hz_inner
     have hz_i : (x i + y i) ∈ Set.Icc (1 : ℝ) (L - 1) := by
-      simpa [coordCubeInner, Set.mem_setOf_eq] using (hz_inner i)
-    have hyi : |y i| < (1 / 2 : ℝ) := hy_abs i
-    have hyi_lt : - (1 / 2 : ℝ) < y i ∧ y i < (1 / 2 : ℝ) := abs_lt.mp hyi
-    cases hxi with
-    | inl hlt =>
-        have : x i + y i < (1 : ℝ) := by linarith
-        exact (not_lt_of_ge hz_i.1) this
-    | inr hgt =>
-        have : (L - 1 : ℝ) < x i + y i := by linarith
-        exact (not_lt_of_ge hz_i.2) this
+      simpa [coordCubeInner, Set.mem_setOf_eq] using hz_inner i
+    have := abs_lt.mp (hyi i)
+    rcases hi with hi | hi <;> linarith [hz_i.1, hz_i.2]
 
 variable (S : SpherePacking d)
 
@@ -227,90 +184,43 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       volume (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
         coordCubeInner (d := d) L 1) := by
   let r : ℝ := (1 / 2 : ℝ)
-  have hdisj :
-      (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x =>
-        ball x r := by
+  have hdisj : (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x => ball x r := by
     intro x hx y hy hxy
-    have hxC : x ∈ S.centers := hs_centers x hx
-    have hyC : y ∈ S.centers := hs_centers y hy
-    have hdist : (1 : ℝ) ≤ dist x y := by
-      simpa [hSsep] using (S.centers_dist' x y hxC hyC hxy)
-    have hsum_eq : r + r = (1 : ℝ) := by
-      simpa [r] using (by norm_num : (2⁻¹ : ℝ) + 2⁻¹ = 1)
-    have hsum : r + r ≤ dist x y := by simpa [hsum_eq] using hdist
-    exact ball_disjoint_ball hsum
-  have hunion :
-      volume (⋃ x ∈ s, ball x r) =
-        (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) r) := by
+    have : (1 : ℝ) ≤ dist x y := by
+      simpa [hSsep] using S.centers_dist' x y (hs_centers x hx) (hs_centers y hy) hxy
+    exact ball_disjoint_ball (by dsimp [r]; linarith)
+  have hunion : volume (⋃ x ∈ s, ball x r) =
+      (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) r) := by
     simpa [Measure.addHaar_ball_center, mul_comm, mul_assoc] using
-      (measure_biUnion_finset (μ := volume) hdisj (by
-        intro x _
-        exact measurableSet_ball))
-  have hle_union :
-      (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) r) ≤
-        volume (⋃ x ∈ s, ball x r) := by
-    rw [hunion]
-  have hsub :
-      (⋃ x ∈ s, ball x r) ⊆
-        g +ᵥ
-          (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-              coordCubeInner (d := d) L 1) := by
+      measure_biUnion_finset (μ := volume) hdisj (fun x _ => measurableSet_ball)
+  have hsub : (⋃ x ∈ s, ball x r) ⊆
+      g +ᵥ (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
+            coordCubeInner (d := d) L 1) := by
     intro y hy
     rcases Set.mem_iUnion.1 hy with ⟨x, hx⟩
     rcases Set.mem_iUnion.1 hx with ⟨hxS, hyBall⟩
     have hxB := hs_boundary x hxS
-    have hx0 : (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ x ∈ coordCube (d := d) L := by
-      simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hxB.1
-    have hx0_notInner :
-        (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ x ∉ coordCubeInner (d := d) L (1 / 2) := by
-      intro hx0Inner
-      apply hxB.2
-      simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hx0Inner
-    have hy0 :
-        (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ y ∈
-          ball ((- (g : EuclideanSpace ℝ (Fin d))) +ᵥ x) r := by
-      simpa [Metric.vadd_ball] using hyBall
-    have hy0' :
-        (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ y ∈
-          ((coordCube (d := d) L \ coordCubeInner (d := d) L (1 / 2)) +
-              ball (0 : EuclideanSpace ℝ (Fin d)) r) := by
-      let x0 : EuclideanSpace ℝ (Fin d) := (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ x
-      let y0 : EuclideanSpace ℝ (Fin d) := (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ y
-      have hy0' : y0 ∈ ball x0 r := by
-        simpa [x0, y0] using hy0
-      let z : EuclideanSpace ℝ (Fin d) := y0 - x0
-      have hz : z ∈ ball (0 : EuclideanSpace ℝ (Fin d)) r := by
-        have : dist y0 x0 < r := by simpa [Metric.mem_ball] using hy0'
-        have : ‖y0 - x0‖ < r := by simpa [dist_eq_norm] using this
-        simpa [z, Metric.mem_ball, dist_eq_norm] using this
-      refine ⟨x0, ⟨?_, ?_⟩, z, hz, by
-        simp [x0, y0, z, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]⟩
-      · simpa [x0] using hx0
-      · simpa [x0] using hx0_notInner
-    have hy0'' :
-        (- (g : EuclideanSpace ℝ (Fin d))) +ᵥ y ∈
-          ((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-            coordCubeInner (d := d) L 1 := by
-      simpa [r] using
-        (coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
-          (by simpa [r] using hy0'))
-    simpa [Set.mem_vadd_set_iff_neg_vadd_mem] using hy0''
-  have hle : volume (⋃ x ∈ s, ball x r) ≤
-      volume (g +ᵥ
-          (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-              coordCubeInner (d := d) L 1)) :=
-    volume.mono hsub
-  have htrans :
-      volume (g +ᵥ
-          (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-              coordCubeInner (d := d) L 1)) =
-        volume (((constVec (d := d) (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-          coordCubeInner (d := d) L 1) := by
-    simp [measure_vadd]
-  have hr : (2⁻¹ : ℝ) = r := by
-    dsimp [r]
-    norm_num
-  simpa [hr] using (hle_union.trans (hle.trans_eq htrans))
+    set x0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ x
+    have hx0 : x0 ∈ coordCube (d := d) L := by
+      simpa [Set.mem_vadd_set_iff_neg_vadd_mem, x0] using hxB.1
+    have hx0_notInner : x0 ∉ coordCubeInner (d := d) L (1 / 2) := by
+      intro h; exact hxB.2 (by simpa [Set.mem_vadd_set_iff_neg_vadd_mem, x0] using h)
+    set y0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ y
+    have hy0 : y0 ∈ ball x0 r := by simpa [Metric.vadd_ball, x0, y0] using hyBall
+    have hz : y0 - x0 ∈ ball (0 : EuclideanSpace ℝ (Fin d)) r := by
+      simpa [Metric.mem_ball, dist_eq_norm] using hy0
+    have hy0' : y0 ∈ (coordCube (d := d) L \ coordCubeInner (d := d) L (1 / 2)) +
+        ball (0 : EuclideanSpace ℝ (Fin d)) r :=
+      ⟨x0, ⟨hx0, hx0_notInner⟩, y0 - x0, hz, by simp [sub_eq_add_neg, add_assoc, add_comm,
+        add_left_comm]⟩
+    have := coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L (by simpa [r] using hy0')
+    simpa [Set.mem_vadd_set_iff_neg_vadd_mem, y0] using this
+  have hr : (2⁻¹ : ℝ) = r := by norm_num
+  calc (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
+      = volume (⋃ x ∈ s, ball x r) := by rw [hr, hunion]
+    _ ≤ volume (g +ᵥ (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
+          coordCubeInner (d := d) L 1)) := volume.mono hsub
+    _ = _ := by simp [measure_vadd]
 
 end BoundaryControl
 
@@ -364,19 +274,13 @@ lemma volume_cubeShell_eq (L : ℝ) :
         (shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0 :=
     coordCubeInner_one_subset_shell (d := d) L
   have hmeas_inner : MeasurableSet (coordCubeInner (d := d) L 1) := by
-    have hmeasPi :
-        MeasurableSet (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc (1 : ℝ) (L - 1)) := by
-      refine MeasurableSet.pi Set.countable_univ ?_
-      intro _ _
-      exact measurableSet_Icc
-    have hmp : MeasurePreserving (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) := by
-      simpa using (PiLp.volume_preserving_ofLp (ι := Fin d))
     simpa [PeriodicConstant.coordCubeInner_eq_preimage_ofLp (d := d) (L := L) (r := (1 : ℝ))] using
-      hmeasPi.preimage hmp.measurable
-  have hfin : volume (coordCubeInner (d := d) L 1) ≠ ∞ := by
-    simp [PeriodicConstant.volume_coordCubeInner]
+      (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
+        (show MeasurePreserving (fun x : EuclideanSpace ℝ (Fin d) => x.ofLp) from
+          by simpa using PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
   simpa [measure_vadd, shellVec] using
-    (measure_diff (μ := volume) hsub hmeas_inner.nullMeasurableSet hfin)
+    measure_diff (μ := volume) hsub hmeas_inner.nullMeasurableSet
+      (by simp [PeriodicConstant.volume_coordCubeInner])
 
 lemma volume_cubeShell_eq_pow (L : ℝ) :
     volume (((shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
@@ -416,13 +320,12 @@ lemma covolume_cubeLattice_eq_volume_coordCube_toReal (L : ℝ) (hL : 0 < L) :
       (volume (coordCube (d := d) L)).toReal := by
   letI : DiscreteTopology (cubeLattice (d := d) L hL) := by dsimp [cubeLattice]; infer_instance
   letI : IsZLattice ℝ (cubeLattice (d := d) L hL) := by dsimp [cubeLattice]; infer_instance
-  have hfund :
-      IsAddFundamentalDomain (cubeLattice (d := d) L hL)
-        (fundamentalDomain (cubeBasis (d := d) L hL)) volume := by
-    simpa [cubeLattice] using (ZSpan.isAddFundamentalDomain (cubeBasis (d := d) L hL) volume)
+  have hfund : IsAddFundamentalDomain (cubeLattice (d := d) L hL)
+      (fundamentalDomain (cubeBasis (d := d) L hL)) volume := by
+    simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis (d := d) L hL) volume
   simpa [Measure.real, fundamentalDomain_cubeBasis_eq_coordCube (d := d) (L := L) (hL := hL)] using
-    (ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice (d := d) L hL)
-      (μ := volume) hfund)
+    ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice (d := d) L hL)
+      (μ := volume) hfund
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hL) volume) =
@@ -500,37 +403,18 @@ end PeriodizeCubeDensity
 
 lemma tendsto_cubeShell_ratio_zero :
     Tendsto (fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)) atTop (𝓝 (0 : ℝ)) := by
-  have hL0 : Tendsto (fun L : ℝ => L⁻¹) atTop (𝓝 (0 : ℝ)) :=
-    tendsto_inv_atTop_zero
-  have hone : Tendsto (fun _ : ℝ => (1 : ℝ)) atTop (𝓝 (1 : ℝ)) :=
-    tendsto_const_nhds
-  have htwo : Tendsto (fun _ : ℝ => (2 : ℝ)) atTop (𝓝 (2 : ℝ)) :=
-    tendsto_const_nhds
   have h1 : Tendsto (fun L : ℝ => (1 + L⁻¹) ^ d) atTop (𝓝 (1 : ℝ)) := by
-    simpa using (hone.add hL0).pow d
+    simpa using (tendsto_const_nhds (x := (1 : ℝ))).add tendsto_inv_atTop_zero |>.pow d
   have h2 : Tendsto (fun L : ℝ => (1 - 2 * L⁻¹) ^ d) atTop (𝓝 (1 : ℝ)) := by
-    simpa using (hone.sub (htwo.mul hL0)).pow d
+    simpa using ((tendsto_const_nhds (x := (1 : ℝ))).sub
+      ((tendsto_const_nhds (x := (2 : ℝ))).mul tendsto_inv_atTop_zero)).pow d
   have hdiff : Tendsto (fun L : ℝ => (1 + L⁻¹) ^ d - (1 - 2 * L⁻¹) ^ d) atTop (𝓝 (0 : ℝ)) := by
-    simpa using (h1.sub h2)
-  have hEq :
-      (fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)) =ᶠ[atTop]
-        fun L : ℝ => (1 + L⁻¹) ^ d - (1 - 2 * L⁻¹) ^ d := by
+    simpa using h1.sub h2
+  have hEq : (fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)) =ᶠ[atTop]
+      fun L : ℝ => (1 + L⁻¹) ^ d - (1 - 2 * L⁻¹) ^ d := by
     filter_upwards [eventually_gt_atTop (0 : ℝ)] with L hLpos
     have hL : L ≠ 0 := ne_of_gt hLpos
-    have hLd : L ^ d ≠ 0 := by positivity
-    -- rewrite by dividing each term by `L^d` and using `div_pow`
-    calc
-      ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)
-          = (L + 1) ^ d / (L ^ d) - (L - 2) ^ d / (L ^ d) := by
-              simp [sub_div]
-      _ = ((L + 1) / L) ^ d - ((L - 2) / L) ^ d := by
-              simp [div_pow]
-      _ = (1 + L⁻¹) ^ d - (1 - 2 * L⁻¹) ^ d := by
-              have h1' : (L + 1) / L = (1 : ℝ) + L⁻¹ := by
-                field_simp [hL]
-              have h2' : (L - 2) / L = (1 : ℝ) - 2 * L⁻¹ := by
-                field_simp [hL]
-              simp [h1', h2']
+    rw [sub_div]; congr 1 <;> rw [← div_pow] <;> congr 1 <;> field_simp
   exact hdiff.congr' hEq.symm
 
 lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
@@ -545,45 +429,23 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
     simpa [f] using (tendsto_cubeShell_ratio_zero (d := d))
   have hof : Tendsto (fun L : ℝ => ENNReal.ofReal (f L)) atTop (𝓝 (0 : ℝ≥0∞)) := by
     simpa using (ENNReal.continuous_ofReal.tendsto (0 : ℝ)).comp hf
-  have hEq :
-      (fun L : ℝ =>
-          volume (((shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-              coordCubeInner (d := d) L 1) /
-            volume (coordCube (d := d) L)) =ᶠ[atTop]
-        fun L : ℝ => ENNReal.ofReal (f L) := by
+  have hEq : (fun L : ℝ =>
+      volume (((shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
+          coordCubeInner (d := d) L 1) / volume (coordCube (d := d) L)) =ᶠ[atTop]
+      fun L : ℝ => ENNReal.ofReal (f L) := by
     filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
-    have hL0 : 0 ≤ L := le_of_lt (lt_trans (by norm_num : (0 : ℝ) < 2) hL2)
+    have hL0 : 0 ≤ L := by linarith
     have hL1 : 0 ≤ L + 1 := by linarith
     have hL2' : 0 ≤ L - 2 := by linarith
-    have hLpos : 0 < L := lt_trans (by norm_num : (0 : ℝ) < 2) hL2
-    have hLdpos : 0 < L ^ d := pow_pos hLpos d
-    have hshell :
-        volume (((shellVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
-            coordCubeInner (d := d) L 1) =
-          (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
-      simpa using (volume_cubeShell_eq_pow (d := d) (L := L))
-    have hcube :
-        volume (coordCube (d := d) L) = (ENNReal.ofReal L) ^ d := by
-      simpa using (PeriodicConstant.volume_coordCube (d := d) (L := L))
-    have hnum :
-        (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d =
-          ENNReal.ofReal ((L + 1) ^ d - (L - 2) ^ d) := by
-      have hq : 0 ≤ (L - 2) ^ d := pow_nonneg hL2' d
-      -- rewrite both powers as `ofReal` of real powers, then use `ofReal_sub`
-      calc
-        (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d
-            = ENNReal.ofReal ((L + 1) ^ d) - ENNReal.ofReal ((L - 2) ^ d) := by
-                rw [← ENNReal.ofReal_pow hL1 d, ← ENNReal.ofReal_pow hL2' d]
-        _ = ENNReal.ofReal ((L + 1) ^ d - (L - 2) ^ d) := by
-                simpa using
-                  (ENNReal.ofReal_sub (p := (L + 1) ^ d) (q := (L - 2) ^ d) hq).symm
-    have hden :
-        (ENNReal.ofReal L) ^ d = ENNReal.ofReal (L ^ d) := by
-      simpa using (ENNReal.ofReal_pow hL0 d).symm
-    -- finish by rewriting in terms of `ENNReal.ofReal`
-    rw [hshell, hcube, hnum, hden]
-    simpa [f] using
-      (ENNReal.ofReal_div_of_pos (x := (L + 1) ^ d - (L - 2) ^ d) (y := L ^ d) hLdpos).symm
+    have hLdpos : 0 < L ^ d := pow_pos (by linarith) d
+    rw [show volume (((shellVec d _) +ᵥ coordCubeInner (d := d) (L + 1) 0) \
+        coordCubeInner (d := d) L 1) = _ from by simpa using volume_cubeShell_eq_pow (d := d) (L := L),
+      show volume (coordCube (d := d) L) = _ from by simpa using PeriodicConstant.volume_coordCube (d := d) (L := L)]
+    rw [← ENNReal.ofReal_pow hL1, ← ENNReal.ofReal_pow hL2', ← ENNReal.ofReal_pow hL0,
+      show ENNReal.ofReal ((L + 1) ^ d) - ENNReal.ofReal ((L - 2) ^ d) =
+        ENNReal.ofReal ((L + 1) ^ d - (L - 2) ^ d) from by
+          simpa using (ENNReal.ofReal_sub _ (pow_nonneg hL2' d)).symm]
+    simpa [f] using (ENNReal.ofReal_div_of_pos (x := (L + 1) ^ d - (L - 2) ^ d) hLdpos).symm
   exact hof.congr' hEq.symm
 
 end PeriodicConstantApprox
@@ -597,13 +459,9 @@ variable {d : ℕ}
 
 lemma div_mul_div_cancel_right {a b c : ℝ≥0∞} (hb0 : b ≠ 0) (hb : b ≠ ∞) :
     ((a * b) / c) / b = a / c := by
-  calc
-    ((a * b) / c) / b = (a * b) * c⁻¹ * b⁻¹ := by
-      simp [div_eq_mul_inv, mul_assoc]
-    _ = a * c⁻¹ * (b * b⁻¹) := by
-      ac_rfl
-    _ = a / c := by
-      simp [div_eq_mul_inv, ENNReal.mul_inv_cancel hb0 hb]
+  simp only [div_eq_mul_inv]
+  rw [show a * b * c⁻¹ * b⁻¹ = a * c⁻¹ * (b * b⁻¹) from by ring]
+  simp [ENNReal.mul_inv_cancel hb0 hb]
 
 theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {b : ℝ≥0∞} (hb : b < S.density) :

--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -501,15 +501,8 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   have hratio_event :
       ∀ᶠ R in (atTop : Filter ℝ), b + cubeShellErr L < c * ratio R :=
     hmul_tend.eventually (Ioi_mem_nhds hb_add)
-  have hfreq : ∃ᶠ R in (atTop : Filter ℝ), c < S.finiteDensity R :=
-    frequently_lt_finiteDensity_of_lt_density (S := S) (b := c) hcS
-  have hfreq' :
-      ∃ᶠ R in (atTop : Filter ℝ),
-        c < S.finiteDensity R ∧ 0 < R ∧ b + cubeShellErr L < c * ratio R := by
-    have hev : ∀ᶠ R in (atTop : Filter ℝ), 0 < R ∧ b + cubeShellErr L < c * ratio R :=
-      (eventually_gt_atTop (0 : ℝ)).and hratio_event
-    exact hfreq.and_eventually hev
-  rcases hfreq'.exists with ⟨R, hcR, hRpos, hRratio⟩
+  rcases ((frequently_lt_finiteDensity_of_lt_density (S := S) (b := c) hcS).and_eventually
+      ((eventually_gt_atTop (0 : ℝ)).and hratio_event)).exists with ⟨R, hcR, hRpos, hRratio⟩
   -- Abbreviations for volumes.
   let volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) r)
   let volCube : ℝ≥0∞ := volume (coordCube (d := d) L)
@@ -525,44 +518,20 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
   have hvolCube_ne_top : volCube ≠ ∞ :=
     (PeriodicConstant.isBounded_coordCube (d := d) L hLpos).measure_lt_top.ne
   -- Convert `hcR` to a strict inequality involving `encard` of centers in `ball 0 (R+r)`.
-  have hcR' :
-      c <
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) *
-            volBall /
-          volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) := by
-    have hle :
-        S.finiteDensity R ≤
-          (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard *
-              volBall /
-            volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) := by
-      simpa [hSsep, volBall, r, add_assoc, add_left_comm, add_comm] using
-        (S.finiteDensity_le (hd := hd) (R := R))
-    exact lt_of_lt_of_le hcR hle
-  have hvolR_ne0 : volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) ≠ 0 :=
-    (volume_ball_pos _ hRpos).ne.symm
-  have hvolR_ne_top : volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) ≠ ∞ :=
-    (volume_ball_lt_top _).ne
-  have hc_mul :
-      c * volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) <
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall :=
+  have hcR' : c < ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) *
+      volBall / volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) :=
+    hcR.trans_le (by simpa [hSsep, volBall, r, add_assoc, add_left_comm, add_comm] using
+      S.finiteDensity_le (hd := hd) (R := R))
+  have hc_mul : c * volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) <
+      ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall :=
     ENNReal.mul_lt_of_lt_div hcR'
-  have hvolR2_ne0 : volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≠ 0 := by
-    have hR2pos : 0 < R + Cshift := by positivity
-    exact (volume_ball_pos _ hR2pos).ne.symm
-  have hvolR2_ne_top : volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≠ ∞ :=
-    (volume_ball_lt_top _).ne
-  have hc_ratio :
-      c * ratio R <
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
-          volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := by
-    have hdiv :
-        c * volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) /
-              volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) <
-          ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) *
-              volBall /
-            volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) :=
-      ENNReal.div_lt_div_right hvolR2_ne0 hvolR2_ne_top hc_mul
-    simpa [ratio, div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using hdiv
+  have hvolR2_ne0 : volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) ≠ 0 :=
+    (volume_ball_pos _ (by positivity)).ne.symm
+  have hc_ratio : c * ratio R <
+      ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + r)).encard : ℝ≥0∞) * volBall /
+        volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift)) := by
+    simpa [ratio, div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using
+      ENNReal.div_lt_div_right hvolR2_ne0 (volume_ball_lt_top _).ne hc_mul
   -- Finite sets of centers and lattice translates.
   let R₁ : ℝ := R + r
   have hX : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).Finite :=


### PR DESCRIPTION
Compress proofs across BoundaryControl.lean, reducing from 1008 to 866 lines (-142 lines, -14%) while preserving all statements.

Key improvements:
- Triangle inequality proofs use linarith with explicit lemma hints
- Volume bound proofs use calc chains instead of long have sequences
- Boundary strip geometry proof halved via compact coordinate reasoning
- Shell ratio limit proof uses field_simp and direct rw chains
- ENNReal division cancellation proof simplified