### PR TITLE
[gauss2] fix linter warnings (except one)

### DIFF
--- a/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
+++ b/SpherePacking/Basic/PeriodicPacking/BoundaryControl.lean
@@ -212,9 +212,9 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       simpa [Metric.mem_ball, dist_eq_norm] using hy0
     have hy0' : y0 ∈ (coordCube (d := d) L \ coordCubeInner (d := d) L (1 / 2)) +
         ball (0 : EuclideanSpace ℝ (Fin d)) r :=
-      ⟨x0, ⟨hx0, hx0_notInner⟩, y0 - x0, hz, by simp [sub_eq_add_neg, add_assoc, add_comm,
-        add_left_comm]⟩
-    have := coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L (by simpa [r] using hy0')
+      ⟨x0, ⟨hx0, hx0_notInner⟩, y0 - x0, hz, by simp [sub_eq_add_neg, add_left_comm]⟩
+    have := coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
+      (by simpa [r] using hy0')
     simpa [Set.mem_vadd_set_iff_neg_vadd_mem, y0] using this
   have hr : (2⁻¹ : ℝ) = r := by norm_num
   calc (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
@@ -645,10 +645,12 @@ theorem exists_periodicSpherePacking_sep_one_density_gt_of_lt_density (hd : 0 < 
       hF_centers hF_inner with ⟨P, hPsep, hPdens⟩
   -- Rewrite `P.density` with denominator `volCube`.
   have hden :
-      (Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) : ℝ≥0∞) = volCube := by
+      (Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) : ℝ≥0∞) =
+        volCube := by
     have h : Real.toNNReal (ZLattice.covolume (cubeLattice (d := d) L hLpos) volume) =
         volCube.toNNReal := by
-      simpa [volCube] using PeriodicConstantApprox.toNNReal_covolume_cubeLattice (d := d) (L := L) hLpos
+      simpa [volCube] using
+        PeriodicConstantApprox.toNNReal_covolume_cubeLattice (d := d) (L := L) hLpos
     rw [h]
     exact ENNReal.coe_toNNReal hvolCube_ne_top
   have hPdens' : P.density = (F.card : ℝ≥0∞) * volBall / volCube := by

--- a/SpherePacking/ModularForms/CuspFormIsoModforms.lean
+++ b/SpherePacking/ModularForms/CuspFormIsoModforms.lean
@@ -69,7 +69,8 @@ public def CuspForms_iso_Modforms (k : ℤ) : CuspForm (CongruenceSubgroup.Gamma
     ext z
     simp [Modform_mul_Delta_apply, CuspForm_div_Discriminant_apply, Delta_apply, Δ_ne_zero]
 
-public lemma cuspform_weight_lt_12_zero (k : ℤ) (hk : k < 12) : Module.rank ℂ (CuspForm Γ(1) k) = 0 := by
+public lemma cuspform_weight_lt_12_zero (k : ℤ) (hk : k < 12) :
+    Module.rank ℂ (CuspForm Γ(1) k) = 0 := by
   have := CuspForms_iso_Modforms k
   --apply Module.finrank_eq_of_rank_eq
   rw [LinearEquiv.rank_eq this]

--- a/SpherePacking/ModularForms/Derivative.lean
+++ b/SpherePacking/ModularForms/Derivative.lean
@@ -1020,7 +1020,8 @@ theorem D_tendsto_zero_of_isBoundedAtImInfty {f : ℍ → ℂ}
     _ = M / (π * z.im) := by ring
 
 
--- TODO: The following lemma from Gauss overlaps with `D_tendsto_zero_of_isBoundedAtImInfty` above. We will probably want to drop it.
+-- TODO: The following lemma from Gauss overlaps with
+-- `D_tendsto_zero_of_isBoundedAtImInfty` above. We will probably want to drop it.
 /-- The D-derivative tends to 0 at infinity for bounded holomorphic functions. -/
 public lemma D_isZeroAtImInfty_of_bounded {f : ℍ → ℂ}
     (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f)

--- a/SpherePacking/ModularForms/Derivative.lean
+++ b/SpherePacking/ModularForms/Derivative.lean
@@ -1020,8 +1020,8 @@ theorem D_tendsto_zero_of_isBoundedAtImInfty {f : ℍ → ℂ}
     _ = M / (π * z.im) := by ring
 
 
--- TODO: The following lemma from Gauss overlaps with
--- `D_tendsto_zero_of_isBoundedAtImInfty` above. We will probably want to drop it.
+-- TODO: The following lemma from Gauss overlaps with `D_tendsto_zero_of_isBoundedAtImInfty`
+-- above. We will probably want to drop it.
 /-- The D-derivative tends to 0 at infinity for bounded holomorphic functions. -/
 public lemma D_isZeroAtImInfty_of_bounded {f : ℍ → ℂ}
     (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f)

--- a/SpherePacking/ModularForms/JacobiTheta.lean
+++ b/SpherePacking/ModularForms/JacobiTheta.lean
@@ -571,7 +571,7 @@ lemma Θ₂_MDifferentiable : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) Θ₂ := by
   have hMD := hΘ₂_diff.mdifferentiableAt.comp τ τ.mdifferentiable_coe
   have : (fun t : ℂ => cexp ((π * I / 4) * t) * jacobiTheta₂ (t / 2) t) ∘
       UpperHalfPlane.coe = Θ₂ := by
-    ext x; simp only [Function.comp_apply, Θ₂_as_jacobiTheta₂, coe_mk_subtype]; ring
+    ext x; simp only [Function.comp_apply, Θ₂_as_jacobiTheta₂]; ring
   rwa [this] at hMD
 
 end H_MDifferentiable

--- a/SpherePacking/Tactic/NormNumI_Scratch.lean
+++ b/SpherePacking/Tactic/NormNumI_Scratch.lean
@@ -1,3 +1,4 @@
+set_option linter.privateModule false
 module
 
 import Mathlib.Analysis.CStarAlgebra.Classes

--- a/SpherePacking/Tactic/NormNumI_Scratch.lean
+++ b/SpherePacking/Tactic/NormNumI_Scratch.lean
@@ -1,8 +1,9 @@
-set_option linter.privateModule false
 module
 
 import Mathlib.Analysis.CStarAlgebra.Classes
 import SpherePacking.Tactic.NormNumI
+
+set_option linter.privateModule false
 
 open Complex
 

--- a/SpherePacking/Tactic/NormNumI_Scratch.lean
+++ b/SpherePacking/Tactic/NormNumI_Scratch.lean
@@ -1,9 +1,8 @@
+set_option linter.privateModule false
 module
 
 import Mathlib.Analysis.CStarAlgebra.Classes
 import SpherePacking.Tactic.NormNumI
-
-set_option linter.privateModule false
 
 open Complex
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -6,7 +6,7 @@ pp.unicode.fun = true
 autoImplicit = false
 relaxedAutoImplicit = false
 weak.linter.mathlibStandardSet = true
-linter.flexible = false
+weak.linter.flexible = false
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
- Remove deprecated/unused `coe_mk_subtype` from simp in JacobiTheta
- Wrap long comment in Derivative.lean to stay within 100 chars
- Suppress privateModule linter in NormNumI_Scratch (scratch file)