### PR TITLE
chore: remove sigma_bound in favor of ArithmeticFunction.sigma_le_pow_succ

### DIFF
--- a/SpherePacking/ModularForms/Eisenstein.lean
+++ b/SpherePacking/ModularForms/Eisenstein.lean
@@ -333,21 +333,6 @@ lemma auxasdf (n : ℕ) : (PowerSeries.coeff n) ((qExpansion 1 E₄) * (qExpansi
     ((qExpansion 1 E₄)) * (PowerSeries.coeff p.2) ((qExpansion 1 E₆)) := by
   apply PowerSeries.coeff_mul
 
-lemma sigma_bound (k n : ℕ) : σ k n ≤ n ^ (k + 1) := by
-  rw [ArithmeticFunction.sigma_apply]
-  have : ∑ d ∈ n.divisors, d ^ k ≤ ∑ d ∈ n.divisors, n ^ k := by
-    apply Finset.sum_le_sum
-    intro i hi
-    gcongr
-    exact Nat.divisor_le hi
-  apply le_trans this
-  simp
-  rw [pow_add]
-  rw [mul_comm]
-  gcongr
-  simp
-  exact Nat.card_divisors_le_self n
-
 def Ek_q (k : ℕ) : ℕ → ℂ := fun m => if m = 0 then 1 else
     (1 / (riemannZeta (k))) * ((-2 * ↑π * Complex.I) ^ k / (k - 1)!) * (σ (k-1) m)
 
@@ -864,7 +849,7 @@ theorem E_even_imag_axis_real (k : ℕ) (hk : (3 : ℤ) ≤ k) (hk2 : Even k) :
         _ ≤ ‖(↑n : ℂ) ^ k‖ * ‖cexp (2 * ↑Real.pi * Complex.I * z * n)‖ := by
           apply mul_le_mul_of_nonneg_right
           · rw [Complex.norm_natCast, Complex.norm_pow, Complex.norm_natCast]
-            have hbound := sigma_bound (k - 1) n
+            have hbound := ArithmeticFunction.sigma_le_pow_succ (k - 1) n
             have hk' : k - 1 + 1 = k := Nat.sub_add_cancel (by omega : 1 ≤ k)
             rw [hk'] at hbound
             exact_mod_cast hbound

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -204,7 +204,7 @@ lemma sigma_qexp_summable_generic (a b : ℕ) (z : UpperHalfPlane) :
       _ ≤ (n : ℝ)^(a + b + 1) * ‖Complex.exp (2 * π * Complex.I * n * z)‖ := by
           apply mul_le_mul_of_nonneg_right _ (norm_nonneg _)
           rw [Complex.norm_mul, Complex.norm_pow, Complex.norm_natCast, Complex.norm_natCast]
-          have hbound := sigma_bound b n
+          have hbound := ArithmeticFunction.sigma_le_pow_succ b n
           calc (n : ℝ)^a * (ArithmeticFunction.sigma b n : ℝ)
               ≤ (n : ℝ)^a * (n : ℝ)^(b + 1) := by
                 exact_mod_cast mul_le_mul_of_nonneg_left hbound (pow_nonneg (Nat.cast_nonneg n) a)
@@ -264,7 +264,7 @@ lemma sigma_qexp_deriv_bound_generic (k : ℕ) :
     _ ≤ (n : ℝ) ^ (k + 1) * (2 * π * n) * ‖Complex.exp (2 * π * Complex.I * n * z.1)‖ := by
         apply mul_le_mul_of_nonneg_right _ (norm_nonneg _)
         have hs : ‖(ArithmeticFunction.sigma k n : ℂ)‖ ≤ (n : ℝ) ^ (k + 1) := by
-          simp only [Complex.norm_natCast]; exact_mod_cast sigma_bound k n
+          simp only [Complex.norm_natCast]; exact_mod_cast ArithmeticFunction.sigma_le_pow_succ k n
         have hn : ‖(2 * π * Complex.I * n : ℂ)‖ = 2 * π * n := by
           simp only [norm_mul, Complex.norm_ofNat, Complex.norm_real, Real.norm_eq_abs,
             abs_of_pos Real.pi_pos, Complex.norm_I, mul_one, Complex.norm_natCast]
@@ -704,7 +704,7 @@ theorem E₂E₄_sub_E₆_div_q_tendsto :
     simp only [ha, norm_mul, Complex.norm_natCast]
     calc (↑(m + 1) : ℝ) * ↑(ArithmeticFunction.sigma 3 (m + 1))
         ≤ (↑(m + 1) : ℝ) * (↑(m + 1) : ℝ) ^ 4 :=
-          mul_le_mul_of_nonneg_left (by exact_mod_cast sigma_bound 3 (m + 1))
+          mul_le_mul_of_nonneg_left (mod_cast ArithmeticFunction.sigma_le_pow_succ 3 (m + 1))
             (Nat.cast_nonneg _)
       _ = _ := by ring
   have h_eq2 : ∀ z : ℍ,
@@ -763,7 +763,7 @@ theorem D_diff_qexp (z : ℍ) :
   have norm_a_le : ∀ n : ℕ+, ‖a n‖ ≤ (n : ℝ)^5 := fun n => by
     simp only [a, Complex.norm_mul, Complex.norm_natCast]
     calc (n : ℝ) * ↑(σ 3 ↑n) ≤ (n : ℝ) * (n : ℝ)^4 := by
-           gcongr; exact_mod_cast sigma_bound 3 n
+           gcongr; exact_mod_cast ArithmeticFunction.sigma_le_pow_succ 3 n
        _ = (n : ℝ)^5 := by ring
   have hsum : Summable (fun n : ℕ+ => a n * cexp (2 * π * I * ↑n * ↑z)) := by
     simpa [pow_one] using sigma_qexp_summable_generic 1 3 z
@@ -831,7 +831,7 @@ private theorem D_diff_div_q_tendsto :
     simp only [ha_def, norm_mul, Complex.norm_natCast, Complex.norm_pow]
     calc (↑(m + 1) : ℝ) ^ 2 * ↑(ArithmeticFunction.sigma 3 (m + 1))
         ≤ (↑(m + 1) : ℝ) ^ 2 * (↑(m + 1) : ℝ) ^ 4 :=
-          mul_le_mul_of_nonneg_left (by exact_mod_cast sigma_bound 3 (m + 1))
+          mul_le_mul_of_nonneg_left (mod_cast ArithmeticFunction.sigma_le_pow_succ 3 (m + 1))
             (pow_nonneg (Nat.cast_nonneg _) _)
       _ = _ := by ring
   have h_eq2 : ∀ z : ℍ,


### PR DESCRIPTION
`sigma_bound` was upstreamed as `ArithmeticFunction.sigma_le_pow_succ` in https://github.com/leanprover-community/mathlib4/pull/37250