### PR TITLE
Golf Jacobi theta derivative proofs

### DIFF
--- a/SpherePacking/ForMathlib/MDifferentiableFunProp.lean
+++ b/SpherePacking/ForMathlib/MDifferentiableFunProp.lean
@@ -32,3 +32,26 @@ attribute [fun_prop]
   mdifferentiable_const
   E₄_MDifferentiable
   E₆_MDifferentiable
+
+-- Lambda forms of MDifferentiable lemmas: fun_prop needs these to match value-level operations
+-- inside lambdas, since the base lemmas use function-level operators (Pi instances).
+section MDifferentiableLambda
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {F' : Type*} [NormedRing F'] [NormedAlgebra 𝕜 F']
+
+@[fun_prop]
+theorem MDifferentiable.hMul {f g : M → F'}
+    (hf : MDifferentiable I 𝓘(𝕜, F') f) (hg : MDifferentiable I 𝓘(𝕜, F') g) :
+    MDifferentiable I 𝓘(𝕜, F') (fun x => f x * g x) := hf.mul hg
+
+@[fun_prop]
+theorem MDifferentiable.hPow {f : M → F'}
+    (hf : MDifferentiable I 𝓘(𝕜, F') f) (n : ℕ) :
+    MDifferentiable I 𝓘(𝕜, F') (fun x => f x ^ n) := hf.pow n
+
+end MDifferentiableLambda

--- a/SpherePacking/ForMathlib/MDifferentiableFunProp.lean
+++ b/SpherePacking/ForMathlib/MDifferentiableFunProp.lean
@@ -32,26 +32,3 @@ attribute [fun_prop]
   mdifferentiable_const
   E₄_MDifferentiable
   E₆_MDifferentiable
-
--- Lambda forms of MDifferentiable lemmas: fun_prop needs these to match value-level operations
--- inside lambdas, since the base lemmas use function-level operators (Pi instances).
-section MDifferentiableLambda
-
-variable
-  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  {F' : Type*} [NormedRing F'] [NormedAlgebra 𝕜 F']
-
-@[fun_prop]
-theorem MDifferentiable.hMul {f g : M → F'}
-    (hf : MDifferentiable I 𝓘(𝕜, F') f) (hg : MDifferentiable I 𝓘(𝕜, F') g) :
-    MDifferentiable I 𝓘(𝕜, F') (fun x => f x * g x) := hf.mul hg
-
-@[fun_prop]
-theorem MDifferentiable.hPow {f : M → F'}
-    (hf : MDifferentiable I 𝓘(𝕜, F') f) (n : ℕ) :
-    MDifferentiable I 𝓘(𝕜, F') (fun x => f x ^ n) := hf.pow n
-
-end MDifferentiableLambda

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -141,10 +141,9 @@ theorem MLDE_F : serre_D 12 (serre_D 10 F) =
 /-- Δ_fun expressed in terms of theta functions. -/
 private lemma Δ_fun_theta :
     Δ_fun = (1 / 256 : ℂ) • ((H₂ * (H₂ + H₄) * H₄) ^ 2) := by
-  ext z
-  rw [congrFun Δ_fun_eq_Δ z, ← Delta_apply, Delta_eq_H₂_H₃_H₄ z, ← jacobi_identity]
-  simp [Pi.add_apply, Pi.mul_apply, Pi.pow_apply, Pi.smul_apply, smul_eq_mul]
-  ring
+  rw [jacobi_identity]
+  ext z; rw [congrFun Δ_fun_eq_Δ z, ← Delta_apply]
+  exact congrFun Delta_eq_H₂_H₃_H₄ z
 
 private lemma serre_D_10_G : serre_D 10 G = (5/3 : ℂ) • (H₂ ^ 3 * ((H₂ + H₄) ^ 3 + H₄ ^ 3)) := by
   rw [G_eq]

--- a/SpherePacking/ModularForms/JacobiTheta/Derivative.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Derivative.lean
@@ -73,26 +73,21 @@ local notation "Γ " n:100 => Gamma n
 -/
 
 /-- Error term for the ∂₂H₂ identity: f₂ = ∂₂H₂ - (1/6)(H₂² + 2H₂H₄) -/
-noncomputable def f₂ : ℍ → ℂ :=
-  serre_D 2 H₂ - (1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))
+noncomputable def f₂ : ℍ → ℂ := serre_D 2 H₂ - (1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))
 
 /-- Error term for the ∂₂H₃ identity: f₃ = ∂₂H₃ - (1/6)(H₂² - H₄²) -/
-noncomputable def f₃ : ℍ → ℂ :=
-  serre_D 2 H₃ - (1/6 : ℂ) • (H₂ ^ 2 - H₄ ^ 2)
+noncomputable def f₃ : ℍ → ℂ := serre_D 2 H₃ - (1/6 : ℂ) • (H₂ ^ 2 - H₄ ^ 2)
 
 /-- Error term for the ∂₂H₄ identity: f₄ = ∂₂H₄ + (1/6)(2H₂H₄ + H₄²) -/
 noncomputable def f₄ : ℍ → ℂ :=
   serre_D 2 H₄ + (1/6 : ℂ) • (H₄ * ((2 : ℂ) • H₂ + H₄))
 
 /-- f₂ decomposes as serre_D 2 H₂ + (-1/6) • (H₂ * (H₂ + 2*H₄)) -/
-lemma f₂_decompose :
-    f₂ = serre_D (2 : ℤ) H₂ + ((-1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))) := by
+lemma f₂_decompose : f₂ = serre_D (2 : ℤ) H₂ + ((-1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))) := by
   ext z; simp [f₂, sub_eq_add_neg]; ring
 
 /-- f₄ decomposes as serre_D 2 H₄ + (1/6) • (H₄ * (2*H₂ + H₄)) -/
-lemma f₄_decompose :
-    f₄ = serre_D (2 : ℤ) H₄ + ((1/6 : ℂ) • (H₄ * ((2 : ℂ) • H₂ + H₄))) := by
-  rfl
+lemma f₄_decompose : f₄ = serre_D (2 : ℤ) H₄ + ((1/6 : ℂ) • (H₄ * ((2 : ℂ) • H₂ + H₄))) := by rfl
 
 /-!
 ## Phase 2: MDifferentiable for Error Terms
@@ -113,19 +108,15 @@ lemma f₄_MDifferentiable : MDiff f₄ := by unfold f₄; fun_prop
 
 /-- The error terms satisfy f₂ + f₄ = f₃ (from Jacobi identity) -/
 lemma f₂_add_f₄_eq_f₃ : f₂ + f₄ = f₃ := by
-  ext z; simp only [Pi.add_apply, f₂, f₃, f₄]
-  -- Key relation: serre_D 2 H₂ z + serre_D 2 H₄ z = serre_D 2 H₃ z (via Jacobi identity)
+  ext z
+  simp only [Pi.add_apply, Pi.sub_apply, Pi.smul_apply, Pi.mul_apply,
+    Pi.pow_apply, smul_eq_mul, f₂, f₃, f₄]
   have h_serre : serre_D 2 H₂ z + serre_D 2 H₄ z = serre_D 2 H₃ z := by
-    have h := congrFun (serre_D_add (2 : ℤ) H₂ H₄ H₂_SIF_MDifferentiable H₄_SIF_MDifferentiable) z
+    have h := congrFun
+      (serre_D_add (2 : ℤ) H₂ H₄ H₂_SIF_MDifferentiable H₄_SIF_MDifferentiable) z
     simp only [Pi.add_apply] at h
     convert h.symm using 2; exact jacobi_identity.symm
-  calc serre_D 2 H₂ z - 1/6 * (H₂ z * (H₂ z + 2 * H₄ z)) +
-       (serre_D 2 H₄ z + 1/6 * (H₄ z * (2 * H₂ z + H₄ z)))
-      = (serre_D 2 H₂ z + serre_D 2 H₄ z) +
-        (1/6 * (H₄ z * (2 * H₂ z + H₄ z)) - 1/6 * (H₂ z * (H₂ z + 2 * H₄ z))) := by ring
-    _ = serre_D 2 H₃ z +
-        (1/6 * (H₄ z * (2 * H₂ z + H₄ z)) - 1/6 * (H₂ z * (H₂ z + 2 * H₄ z))) := by rw [h_serre]
-    _ = serre_D 2 H₃ z - 1/6 * (H₂ z ^ 2 - H₄ z ^ 2) := by ring
+  linear_combination h_serre
 
 /-!
 ## Phase 5: S/T Transformation Rules for f₂, f₄
@@ -163,13 +154,17 @@ lemma f₂_S_action : (f₂ ∣[(4 : ℤ)] S) = -f₄ := by
         serre_D_slash_equivariant (2 : ℤ) H₂ H₂_SIF_MDifferentiable S, H₂_S_action]
     simpa using serre_D_smul 2 (-1) H₄ H₄_SIF_MDifferentiable
   -- Step 2: (H₂ + 2•H₄)|[2]S = -(H₄ + 2•H₂)
-  have h_lin_comb : ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] S) = -(H₄ + (2 : ℂ) • H₂) := by
+  have h_lin_comb :
+      ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] S) = -(H₄ + (2 : ℂ) • H₂) := by
     rw [add_slash, SL_smul_slash, H₂_S_action, H₄_S_action]
     ext z; simp [Pi.add_apply, Pi.smul_apply, Pi.neg_apply]; ring
-  -- Step 3: Product (H₂ * (H₂ + 2•H₄))|[4]S = H₄ * (H₄ + 2•H₂)
-  have h_prod : ((H₂ * (H₂ + (2 : ℂ) • H₄)) ∣[(4 : ℤ)] S) = H₄ * (H₄ + (2 : ℂ) • H₂) := by
-    rw [show (4 : ℤ) = 2 + 2 from rfl, mul_slash_SL2 2 2 S _ _, H₂_S_action, h_lin_comb]
-    ext z; simp [Pi.mul_apply, Pi.neg_apply, Pi.add_apply, Pi.smul_apply]; ring
+  -- Step 3
+  have h_prod : ((H₂ * (H₂ + (2 : ℂ) • H₄)) ∣[(4 : ℤ)] S) =
+      H₄ * (H₄ + (2 : ℂ) • H₂) := by
+    rw [show (4 : ℤ) = 2 + 2 from rfl,
+      mul_slash_SL2 2 2 S _ _, H₂_S_action, h_lin_comb]
+    ext z; simp [Pi.mul_apply, Pi.neg_apply, Pi.add_apply, Pi.smul_apply]
+    ring
   -- Combine: f₂|[4]S = -serre_D 2 H₄ - (1/6) * H₄ * (2*H₂ + H₄) = -f₄
   rw [f₂_decompose, add_slash, SL_smul_slash, h_serre_term, h_prod]
   unfold f₄
@@ -198,14 +193,19 @@ lemma f₂_T_action : (f₂ ∣[(4 : ℤ)] T) = -f₂ := by
   have h_lin_comb : ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] T) = H₂ + (2 : ℂ) • H₄ := by
     rw [add_slash, SL_smul_slash, H₂_T_action, H₄_T_action]
     ext z; simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, smul_eq_mul]
-    simp only [show H₃ z = H₂ z + H₄ z by rw [← Pi.add_apply, (congrFun jacobi_identity z).symm]]
+    simp only [(by rw [← Pi.add_apply,
+      (congrFun jacobi_identity z).symm] : H₃ z = H₂ z + H₄ z)]
     ring
   -- Step 3: Product (H₂ * (H₂ + 2•H₄))|[4]T = (-H₂) * (H₂ + 2•H₄)
-  have h_prod : ((H₂ * (H₂ + (2 : ℂ) • H₄)) ∣[(4 : ℤ)] T) = -H₂ * (H₂ + (2 : ℂ) • H₄) := by
-    rw [show (4 : ℤ) = 2 + 2 from rfl, mul_slash_SL2 2 2 T _ _, H₂_T_action, h_lin_comb]
-  -- Combine: f₂|[4]T = -serre_D 2 H₂ - (1/6)(-H₂)(H₂ + 2H₄) = -f₂
+  have h_prod : ((H₂ * (H₂ + (2 : ℂ) • H₄)) ∣[(4 : ℤ)] T) =
+      -H₂ * (H₂ + (2 : ℂ) • H₄) := by
+    rw [show (4 : ℤ) = 2 + 2 from rfl,
+      mul_slash_SL2 2 2 T _ _, H₂_T_action, h_lin_comb]
+  -- Combine
   rw [f₂_decompose, add_slash, SL_smul_slash, h_serre_term, h_prod]
-  ext z; simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.mul_apply, smul_eq_mul]; ring
+  ext z
+  simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.mul_apply, smul_eq_mul]
+  ring
 
 /-- f₄ transforms under S as f₄|S = -f₂.
 
@@ -220,14 +220,15 @@ lemma f₄_S_action : (f₄ ∣[(4 : ℤ)] S) = -f₂ := by
         serre_D_slash_equivariant (2 : ℤ) H₄ H₄_SIF_MDifferentiable S, H₄_S_action]
     simpa using serre_D_smul 2 (-1) H₂ H₂_SIF_MDifferentiable
   -- Step 2: (2•H₂ + H₄)|[2]S = -(2•H₄ + H₂)
-  have h_lin_comb : (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] S) = -((2 : ℂ) • H₄ + H₂) := by
+  have h_lin_comb :
+      (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] S) = -((2 : ℂ) • H₄ + H₂) := by
     rw [add_slash, SL_smul_slash, H₂_S_action, H₄_S_action]
     ext z; simp [Pi.add_apply, Pi.smul_apply, Pi.neg_apply]; ring
   -- Step 3: Product (H₄ * (2•H₂ + H₄))|[4]S = H₂ * (H₂ + 2•H₄)
   have h_prod : ((H₄ * ((2 : ℂ) • H₂ + H₄)) ∣[(4 : ℤ)] S) = H₂ * (H₂ + (2 : ℂ) • H₄) := by
     rw [show (4 : ℤ) = 2 + 2 from rfl, mul_slash_SL2 2 2 S _ _, H₄_S_action, h_lin_comb]
     ext z; simp [Pi.mul_apply, Pi.neg_apply, Pi.add_apply, Pi.smul_apply]; ring
-  -- Combine: f₄|[4]S = -serre_D 2 H₂ + (1/6) * H₂ * (H₂ + 2H₄) = -f₂
+  -- Combine
   rw [f₄_decompose, add_slash, SL_smul_slash, h_serre_term, h_prod]
   unfold f₂
   ext z
@@ -253,20 +254,22 @@ lemma f₄_T_action : (f₄ ∣[(4 : ℤ)] T) = f₃ := by
   -- -2H₂ + H₃ = -2H₂ + (H₂ + H₄) = H₄ - H₂
   have h_lin_comb : (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] T) = H₄ - H₂ := by
     rw [add_slash, SL_smul_slash, H₂_T_action, H₄_T_action]
-    ext z; simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.sub_apply, smul_eq_mul]
-    simp only [show H₃ z = H₂ z + H₄ z by rw [← Pi.add_apply, (congrFun jacobi_identity z).symm]]
+    ext z
+    simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply,
+      Pi.sub_apply, smul_eq_mul]
+    simp only [(by rw [← Pi.add_apply,
+      (congrFun jacobi_identity z).symm] : H₃ z = H₂ z + H₄ z)]
     ring
-  -- Step 3: Product (H₄ * (2•H₂ + H₄))|[4]T = H₃ * (H₄ - H₂)
+  -- Step 3
   have h_prod : ((H₄ * ((2 : ℂ) • H₂ + H₄)) ∣[(4 : ℤ)] T) = H₃ * (H₄ - H₂) := by
-    rw [show (4 : ℤ) = 2 + 2 from rfl, mul_slash_SL2 2 2 T _ _, H₄_T_action, h_lin_comb]
-  -- Combine: f₄|[4]T = serre_D 2 H₃ + (1/6) * H₃ * (H₄ - H₂) = f₃
+    rw [show (4 : ℤ) = 2 + 2 from rfl,
+      mul_slash_SL2 2 2 T _ _, H₄_T_action, h_lin_comb]
+  -- Combine
   rw [f₄_decompose, add_slash, SL_smul_slash, h_serre_term, h_prod]
-  -- Now: serre_D 2 H₃ + (1/6) • H₃ * (H₄ - H₂) = f₃
-  -- Key: H₂² - H₄² = (H₂ - H₄)(H₂ + H₄) = (H₂ - H₄) * H₃
   unfold f₃
   ext z
   simp only [Pi.sub_apply, Pi.add_apply, Pi.smul_apply, Pi.mul_apply, Pi.pow_apply, smul_eq_mul]
-  rw [show H₃ z = H₂ z + H₄ z by rw [← Pi.add_apply, (congrFun jacobi_identity z).symm]]
+  rw [(by rw [← Pi.add_apply, (congrFun jacobi_identity z).symm] : H₃ z = H₂ z + H₄ z)]
   ring_nf
 
 /-!
@@ -274,8 +277,7 @@ lemma f₄_T_action : (f₄ ∣[(4 : ℤ)] T) = f₃ := by
 -/
 
 /-- Level-1 invariant of weight 6: g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄ -/
-noncomputable def theta_g : ℍ → ℂ :=
-  ((2 : ℂ) • H₂ + H₄) * f₂ + (H₂ + (2 : ℂ) • H₄) * f₄
+noncomputable def theta_g : ℍ → ℂ := ((2 : ℂ) • H₂ + H₄) * f₂ + (H₂ + (2 : ℂ) • H₄) * f₄
 
 /-- Level-1 invariant of weight 8: h = f₂² + f₂f₄ + f₄² -/
 noncomputable def theta_h : ℍ → ℂ := f₂ ^ 2 + f₂ * f₄ + f₄ ^ 2
@@ -288,25 +290,29 @@ g|S = (2(-H₄) + (-H₂))(-f₄) + ((-H₄) + 2(-H₂))(-f₂)
     = (2H₄ + H₂)f₄ + (H₄ + 2H₂)f₂
     = g -/
 lemma theta_g_S_action : (theta_g ∣[(6 : ℤ)] S) = theta_g := by
-  -- Linear combination transforms: (2•H₂ + H₄)|S = -(2•H₄ + H₂), (H₂ + 2•H₄)|S = -(H₄ + 2•H₂)
-  have h_2H₂_H₄ : (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] S) = -((2 : ℂ) • H₄ + H₂) := by
+  have h_2H₂_H₄ :
+      (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] S) = -((2 : ℂ) • H₄ + H₂) := by
     simp only [add_slash, SL_smul_slash, H₂_S_action, H₄_S_action]
     ext z; simp [Pi.add_apply, Pi.smul_apply, Pi.neg_apply]; ring
-  have h_H₂_2H₄ : ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] S) = -(H₄ + (2 : ℂ) • H₂) := by
+  have h_H₂_2H₄ :
+      ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] S) = -(H₄ + (2 : ℂ) • H₂) := by
     simp only [add_slash, SL_smul_slash, H₂_S_action, H₄_S_action]
     ext z; simp [Pi.add_apply, Pi.smul_apply, Pi.neg_apply]; ring
-  -- Product transforms using mul_slash_SL2
-  have h_term1 : ((((2 : ℂ) • H₂ + H₄) * f₂) ∣[(6 : ℤ)] S) = ((2 : ℂ) • H₄ + H₂) * f₄ := by
+  have h_term1 : ((((2 : ℂ) • H₂ + H₄) * f₂) ∣[(6 : ℤ)] S) =
+      ((2 : ℂ) • H₄ + H₂) * f₄ := by
     have hmul := mul_slash_SL2 2 4 S ((2 : ℂ) • H₂ + H₄) f₂
     simp only [h_2H₂_H₄, f₂_S_action] at hmul
-    convert hmul using 1; ext z; simp only [Pi.mul_apply, Pi.neg_apply]; ring
-  have h_term2 : (((H₂ + (2 : ℂ) • H₄) * f₄) ∣[(6 : ℤ)] S) = (H₄ + (2 : ℂ) • H₂) * f₂ := by
+    convert hmul using 1
+    ext z; simp only [Pi.mul_apply, Pi.neg_apply]; ring
+  have h_term2 : (((H₂ + (2 : ℂ) • H₄) * f₄) ∣[(6 : ℤ)] S) =
+      (H₄ + (2 : ℂ) • H₂) * f₂ := by
     have hmul := mul_slash_SL2 2 4 S (H₂ + (2 : ℂ) • H₄) f₄
     simp only [h_H₂_2H₄, f₄_S_action] at hmul
-    convert hmul using 1; ext z; simp only [Pi.mul_apply, Pi.neg_apply]; ring
-  -- g|S = (2H₄ + H₂)f₄ + (H₄ + 2H₂)f₂ = g
+    convert hmul using 1
+    ext z; simp only [Pi.mul_apply, Pi.neg_apply]; ring
   simp only [theta_g, add_slash, h_term1, h_term2]
-  ext z; simp only [Pi.add_apply, Pi.mul_apply, Pi.smul_apply]; ring
+  ext z
+  simp only [Pi.add_apply, Pi.mul_apply, Pi.smul_apply]; ring
 
 /-- g is invariant under T.
 
@@ -314,24 +320,21 @@ Proof: Under T: H₂ ↦ -H₂, H₄ ↦ H₃, f₂ ↦ -f₂, f₄ ↦ f₃ = f
 g|T = (2(-H₂) + H₃)(-f₂) + ((-H₂) + 2H₃)(f₂ + f₄)
 Using Jacobi: H₃ = H₂ + H₄, simplifies to g. -/
 lemma theta_g_T_action : (theta_g ∣[(6 : ℤ)] T) = theta_g := by
-  -- Under T: H₂ → -H₂, H₄ → H₃, f₂ → -f₂, f₄ → f₃
-  -- Linear combination transforms: (2•H₂ + H₄)|T = -2•H₂ + H₃, (H₂ + 2•H₄)|T = -H₂ + 2•H₃
-  have h_2H₂_H₄ : (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] T) = -(2 : ℂ) • H₂ + H₃ := by
-    simp only [add_slash, SL_smul_slash, H₂_T_action, H₄_T_action, smul_neg]
+  have h_2H₂_H₄ :
+      (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] T) = -(2 : ℂ) • H₂ + H₃ := by
+    simp only [add_slash, SL_smul_slash,
+      H₂_T_action, H₄_T_action, smul_neg]
     ext z
-    simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, smul_eq_mul]
+    simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply,
+      smul_eq_mul]
     ring
-  have h_H₂_2H₄ : ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] T) = -H₂ + (2 : ℂ) • H₃ := by
+  have h_H₂_2H₄ :
+      ((H₂ + (2 : ℂ) • H₄) ∣[(2 : ℤ)] T) = -H₂ + (2 : ℂ) • H₃ := by
     simp only [add_slash, SL_smul_slash, H₂_T_action, H₄_T_action]
-  -- Product transforms
   have h_term1 : ((((2 : ℂ) • H₂ + H₄) * f₂) ∣[(6 : ℤ)] T) = (-(2 : ℂ) • H₂ + H₃) * (-f₂) := by
-    have hmul := mul_slash_SL2 2 4 T ((2 : ℂ) • H₂ + H₄) f₂
-    simp only [h_2H₂_H₄, f₂_T_action] at hmul
-    exact hmul
+    simpa only [h_2H₂_H₄, f₂_T_action] using mul_slash_SL2 2 4 T ((2 : ℂ) • H₂ + H₄) f₂
   have h_term2 : (((H₂ + (2 : ℂ) • H₄) * f₄) ∣[(6 : ℤ)] T) = (-H₂ + (2 : ℂ) • H₃) * f₃ := by
-    have hmul := mul_slash_SL2 2 4 T (H₂ + (2 : ℂ) • H₄) f₄
-    simp only [h_H₂_2H₄, f₄_T_action] at hmul
-    exact hmul
+    simpa only [h_H₂_2H₄, f₄_T_action]  using mul_slash_SL2 2 4 T (H₂ + (2 : ℂ) • H₄) f₄
   -- Combine and simplify using Jacobi: H₃ = H₂ + H₄, f₃ = f₂ + f₄
   simp only [theta_g, add_slash, h_term1, h_term2]
   ext z; simp only [Pi.add_apply, Pi.mul_apply, Pi.smul_apply, Pi.neg_apply, smul_eq_mul]
@@ -413,39 +416,20 @@ The tendsto lemmas for H₂, H₃, H₄ are already in `Basic.lean`:
 -/
 
 /-- theta_g is MDifferentiable (from MDifferentiable of f₂, f₄, H₂, H₄) -/
-lemma theta_g_MDifferentiable : MDiff theta_g :=
-  ((mdifferentiable_const.mul H₂_SIF_MDifferentiable).add H₄_SIF_MDifferentiable).mul
-    f₂_MDifferentiable |>.add <|
-  (H₂_SIF_MDifferentiable.add (mdifferentiable_const.mul H₄_SIF_MDifferentiable)).mul
-    f₄_MDifferentiable
+lemma theta_g_MDifferentiable : MDiff theta_g := by unfold theta_g f₂ f₄; fun_prop
 
 /-- theta_h is MDifferentiable (from MDifferentiable of f₂, f₄) -/
-lemma theta_h_MDifferentiable : MDiff theta_h := by
-  unfold theta_h
-  exact ((f₂_MDifferentiable.pow 2).add (f₂_MDifferentiable.mul f₄_MDifferentiable)).add
-    (f₄_MDifferentiable.pow 2)
-
-/-- theta_g is slash-invariant under Γ(1) in GL₂(ℝ) form -/
-lemma theta_g_slash_invariant_GL :
-    ∀ γ ∈ Subgroup.map (SpecialLinearGroup.mapGL ℝ) (Γ 1),
-    theta_g ∣[(6 : ℤ)] γ = theta_g :=
-  slashaction_generators_GL2R theta_g 6 theta_g_S_action theta_g_T_action
-
-/-- theta_h is slash-invariant under Γ(1) in GL₂(ℝ) form -/
-lemma theta_h_slash_invariant_GL :
-    ∀ γ ∈ Subgroup.map (SpecialLinearGroup.mapGL ℝ) (Γ 1),
-    theta_h ∣[(8 : ℤ)] γ = theta_h :=
-  slashaction_generators_GL2R theta_h 8 theta_h_S_action theta_h_T_action
+lemma theta_h_MDifferentiable : MDiff theta_h := by unfold theta_h f₂ f₄; fun_prop
 
 /-- theta_g as a SlashInvariantForm of level 1 -/
 noncomputable def theta_g_SIF : SlashInvariantForm (Γ 1) 6 where
   toFun := theta_g
-  slash_action_eq' := theta_g_slash_invariant_GL
+  slash_action_eq' := slashaction_generators_GL2R theta_g 6 theta_g_S_action theta_g_T_action
 
 /-- theta_h as a SlashInvariantForm of level 1 -/
 noncomputable def theta_h_SIF : SlashInvariantForm (Γ 1) 8 where
   toFun := theta_h
-  slash_action_eq' := theta_h_slash_invariant_GL
+  slash_action_eq' := slashaction_generators_GL2R theta_h 8 theta_h_S_action theta_h_T_action
 
 /-- f₂ tends to 0 at infinity.
 Proof: f₂ = serre_D 2 H₂ - (1/6)H₂(H₂ + 2H₄)
@@ -484,8 +468,7 @@ lemma theta_g_tendsto_atImInfty : Tendsto theta_g atImInfty (𝓝 0) := by
   have := H₄_tendsto_atImInfty
   have := f₂_tendsto_atImInfty
   have := f₄_tendsto_atImInfty
-  change Tendsto (fun z => (2 * H₂ z + H₄ z) * f₂ z + (H₂ z + 2 * H₄ z) * f₄ z)
-    atImInfty (𝓝 0)
+  change Tendsto (fun z => (2 * H₂ z + H₄ z) * f₂ z + (H₂ z + 2 * H₄ z) * f₄ z) atImInfty (𝓝 0)
   tendsto_cont
 
 /-- theta_h tends to 0 at infinity.
@@ -521,24 +504,20 @@ lemma theta_h_eq_zero : theta_h = 0 :=
 -/
 
 /-- H₂² + H₂H₄ + H₄² -/
-noncomputable def H_sum_sq : ℍ → ℂ := fun z => H₂ z ^ 2 + H₂ z * H₄ z + H₄ z ^ 2
+noncomputable def H_sum_sq : ℍ → ℂ := H₂ ^ 2 + H₂ * H₄ + H₄ ^ 2
 
 /-- H_sum_sq is MDifferentiable -/
-lemma H_sum_sq_MDifferentiable : MDiff H_sum_sq := by
-  unfold H_sum_sq
-  exact ((H₂_SIF_MDifferentiable.pow 2).add (H₂_SIF_MDifferentiable.mul H₄_SIF_MDifferentiable)).add
-    (H₄_SIF_MDifferentiable.pow 2)
+lemma H_sum_sq_MDifferentiable : MDiff H_sum_sq := by unfold H_sum_sq; fun_prop
 
 /-- H_sum_sq → 1 at infinity -/
 lemma H_sum_sq_tendsto : Tendsto H_sum_sq atImInfty (𝓝 1) := by
   have := H₂_tendsto_atImInfty
   have := H₄_tendsto_atImInfty
-  unfold H_sum_sq
+  change Tendsto (fun z => H₂ z ^ 2 + H₂ z * H₄ z + H₄ z ^ 2) atImInfty (𝓝 1)
   tendsto_cont
 
 /-- H_sum_sq ≠ 0 (since it tends to 1 ≠ 0) -/
-lemma H_sum_sq_ne_zero : H_sum_sq ≠ 0 :=
-  ne_zero_of_tendsto_ne_zero one_ne_zero H_sum_sq_tendsto
+lemma H_sum_sq_ne_zero : H_sum_sq ≠ 0 := ne_zero_of_tendsto_ne_zero one_ne_zero H_sum_sq_tendsto
 
 /-- 3 * H_sum_sq ≠ 0 -/
 lemma three_H_sum_sq_ne_zero : (fun z => 3 * H_sum_sq z) ≠ 0 :=
@@ -556,29 +535,27 @@ E₄ and H_sum_sq are both weight-4 level-1 modular forms tending to 1 at ∞.
 Their difference is a weight-4 cusp form, hence zero by dimension vanishing.
 -/
 
+private lemma H_sum_sq_eq_mul : H_sum_sq = H₂ * H₂ + H₂ * H₄ + H₄ * H₄ := by
+  ext z; simp [H_sum_sq, sq]
+
 /-- S-action on H_sum_sq: invariant since H₂|S = -H₄ and H₄|S = -H₂ -/
 private lemma H_sum_sq_S_action : (H_sum_sq ∣[(4 : ℤ)] S) = H_sum_sq := by
-  have h_eq : H_sum_sq = H₂ * H₂ + H₂ * H₄ + H₄ * H₄ := by
-    ext z; simp [H_sum_sq, sq]
-  simp only [h_eq, show (4 : ℤ) = 2 + 2 from by norm_num,
-    SlashAction.add_slash, mul_slash_SL2 2 2 S _ _, H₂_S_action, H₄_S_action]
+  rw [H_sum_sq_eq_mul, show (4 : ℤ) = 2 + 2 from rfl]
+  simp only [SlashAction.add_slash, mul_slash_SL2 2 2 S _ _, H₂_S_action, H₄_S_action]
   ext z; simp [Pi.mul_apply, Pi.add_apply]; ring
 
-/-- T-action on H_sum_sq: invariant since H₂|T = -H₂ and H₄|T = H₃ = H₂+H₄ -/
+/-- T-action on H_sum_sq -/
 private lemma H_sum_sq_T_action : (H_sum_sq ∣[(4 : ℤ)] T) = H_sum_sq := by
-  have h_eq : H_sum_sq = H₂ * H₂ + H₂ * H₄ + H₄ * H₄ := by
-    ext z; simp [H_sum_sq, sq]
-  simp only [h_eq, show (4 : ℤ) = 2 + 2 from by norm_num,
-    SlashAction.add_slash, mul_slash_SL2 2 2 T _ _, H₂_T_action, H₄_T_action, ← jacobi_identity]
+  rw [H_sum_sq_eq_mul, show (4 : ℤ) = 2 + 2 from rfl]
+  simp only [SlashAction.add_slash, mul_slash_SL2 2 2 T _ _,
+    H₂_T_action, H₄_T_action, ← jacobi_identity]
   ext z; simp [Pi.mul_apply, Pi.add_apply]; ring
 
-private lemma H_sum_sq_SL2Z_invariant :
-    ∀ γ : SL(2, ℤ), H_sum_sq ∣[(4 : ℤ)] γ = H_sum_sq :=
+private lemma H_sum_sq_SL2Z_invariant : ∀ γ : SL(2, ℤ), H_sum_sq ∣[(4 : ℤ)] γ = H_sum_sq :=
   slashaction_generators_SL2Z H_sum_sq 4 H_sum_sq_S_action H_sum_sq_T_action
 
 private lemma isBoundedAtImInfty_H_sum_sq : IsBoundedAtImInfty H_sum_sq := by
-  have : H_sum_sq = H₂ * H₂ + H₂ * H₄ + H₄ * H₄ := by ext z; simp [H_sum_sq, sq]
-  rw [this]
+  rw [H_sum_sq_eq_mul]
   exact ((isBoundedAtImInfty_H₂.mul isBoundedAtImInfty_H₂).add
     (isBoundedAtImInfty_H₂.mul isBoundedAtImInfty_H₄)).add
     (isBoundedAtImInfty_H₄.mul isBoundedAtImInfty_H₄)
@@ -628,24 +605,16 @@ lemma f₄_sq_mul_eq (z : ℍ) (hg_z : theta_g z = 0) :
   -- A²f₂² = B²f₄²
   have h1 : A ^ 2 * f₂ z ^ 2 = B ^ 2 * f₄ z ^ 2 := by
     have h_sq : (A * f₂ z) ^ 2 = (B * f₄ z) ^ 2 := by rw [hAf₂]; ring
-    calc A ^ 2 * f₂ z ^ 2 = (A * f₂ z) ^ 2 := by ring
-      _ = (B * f₄ z) ^ 2 := h_sq
-      _ = B ^ 2 * f₄ z ^ 2 := by ring
+    linear_combination h_sq
   -- A²f₂f₄ = -ABf₄²
-  have h2 : A ^ 2 * (f₂ z * f₄ z) = -(A * B * f₄ z ^ 2) := by
-    calc A ^ 2 * (f₂ z * f₄ z) = (A * f₂ z) * (A * f₄ z) := by ring
-      _ = (-(B * f₄ z)) * (A * f₄ z) := by rw [hAf₂]
-      _ = -(A * B * f₄ z ^ 2) := by ring
+  have h2 : A ^ 2 * (f₂ z * f₄ z) = -(A * B * f₄ z ^ 2) := by linear_combination A * f₄ z * hAf₂
   -- A² - AB + B² = 3(H₂² + H₂H₄ + H₄²)
   have h_sum : A ^ 2 - A * B + B ^ 2 = 3 * (H₂ z ^ 2 + H₂ z * H₄ z + H₄ z ^ 2) := by
     simp only [hA, hB]; ring
   -- Now compute A²θₕ
   unfold theta_h
-  calc f₄ z ^ 2 * (3 * (H₂ z ^ 2 + H₂ z * H₄ z + H₄ z ^ 2))
-      = f₄ z ^ 2 * (A ^ 2 - A * B + B ^ 2) := by rw [h_sum]
-    _ = B ^ 2 * f₄ z ^ 2 + (-(A * B * f₄ z ^ 2)) + A ^ 2 * f₄ z ^ 2 := by ring
-    _ = A ^ 2 * f₂ z ^ 2 + A ^ 2 * (f₂ z * f₄ z) + A ^ 2 * f₄ z ^ 2 := by rw [h1, h2]
-    _ = A ^ 2 * (f₂ z ^ 2 + f₂ z * f₄ z + f₄ z ^ 2) := by ring
+  simp only [Pi.add_apply, Pi.mul_apply, Pi.pow_apply]
+  linear_combination -f₄ z ^ 2 * h_sum - h1 - h2
 
 /-- From g = 0 and h = 0, deduce f₂ = 0.
 
@@ -694,8 +663,7 @@ lemma f₃_eq_zero : f₃ = 0 := by
 -/
 
 /-- Serre derivative of H₂: ∂₂H₂ = (1/6)(H₂² + 2H₂H₄) -/
-theorem serre_D_H₂ :
-    serre_D 2 H₂ = fun z => (1/6 : ℂ) * (H₂ z ^ 2 + 2 * H₂ z * H₄ z) := by
+theorem serre_D_H₂ : serre_D 2 H₂ = fun z => (1/6 : ℂ) * (H₂ z ^ 2 + 2 * H₂ z * H₄ z) := by
   funext z; have := congrFun f₂_eq_zero z
   simp only [f₂, Pi.sub_apply, Pi.smul_apply, Pi.mul_apply, Pi.add_apply, smul_eq_mul,
     Pi.zero_apply, sub_eq_zero] at this
@@ -709,16 +677,14 @@ theorem serre_D_H₃ : serre_D 2 H₃ = fun z => (1/6 : ℂ) * (H₂ z ^ 2 - H�
   exact this
 
 /-- Serre derivative of H₄: ∂₂H₄ = -(1/6)(2H₂H₄ + H₄²) -/
-theorem serre_D_H₄ :
-    serre_D 2 H₄ = fun z => -(1/6 : ℂ) * (2 * H₂ z * H₄ z + H₄ z ^ 2) := by
+theorem serre_D_H₄ : serre_D 2 H₄ = fun z => -(1/6 : ℂ) * (2 * H₂ z * H₄ z + H₄ z ^ 2) := by
   funext z; have := congrFun f₄_eq_zero z
   simp only [f₄, Pi.add_apply, Pi.smul_apply, Pi.mul_apply, smul_eq_mul, Pi.zero_apply,
     add_eq_zero_iff_eq_neg] at this
   convert this using 1; ring
 
 /-- Ordinary derivative of `H₂` in terms of `H₂`, `H₄`, and `E₂`. -/
-theorem D_H₂ :
-    D H₂ = (1 / 6 : ℂ) • (H₂ ^ 2 + (2 : ℂ) • (H₂ * H₄)) + (1 / 6 : ℂ) • (E₂ * H₂) := by
+theorem D_H₂ : D H₂ = (1 / 6 : ℂ) • (H₂ ^ 2 + (2 : ℂ) • (H₂ * H₄)) + (1 / 6 : ℂ) • (E₂ * H₂) := by
   ext z
   have h : D H₂ z = serre_D 2 H₂ z + 2 * 12⁻¹ * E₂ z * H₂ z := by
     simp only [serre_D_apply]
@@ -728,8 +694,7 @@ theorem D_H₂ :
   ring
 
 /-- Ordinary derivative of `H₃` in terms of `H₂`, `H₄`, and `E₂`. -/
-theorem D_H₃ :
-    D H₃ = (1 / 6 : ℂ) • (H₂ ^ 2 - H₄ ^ 2) + (1 / 6 : ℂ) • (E₂ * H₃) := by
+theorem D_H₃ : D H₃ = (1 / 6 : ℂ) • (H₂ ^ 2 - H₄ ^ 2) + (1 / 6 : ℂ) • (E₂ * H₃) := by
   ext z
   have h : D H₃ z = serre_D 2 H₃ z + 2 * 12⁻¹ * E₂ z * H₃ z := by
     simp only [serre_D_apply]
@@ -739,9 +704,8 @@ theorem D_H₃ :
   ring
 
 /-- Ordinary derivative of `H₄` in terms of `H₂`, `H₄`, and `E₂`. -/
-theorem D_H₄ :
-    D H₄ = (-(1 / 6 : ℂ)) • ((2 : ℂ) • (H₂ * H₄) + H₄ ^ 2) +
-      (1 / 6 : ℂ) • (E₂ * H₄) := by
+theorem D_H₄ : D H₄ =
+    (-(1 / 6 : ℂ)) • ((2 : ℂ) • (H₂ * H₄) + H₄ ^ 2) + (1 / 6 : ℂ) • (E₂ * H₄) := by
   ext z
   have h : D H₄ z = serre_D 2 H₄ z + 2 * 12⁻¹ * E₂ z * H₄ z := by
     simp only [serre_D_apply]

--- a/SpherePacking/ModularForms/JacobiTheta/Derivative.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Derivative.lean
@@ -11,54 +11,18 @@ public import SpherePacking.Tactic.TendstoCont
 @[expose] public section
 
 /-!
-# Theta Derivative Identities
+# Serre derivative identities for Jacobi theta functions
 
-This file proves the Serre derivative identities for Jacobi theta functions
-(Blueprint Proposition 6.52, equations (32)–(34)):
+Proves Blueprint Proposition 6.52, equations (32)-(34):
+* `serre_D_H₂` : `serre_D 2 H₂ = (1/6)(H₂² + 2H₂H₄)`
+* `serre_D_H₃` : `serre_D 2 H₃ = (1/6)(H₂² - H₄²)`
+* `serre_D_H₄` : `serre_D 2 H₄ = -(1/6)(2H₂H₄ + H₄²)`
 
-* `serre_D_H₂` : serre_D 2 H₂ = (1/6) * (H₂² + 2*H₂*H₄)
-* `serre_D_H₃` : serre_D 2 H₃ = (1/6) * (H₂² - H₄²)
-* `serre_D_H₄` : serre_D 2 H₄ = -(1/6) * (2*H₂*H₄ + H₄²)
-
-## Contents
-
-### Error Terms (Phases 1-5)
-* Error terms `f₂`, `f₃`, `f₄` definitions
-* MDifferentiable proofs for error terms
-* Relation `f₂ + f₄ = f₃` (from `jacobi_identity` in `JacobiIdentity.lean`)
-* S/T transformation rules: `f₂_S_action`, `f₂_T_action`, `f₄_S_action`, `f₄_T_action`
-
-### Level-1 Invariants (Phase 6)
-* Level-1 invariant `theta_g` (weight 6): g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄
-* Level-1 invariant `theta_h` (weight 8): h = f₂² + f₂f₄ + f₄²
-* S/T invariance: `theta_g_S_action`, `theta_g_T_action`, `theta_h_S_action`, `theta_h_T_action`
-
-### Cusp Form Arguments (Phase 7)
-* Tendsto lemmas for f₂, f₄, theta_g, theta_h at infinity
-* Cusp form construction for theta_g and theta_h
-
-### Dimension Vanishing (Phase 8)
-* theta_g = 0 and theta_h = 0 by weight < 12 cusp form vanishing
-
-### Main Deduction (Phase 9)
-* f₂ = f₃ = f₄ = 0
-
-### Main Theorems (Phase 10)
-* serre_D_H₂, serre_D_H₃, serre_D_H₄
-
-## Strategy
-
-We define error terms f₂, f₃, f₄ = (LHS - RHS) and prove their transformation rules under
-the S and T generators of SL(2,ℤ). The key results are:
-- f₂|S = -f₄, f₂|T = -f₂
-- f₄|S = -f₂, f₄|T = f₃
-
-Using these transformation rules, we construct g and h such that g|S = g, g|T = g, h|S = h, h|T = h.
-This makes g and h into level-1 (SL(2,ℤ)-invariant) modular forms.
-
-We then show g and h vanish at infinity (Phase 7), hence are cusp forms. By dimension
-vanishing (Phase 8), all level-1 cusp forms of weight < 12 are zero. This gives g = h = 0,
-from which we deduce f₂ = f₃ = f₄ = 0 (Phase 9), yielding the main theorems (Phase 10).
+Strategy: define error terms `f₂, f₃, f₄ := (LHS - RHS)`, show their S/T
+transformation rules (`f₂|S = -f₄`, `f₂|T = -f₂`, `f₄|S = -f₂`,
+`f₄|T = f₃`), build level-1 invariants `g` (weight 6) and `h` (weight 8)
+that vanish at `i∞`, then apply cusp form dimension vanishing to get
+`g = h = 0`, from which `f₂ = f₃ = f₄ = 0`.
 -/
 
 open UpperHalfPlane hiding I
@@ -68,45 +32,33 @@ open Complex Real Asymptotics Filter Topology Manifold SlashInvariantForm Matrix
 local notation "Γ " n:100 => Gamma n
 
 
-/-!
-## Phase 1: Error Term Definitions
--/
-
-/-- Error term for the ∂₂H₂ identity: f₂ = ∂₂H₂ - (1/6)(H₂² + 2H₂H₄) -/
+/-- Error term: `f₂ = ∂₂H₂ - (1/6)(H₂² + 2H₂H₄)` -/
 noncomputable def f₂ : ℍ → ℂ := serre_D 2 H₂ - (1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))
 
-/-- Error term for the ∂₂H₃ identity: f₃ = ∂₂H₃ - (1/6)(H₂² - H₄²) -/
+/-- Error term: `f₃ = ∂₂H₃ - (1/6)(H₂² - H₄²)` -/
 noncomputable def f₃ : ℍ → ℂ := serre_D 2 H₃ - (1/6 : ℂ) • (H₂ ^ 2 - H₄ ^ 2)
 
-/-- Error term for the ∂₂H₄ identity: f₄ = ∂₂H₄ + (1/6)(2H₂H₄ + H₄²) -/
+/-- Error term: `f₄ = ∂₂H₄ + (1/6)(2H₂H₄ + H₄²)` -/
 noncomputable def f₄ : ℍ → ℂ :=
   serre_D 2 H₄ + (1/6 : ℂ) • (H₄ * ((2 : ℂ) • H₂ + H₄))
 
-/-- f₂ decomposes as serre_D 2 H₂ + (-1/6) • (H₂ * (H₂ + 2*H₄)) -/
+/-- `f₂ = serre_D 2 H₂ + (-1/6) • (H₂ * (H₂ + 2H₄))` -/
 lemma f₂_decompose : f₂ = serre_D (2 : ℤ) H₂ + ((-1/6 : ℂ) • (H₂ * (H₂ + (2 : ℂ) • H₄))) := by
   ext z; simp [f₂, sub_eq_add_neg]; ring
 
-/-- f₄ decomposes as serre_D 2 H₄ + (1/6) • (H₄ * (2*H₂ + H₄)) -/
+/-- `f₄ = serre_D 2 H₄ + (1/6) • (H₄ * (2H₂ + H₄))` -/
 lemma f₄_decompose : f₄ = serre_D (2 : ℤ) H₄ + ((1/6 : ℂ) • (H₄ * ((2 : ℂ) • H₂ + H₄))) := by rfl
 
-/-!
-## Phase 2: MDifferentiable for Error Terms
--/
-
-/-- f₂ is MDifferentiable -/
+/-- `f₂` is MDifferentiable -/
 lemma f₂_MDifferentiable : MDiff f₂ := by unfold f₂; fun_prop
 
-/-- f₃ is MDifferentiable -/
+/-- `f₃` is MDifferentiable -/
 lemma f₃_MDifferentiable : MDiff f₃ := by unfold f₃; fun_prop
 
-/-- f₄ is MDifferentiable -/
+/-- `f₄` is MDifferentiable -/
 lemma f₄_MDifferentiable : MDiff f₄ := by unfold f₄; fun_prop
 
-/-!
-## Phase 3-4: Relation f₂ + f₄ = f₃
--/
-
-/-- The error terms satisfy f₂ + f₄ = f₃ (from Jacobi identity) -/
+/-- `f₂ + f₄ = f₃` (from Jacobi identity) -/
 lemma f₂_add_f₄_eq_f₃ : f₂ + f₄ = f₃ := by
   ext z
   simp only [Pi.add_apply, Pi.sub_apply, Pi.smul_apply, Pi.mul_apply,
@@ -118,35 +70,7 @@ lemma f₂_add_f₄_eq_f₃ : f₂ + f₄ = f₃ := by
     convert h.symm using 2; exact jacobi_identity.symm
   linear_combination h_serre
 
-/-!
-## Phase 5: S/T Transformation Rules for f₂, f₄
-
-These transformations depend on `serre_D_slash_equivariant` (which has a sorry in Derivative.lean).
-The proofs use:
-- serre_D_slash_equivariant: (serre_D k F)|[k+2]γ = serre_D k (F|[k]γ)
-- H₂_S_action: H₂|[2]S = -H₄
-- H₄_S_action: H₄|[2]S = -H₂
-- H₂_T_action: H₂|[2]T = -H₂
-- H₃_T_action: H₃|[2]T = H₄
-- H₄_T_action: H₄|[2]T = H₃
-
-From these, we get:
-- (serre_D 2 H₂)|[4]S = serre_D 2 (H₂|[2]S) = serre_D 2 (-H₄) = -serre_D 2 H₄
-- Products transform multiplicatively: (H₂·G)|[4]S = (H₂|[2]S)·(G|[2]S)
--/
-
-/-- f₂ transforms under S as f₂|S = -f₄.
-
-Proof outline using serre_D_slash_equivariant:
-1. (serre_D 2 H₂)|[4]S = serre_D 2 (H₂|[2]S) = serre_D 2 (-H₄) = -serre_D 2 H₄
-2. (H₂(H₂ + 2H₄))|[4]S = (-H₄)((-H₄) + 2(-H₂)) = H₄(H₄ + 2H₂)
-3. f₂|[4]S = -serre_D 2 H₄ - (1/6)H₄(H₄ + 2H₂) = -f₄
-
-Key lemmas used:
-- serre_D_slash_equivariant: (serre_D k F)|[k+2]γ = serre_D k (F|[k]γ)
-- serre_D_smul: serre_D k (c • F) = c • serre_D k F (used for negation)
-- mul_slash_SL2: (f * g)|[k1+k2]A = (f|[k1]A) * (g|[k2]A)
-- add_slash, SL_smul_slash for linearity -/
+/-- `f₂|[4]S = -f₄` -/
 lemma f₂_S_action : (f₂ ∣[(4 : ℤ)] S) = -f₄ := by
   -- Step 1: (serre_D 2 H₂)|[4]S = -serre_D 2 H₄ (via equivariance)
   have h_serre_term : (serre_D (2 : ℤ) H₂ ∣[(4 : ℤ)] S) = -serre_D (2 : ℤ) H₄ := by
@@ -172,16 +96,7 @@ lemma f₂_S_action : (f₂ ∣[(4 : ℤ)] S) = -f₄ := by
   simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.mul_apply, smul_eq_mul]
   ring_nf
 
-/-- f₂ transforms under T as f₂|T = -f₂.
-
-Proof outline:
-1. (serre_D 2 H₂)|[4]T = serre_D 2 (H₂|[2]T) = serre_D 2 (-H₂) = -serre_D 2 H₂
-2. (H₂(H₂ + 2H₄))|[4]T = (-H₂)((-H₂) + 2H₃)
-   Using Jacobi H₃ = H₂ + H₄: -H₂ + 2H₃ = -H₂ + 2(H₂ + H₄) = H₂ + 2H₄
-   So: (H₂(H₂ + 2H₄))|[4]T = (-H₂)(H₂ + 2H₄)
-3. f₂|[4]T = -serre_D 2 H₂ - (1/6)(-H₂)(H₂ + 2H₄)
-           = -serre_D 2 H₂ + (1/6)H₂(H₂ + 2H₄)
-           = -(serre_D 2 H₂ - (1/6)H₂(H₂ + 2H₄)) = -f₂ -/
+/-- `f₂|[4]T = -f₂` -/
 lemma f₂_T_action : (f₂ ∣[(4 : ℤ)] T) = -f₂ := by
   -- Step 1: (serre_D 2 H₂)|[4]T = -serre_D 2 H₂ (via equivariance)
   have h_serre_term : (serre_D (2 : ℤ) H₂ ∣[(4 : ℤ)] T) = -serre_D (2 : ℤ) H₂ := by
@@ -207,12 +122,7 @@ lemma f₂_T_action : (f₂ ∣[(4 : ℤ)] T) = -f₂ := by
   simp only [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.mul_apply, smul_eq_mul]
   ring
 
-/-- f₄ transforms under S as f₄|S = -f₂.
-
-Proof outline (symmetric to f₂_S_action):
-1. (serre_D 2 H₄)|[4]S = serre_D 2 (H₄|[2]S) = serre_D 2 (-H₂) = -serre_D 2 H₂
-2. (H₄(2H₂ + H₄))|[4]S = (-H₂)(2(-H₄) + (-H₂)) = H₂(H₂ + 2H₄)
-3. f₄|[4]S = -serre_D 2 H₂ + (1/6)H₂(H₂ + 2H₄) = -f₂ -/
+/-- `f₄|[4]S = -f₂` -/
 lemma f₄_S_action : (f₄ ∣[(4 : ℤ)] S) = -f₂ := by
   -- Step 1: (serre_D 2 H₄)|[4]S = -serre_D 2 H₂ (via equivariance)
   have h_serre_term : (serre_D (2 : ℤ) H₄ ∣[(4 : ℤ)] S) = -serre_D (2 : ℤ) H₂ := by
@@ -235,16 +145,7 @@ lemma f₄_S_action : (f₄ ∣[(4 : ℤ)] S) = -f₂ := by
   simp only [Pi.sub_apply, Pi.add_apply, Pi.smul_apply, Pi.neg_apply, Pi.mul_apply, smul_eq_mul]
   ring_nf
 
-/-- f₄ transforms under T as f₄|T = f₃.
-
-Proof outline:
-1. (serre_D 2 H₄)|[4]T = serre_D 2 (H₄|[2]T) = serre_D 2 H₃
-2. (H₄(2H₂ + H₄))|[4]T = H₃(2(-H₂) + H₃) = H₃(H₃ - 2H₂)
-   Using Jacobi H₃ = H₂ + H₄: H₃ - 2H₂ = H₄ - H₂
-3. f₄|[4]T = serre_D 2 H₃ + (1/6)H₃(H₃ - 2H₂)
-   But H₂² - H₄² = (H₂ - H₄)(H₂ + H₄) = (H₂ - H₄)H₃
-   So (1/6)(H₂² - H₄²) = -(1/6)H₃(H₄ - H₂) = -(1/6)H₃(H₃ - 2H₂)
-   Thus f₃ = serre_D 2 H₃ - (1/6)(H₂² - H₄²) = f₄|[4]T -/
+/-- `f₄|[4]T = f₃` -/
 lemma f₄_T_action : (f₄ ∣[(4 : ℤ)] T) = f₃ := by
   -- Step 1: (serre_D 2 H₄)|[4]T = serre_D 2 H₃ (via equivariance)
   have h_serre_term : (serre_D (2 : ℤ) H₄ ∣[(4 : ℤ)] T) = serre_D (2 : ℤ) H₃ := by
@@ -272,23 +173,13 @@ lemma f₄_T_action : (f₄ ∣[(4 : ℤ)] T) = f₃ := by
   rw [(by rw [← Pi.add_apply, (congrFun jacobi_identity z).symm] : H₃ z = H₂ z + H₄ z)]
   ring_nf
 
-/-!
-## Phase 6: Level-1 Invariants g, h
--/
-
-/-- Level-1 invariant of weight 6: g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄ -/
+/-- Weight-6 level-1 invariant: `g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄` -/
 noncomputable def theta_g : ℍ → ℂ := ((2 : ℂ) • H₂ + H₄) * f₂ + (H₂ + (2 : ℂ) • H₄) * f₄
 
-/-- Level-1 invariant of weight 8: h = f₂² + f₂f₄ + f₄² -/
+/-- Weight-8 level-1 invariant: `h = f₂² + f₂f₄ + f₄²` -/
 noncomputable def theta_h : ℍ → ℂ := f₂ ^ 2 + f₂ * f₄ + f₄ ^ 2
 
-/-- g is invariant under S.
-
-Proof: g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄
-Under S: H₂ ↦ -H₄, H₄ ↦ -H₂, f₂ ↦ -f₄, f₄ ↦ -f₂
-g|S = (2(-H₄) + (-H₂))(-f₄) + ((-H₄) + 2(-H₂))(-f₂)
-    = (2H₄ + H₂)f₄ + (H₄ + 2H₂)f₂
-    = g -/
+/-- `g|[6]S = g` -/
 lemma theta_g_S_action : (theta_g ∣[(6 : ℤ)] S) = theta_g := by
   have h_2H₂_H₄ :
       (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] S) = -((2 : ℂ) • H₄ + H₂) := by
@@ -314,11 +205,7 @@ lemma theta_g_S_action : (theta_g ∣[(6 : ℤ)] S) = theta_g := by
   ext z
   simp only [Pi.add_apply, Pi.mul_apply, Pi.smul_apply]; ring
 
-/-- g is invariant under T.
-
-Proof: Under T: H₂ ↦ -H₂, H₄ ↦ H₃, f₂ ↦ -f₂, f₄ ↦ f₃ = f₂ + f₄
-g|T = (2(-H₂) + H₃)(-f₂) + ((-H₂) + 2H₃)(f₂ + f₄)
-Using Jacobi: H₃ = H₂ + H₄, simplifies to g. -/
+/-- `g|[6]T = g` -/
 lemma theta_g_T_action : (theta_g ∣[(6 : ℤ)] T) = theta_g := by
   have h_2H₂_H₄ :
       (((2 : ℂ) • H₂ + H₄) ∣[(2 : ℤ)] T) = -(2 : ℂ) • H₂ + H₃ := by
@@ -341,14 +228,7 @@ lemma theta_g_T_action : (theta_g ∣[(6 : ℤ)] T) = theta_g := by
   rw [(congrFun jacobi_identity z).symm, (congrFun f₂_add_f₄_eq_f₃ z).symm]
   simp only [Pi.add_apply]; ring
 
-/-- h is invariant under S.
-
-Proof: h = f₂² + f₂f₄ + f₄²
-Under S: f₂|[4]S = -f₄, f₄|[4]S = -f₂
-Using mul_slash_SL2: (f₂²)|[8]S = (f₂|[4]S)² = (-f₄)² = f₄²
-                     (f₂f₄)|[8]S = (f₂|[4]S)(f₄|[4]S) = (-f₄)(-f₂) = f₂f₄
-                     (f₄²)|[8]S = (f₄|[4]S)² = (-f₂)² = f₂²
-So h|[8]S = f₄² + f₂f₄ + f₂² = f₂² + f₂f₄ + f₄² = h -/
+/-- `h|[8]S = h` -/
 lemma theta_h_S_action : (theta_h ∣[(8 : ℤ)] S) = theta_h := by
   -- Under S: f₂ ↦ -f₄, f₄ ↦ -f₂
   -- (f₂²)|S = f₄², (f₄²)|S = f₂², (f₂f₄)|S = f₂f₄
@@ -372,12 +252,7 @@ lemma theta_h_S_action : (theta_h ∣[(8 : ℤ)] S) = theta_h := by
   simp only [Pi.add_apply, Pi.mul_apply, sq]
   ring
 
-/-- h is invariant under T.
-
-Proof: Under T: f₂ ↦ -f₂, f₄ ↦ f₃ = f₂ + f₄
-h|T = (-f₂)² + (-f₂)(f₂ + f₄) + (f₂ + f₄)²
-    = f₂² - f₂² - f₂f₄ + f₂² + 2f₂f₄ + f₄²
-    = f₂² + f₂f₄ + f₄² = h -/
+/-- `h|[8]T = h` -/
 lemma theta_h_T_action : (theta_h ∣[(8 : ℤ)] T) = theta_h := by
   -- Under T: f₂ ↦ -f₂, f₄ ↦ f₃ = f₂ + f₄
   -- (f₂²)|T = f₂², (f₄²)|T = (f₂+f₄)², (f₂f₄)|T = (-f₂)(f₂+f₄)
@@ -405,35 +280,23 @@ lemma theta_h_T_action : (theta_h ∣[(8 : ℤ)] T) = theta_h := by
   simp only [Pi.add_apply, Pi.mul_apply, Pi.neg_apply, sq]
   ring
 
-/-!
-## Phase 7: Cusp Form Arguments
-
-We need to show g and h vanish at infinity.
-The tendsto lemmas for H₂, H₃, H₄ are already in `Basic.lean`:
-- H₂_tendsto_atImInfty : Tendsto H₂ atImInfty (𝓝 0)
-- H₃_tendsto_atImInfty : Tendsto H₃ atImInfty (𝓝 1)
-- H₄_tendsto_atImInfty : Tendsto H₄ atImInfty (𝓝 1)
--/
-
-/-- theta_g is MDifferentiable (from MDifferentiable of f₂, f₄, H₂, H₄) -/
+/-- `theta_g` is MDifferentiable -/
 lemma theta_g_MDifferentiable : MDiff theta_g := by unfold theta_g f₂ f₄; fun_prop
 
-/-- theta_h is MDifferentiable (from MDifferentiable of f₂, f₄) -/
+/-- `theta_h` is MDifferentiable -/
 lemma theta_h_MDifferentiable : MDiff theta_h := by unfold theta_h f₂ f₄; fun_prop
 
-/-- theta_g as a SlashInvariantForm of level 1 -/
+/-- `theta_g` as a `SlashInvariantForm` of level 1 -/
 noncomputable def theta_g_SIF : SlashInvariantForm (Γ 1) 6 where
   toFun := theta_g
   slash_action_eq' := slashaction_generators_GL2R theta_g 6 theta_g_S_action theta_g_T_action
 
-/-- theta_h as a SlashInvariantForm of level 1 -/
+/-- `theta_h` as a `SlashInvariantForm` of level 1 -/
 noncomputable def theta_h_SIF : SlashInvariantForm (Γ 1) 8 where
   toFun := theta_h
   slash_action_eq' := slashaction_generators_GL2R theta_h 8 theta_h_S_action theta_h_T_action
 
-/-- f₂ tends to 0 at infinity.
-Proof: f₂ = serre_D 2 H₂ - (1/6)H₂(H₂ + 2H₄)
-Since H₂ → 0, both serre_D 2 H₂ → 0 and H₂(H₂ + 2H₄) → 0, so f₂ → 0. -/
+/-- `f₂ → 0` at `i∞` -/
 lemma f₂_tendsto_atImInfty : Tendsto f₂ atImInfty (𝓝 0) := by
   have h_serre_H₂ := serre_D_tendsto_zero_of_tendsto_zero 2 H₂
     H₂_SIF_MDifferentiable isBoundedAtImInfty_H₂ H₂_tendsto_atImInfty
@@ -443,11 +306,7 @@ lemma f₂_tendsto_atImInfty : Tendsto f₂ atImInfty (𝓝 0) := by
     tendsto_cont
   simpa [f₂] using h_serre_H₂.sub (h_prod.const_mul (1/6 : ℂ))
 
-/-- f₄ tends to 0 at infinity.
-Proof: f₄ = serre_D 2 H₄ + (1/6)H₄(2H₂ + H₄)
-serre_D 2 H₄ = D H₄ - (1/6)E₂ H₄ → 0 - (1/6)*1*1 = -1/6 (since H₄ → 1, E₂ → 1)
-H₄(2H₂ + H₄) → 1*(0 + 1) = 1
-So f₄ → -1/6 + (1/6)*1 = 0. -/
+/-- `f₄ → 0` at `i∞` -/
 lemma f₄_tendsto_atImInfty : Tendsto f₄ atImInfty (𝓝 0) := by
   have h_serre_H₄ : Tendsto (serre_D 2 H₄) atImInfty (𝓝 (-(1/6 : ℂ))) := by
     convert serre_D_tendsto_neg_k_div_12 2 H₄ H₄_SIF_MDifferentiable isBoundedAtImInfty_H₄
@@ -460,9 +319,7 @@ lemma f₄_tendsto_atImInfty : Tendsto f₄ atImInfty (𝓝 0) := by
     tendsto_cont
   simpa [f₄] using h_serre_H₄.add h_scaled
 
-/-- theta_g tends to 0 at infinity.
-theta_g = (2H₂ + H₄)f₂ + (H₂ + 2H₄)f₄.
-Since 2H₂ + H₄ → 1, H₂ + 2H₄ → 2, and f₂, f₄ → 0, we get theta_g → 0. -/
+/-- `theta_g → 0` at `i∞` -/
 lemma theta_g_tendsto_atImInfty : Tendsto theta_g atImInfty (𝓝 0) := by
   have := H₂_tendsto_atImInfty
   have := H₄_tendsto_atImInfty
@@ -471,8 +328,7 @@ lemma theta_g_tendsto_atImInfty : Tendsto theta_g atImInfty (𝓝 0) := by
   change Tendsto (fun z => (2 * H₂ z + H₄ z) * f₂ z + (H₂ z + 2 * H₄ z) * f₄ z) atImInfty (𝓝 0)
   tendsto_cont
 
-/-- theta_h tends to 0 at infinity.
-theta_h = f₂² + f₂f₄ + f₄² → 0 + 0 + 0 = 0 as f₂, f₄ → 0. -/
+/-- `theta_h → 0` at `i∞` -/
 lemma theta_h_tendsto_atImInfty : Tendsto theta_h atImInfty (𝓝 0) := by
   have := f₂_tendsto_atImInfty
   have := f₄_tendsto_atImInfty
@@ -485,66 +341,51 @@ private noncomputable def theta_g_CF : CuspForm (Γ 1) 6 :=
 private noncomputable def theta_h_CF : CuspForm (Γ 1) 8 :=
   cuspFormOfSIFTendstoZero theta_h_SIF theta_h_MDifferentiable theta_h_tendsto_atImInfty
 
-/-!
-## Phase 8: Apply Dimension Vanishing
--/
-
-/-- g = 0 by dimension argument: weight-6 cusp forms vanish. -/
+/-- `g = 0` by weight-6 cusp form dimension vanishing -/
 lemma theta_g_eq_zero : theta_g = 0 :=
   congr_arg (·.toFun)
     (rank_zero_iff_forall_zero.mp (cuspform_weight_lt_12_zero 6 (by norm_num)) theta_g_CF)
 
-/-- h = 0 by dimension argument: weight-8 cusp forms vanish. -/
+/-- `h = 0` by weight-8 cusp form dimension vanishing -/
 lemma theta_h_eq_zero : theta_h = 0 :=
   congr_arg (·.toFun)
     (rank_zero_iff_forall_zero.mp (cuspform_weight_lt_12_zero 8 (by norm_num)) theta_h_CF)
 
-/-!
-## H_sum_sq: H₂² + H₂H₄ + H₄²
--/
-
-/-- H₂² + H₂H₄ + H₄² -/
+/-- `H₂² + H₂H₄ + H₄²` -/
 noncomputable def H_sum_sq : ℍ → ℂ := H₂ ^ 2 + H₂ * H₄ + H₄ ^ 2
 
-/-- H_sum_sq is MDifferentiable -/
+/-- `H_sum_sq` is MDifferentiable -/
 lemma H_sum_sq_MDifferentiable : MDiff H_sum_sq := by unfold H_sum_sq; fun_prop
 
-/-- H_sum_sq → 1 at infinity -/
+/-- `H_sum_sq → 1` at `i∞` -/
 lemma H_sum_sq_tendsto : Tendsto H_sum_sq atImInfty (𝓝 1) := by
   have := H₂_tendsto_atImInfty
   have := H₄_tendsto_atImInfty
   change Tendsto (fun z => H₂ z ^ 2 + H₂ z * H₄ z + H₄ z ^ 2) atImInfty (𝓝 1)
   tendsto_cont
 
-/-- H_sum_sq ≠ 0 (since it tends to 1 ≠ 0) -/
+/-- `H_sum_sq ≠ 0` -/
 lemma H_sum_sq_ne_zero : H_sum_sq ≠ 0 := ne_zero_of_tendsto_ne_zero one_ne_zero H_sum_sq_tendsto
 
-/-- 3 * H_sum_sq ≠ 0 -/
+/-- `3 * H_sum_sq ≠ 0` -/
 lemma three_H_sum_sq_ne_zero : (fun z => 3 * H_sum_sq z) ≠ 0 :=
   fun h => H_sum_sq_ne_zero
     (funext fun z => (mul_eq_zero.mp (congrFun h z)).resolve_left (by norm_num))
 
-/-- 3 * H_sum_sq is MDifferentiable -/
+/-- `3 * H_sum_sq` is MDifferentiable -/
 lemma three_H_sum_sq_MDifferentiable : MDiff (fun z => 3 * H_sum_sq z) :=
   mdifferentiable_const.mul H_sum_sq_MDifferentiable
-
-/-!
-## E₄ = H_sum_sq (dimension argument)
-
-E₄ and H_sum_sq are both weight-4 level-1 modular forms tending to 1 at ∞.
-Their difference is a weight-4 cusp form, hence zero by dimension vanishing.
--/
 
 private lemma H_sum_sq_eq_mul : H_sum_sq = H₂ * H₂ + H₂ * H₄ + H₄ * H₄ := by
   ext z; simp [H_sum_sq, sq]
 
-/-- S-action on H_sum_sq: invariant since H₂|S = -H₄ and H₄|S = -H₂ -/
+/-- `H_sum_sq|[4]S = H_sum_sq` -/
 private lemma H_sum_sq_S_action : (H_sum_sq ∣[(4 : ℤ)] S) = H_sum_sq := by
   rw [H_sum_sq_eq_mul, show (4 : ℤ) = 2 + 2 from rfl]
   simp only [SlashAction.add_slash, mul_slash_SL2 2 2 S _ _, H₂_S_action, H₄_S_action]
   ext z; simp [Pi.mul_apply, Pi.add_apply]; ring
 
-/-- T-action on H_sum_sq -/
+/-- `H_sum_sq|[4]T = H_sum_sq` -/
 private lemma H_sum_sq_T_action : (H_sum_sq ∣[(4 : ℤ)] T) = H_sum_sq := by
   rw [H_sum_sq_eq_mul, show (4 : ℤ) = 2 + 2 from rfl]
   simp only [SlashAction.add_slash, mul_slash_SL2 2 2 T _ _,
@@ -571,8 +412,7 @@ private noncomputable def H_sum_sq_MF : ModularForm (Γ 1) 4 := {
     rw [← hA]; simpa [SL_slash] using H_sum_sq_SL2Z_invariant A' ▸ isBoundedAtImInfty_H_sum_sq
 }
 
-/-- E₄.toFun = H₂² + H₂H₄ + H₄². Both are weight-4 level-1 modular forms tending to 1
-at ∞, so their difference is a weight-4 cusp form, hence zero. -/
+/-- `E₄ = H₂² + H₂H₄ + H₄²` by weight-4 cusp form dimension vanishing -/
 theorem E₄_eq_H_sum_sq : E₄.toFun = H_sum_sq := by
   have h_toFun : (E₄ - H_sum_sq_MF).toFun = E₄.toFun - H_sum_sq := by
     ext z; simp [H_sum_sq_MF, H_sum_sq_SIF]; rfl
@@ -584,12 +424,7 @@ theorem E₄_eq_H_sum_sq : E₄.toFun = H_sum_sq := by
   have h_zero := IsCuspForm_weight_lt_eq_zero 4 (by norm_num) (E₄ - H_sum_sq_MF) h_cusp
   funext z; simpa [sub_eq_zero] using DFunLike.congr_fun h_zero z
 
-/-!
-## Phase 9: Deduce f₂ = f₃ = f₄ = 0
--/
-
-/-- Key algebraic identity for proving f₂ = f₄ = 0.
-Given Af₂ + Bf₄ = 0, we have f₄² * (A² - AB + B²) = A² * (f₂² + f₂f₄ + f₄²). -/
+/-- From `Af₂ + Bf₄ = 0`: `f₄² · 3H_sum_sq = A² · theta_h` -/
 lemma f₄_sq_mul_eq (z : ℍ) (hg_z : theta_g z = 0) :
     f₄ z ^ 2 * (3 * H_sum_sq z) = (2 * H₂ z + H₄ z) ^ 2 * theta_h z := by
   unfold H_sum_sq
@@ -616,11 +451,7 @@ lemma f₄_sq_mul_eq (z : ℍ) (hg_z : theta_g z = 0) :
   simp only [Pi.add_apply, Pi.mul_apply, Pi.pow_apply]
   linear_combination -f₄ z ^ 2 * h_sum - h1 - h2
 
-/-- From g = 0 and h = 0, deduce f₂ = 0.
-
-Proof: From g = 0 we get a relation between f₂ and f₄. Combined with h = 0,
-we show f₄² · (3 · H_sum_sq) = 0. Since H_sum_sq → 1 ≠ 0, we get f₄ = 0,
-then f₂ = 0 follows from h = f₂² = 0. -/
+/-- `f₂ = 0` from `g = 0` and `h = 0` -/
 lemma f₂_eq_zero : f₂ = 0 := by
   have hg := theta_g_eq_zero
   have hh := theta_h_eq_zero
@@ -649,34 +480,30 @@ lemma f₂_eq_zero : f₂ = 0 := by
   exact (UpperHalfPlane.mul_eq_zero_iff f₄_MDifferentiable f₄_MDifferentiable).mp
     (pow_two f₄ ▸ h_f₄_sq_zero) |>.elim id id
 
-/-- From f₂ = 0 and h = 0, deduce f₄ = 0 -/
+/-- `f₄ = 0` -/
 lemma f₄_eq_zero : f₄ = 0 := by
   funext z; simpa [theta_h, sq_eq_zero_iff, f₂_eq_zero] using congrFun theta_h_eq_zero z
 
-/-- From f₂ + f₄ = f₃ and both = 0, f₃ = 0 -/
+/-- `f₃ = 0` -/
 lemma f₃_eq_zero : f₃ = 0 := by
   rw [← f₂_add_f₄_eq_f₃]
   simp [f₂_eq_zero, f₄_eq_zero]
 
-/-!
-## Phase 10: Main Theorems
--/
-
-/-- Serre derivative of H₂: ∂₂H₂ = (1/6)(H₂² + 2H₂H₄) -/
+/-- `∂₂H₂ = (1/6)(H₂² + 2H₂H₄)` -/
 theorem serre_D_H₂ : serre_D 2 H₂ = fun z => (1/6 : ℂ) * (H₂ z ^ 2 + 2 * H₂ z * H₄ z) := by
   funext z; have := congrFun f₂_eq_zero z
   simp only [f₂, Pi.sub_apply, Pi.smul_apply, Pi.mul_apply, Pi.add_apply, smul_eq_mul,
     Pi.zero_apply, sub_eq_zero] at this
   convert this using 1; ring
 
-/-- Serre derivative of H₃: ∂₂H₃ = (1/6)(H₂² - H₄²) -/
+/-- `∂₂H₃ = (1/6)(H₂² - H₄²)` -/
 theorem serre_D_H₃ : serre_D 2 H₃ = fun z => (1/6 : ℂ) * (H₂ z ^ 2 - H₄ z ^ 2) := by
   funext z; have := congrFun f₃_eq_zero z
   simp only [f₃, Pi.sub_apply, Pi.smul_apply, Pi.pow_apply, smul_eq_mul, Pi.zero_apply,
     sub_eq_zero] at this
   exact this
 
-/-- Serre derivative of H₄: ∂₂H₄ = -(1/6)(2H₂H₄ + H₄²) -/
+/-- `∂₂H₄ = -(1/6)(2H₂H₄ + H₄²)` -/
 theorem serre_D_H₄ : serre_D 2 H₄ = fun z => -(1/6 : ℂ) * (2 * H₂ z * H₄ z + H₄ z ^ 2) := by
   funext z; have := congrFun f₄_eq_zero z
   simp only [f₄, Pi.add_apply, Pi.smul_apply, Pi.mul_apply, smul_eq_mul, Pi.zero_apply,

--- a/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
@@ -36,21 +36,15 @@ noncomputable def jacobi_f : ℍ → ℂ := jacobi_g ^ 2
 
 /-- S-action on `g`: `g|[2]S = -g`. -/
 lemma jacobi_g_S_action : (jacobi_g ∣[(2 : ℤ)] S) = -jacobi_g := by
-  change ((H₂ + H₄ - H₃) ∣[(2 : ℤ)] S) = -(H₂ + H₄ - H₃)
-  simp only [sub_eq_add_neg, SlashAction.add_slash, SlashAction.neg_slash,
+  simp only [jacobi_g, sub_eq_add_neg, SlashAction.add_slash, SlashAction.neg_slash,
     H₂_S_action, H₃_S_action, H₄_S_action]
-  ext z
-  simp only [Pi.add_apply, Pi.neg_apply]
-  ring
+  ext z; simp only [Pi.add_apply, Pi.neg_apply]; ring
 
 /-- T-action on `g`: `g|[2]T = -g`. -/
 lemma jacobi_g_T_action : (jacobi_g ∣[(2 : ℤ)] T) = -jacobi_g := by
-  change ((H₂ + H₄ - H₃) ∣[(2 : ℤ)] T) = -(H₂ + H₄ - H₃)
-  simp only [sub_eq_add_neg, SlashAction.add_slash, SlashAction.neg_slash,
+  simp only [jacobi_g, sub_eq_add_neg, SlashAction.add_slash, SlashAction.neg_slash,
     H₂_T_action, H₃_T_action, H₄_T_action]
-  ext z
-  simp only [Pi.add_apply, Pi.neg_apply]
-  ring
+  ext z; simp only [Pi.add_apply, Pi.neg_apply]; ring
 
 /-- Rewrite `jacobi_f` as a pointwise product. -/
 lemma jacobi_f_eq_mul : jacobi_f = jacobi_g * jacobi_g := by
@@ -59,12 +53,12 @@ lemma jacobi_f_eq_mul : jacobi_f = jacobi_g * jacobi_g := by
 
 /-- S-invariance of `f`: `f|[4]S = f`, because `g|[2]S = -g`. -/
 lemma jacobi_f_S_action : (jacobi_f ∣[(4 : ℤ)] S) = jacobi_f := by
-  simp only [jacobi_f_eq_mul, show (4 : ℤ) = 2 + 2 by norm_num,
+  simp only [jacobi_f_eq_mul, (by norm_num : (4 : ℤ) = 2 + 2),
     mul_slash_SL2 2 2 S _ _, jacobi_g_S_action, neg_mul_neg]
 
 /-- T-invariance of `f`: `f|[4]T = f`, because `g|[2]T = -g`. -/
 lemma jacobi_f_T_action : (jacobi_f ∣[(4 : ℤ)] T) = jacobi_f := by
-  simp only [jacobi_f_eq_mul, show (4 : ℤ) = 2 + 2 by norm_num,
+  simp only [jacobi_f_eq_mul, (by norm_num : (4 : ℤ) = 2 + 2),
     mul_slash_SL2 2 2 T _ _, jacobi_g_T_action, neg_mul_neg]
 
 /-- Full `SL₂(ℤ)` invariance of `f` with weight 4. -/
@@ -83,9 +77,7 @@ lemma jacobi_g_MDifferentiable : MDiff jacobi_g := by
 
 /-- `jacobi_f` is holomorphic since `jacobi_g` is. -/
 lemma jacobi_f_MDifferentiable : MDiff jacobi_f := by
-  unfold jacobi_f
-  have _ := jacobi_g_MDifferentiable
-  fun_prop
+  unfold jacobi_f jacobi_g; fun_prop
 
 /-- `jacobi_f_SIF` is holomorphic. -/
 lemma jacobi_f_SIF_MDifferentiable : MDiff jacobi_f_SIF := jacobi_f_MDifferentiable
@@ -136,33 +128,29 @@ theorem jacobi_identity : H₂ + H₄ = H₃ := by
 private noncomputable def theta_prod : ℍ → ℂ := H₂ * H₃ * H₄
 
 private lemma theta_prod_S_action : (theta_prod ∣[(6 : ℤ)] S) = -theta_prod := by
-  simp only [theta_prod, show (6 : ℤ) = (2 + 2) + 2 from by norm_num,
+  simp only [theta_prod, (by norm_num : (6 : ℤ) = 2 + 2 + 2),
     mul_slash_SL2 (2 + 2) 2 S _ _, mul_slash_SL2 2 2 S _ _,
     H₂_S_action, H₃_S_action, H₄_S_action]
-  ext z
-  simp [Pi.mul_apply, Pi.neg_apply]
-  ring
+  ext z; simp [Pi.mul_apply, Pi.neg_apply]; ring
 
 private lemma theta_prod_T_action : (theta_prod ∣[(6 : ℤ)] T) = -theta_prod := by
-  simp only [theta_prod, show (6 : ℤ) = (2 + 2) + 2 from by norm_num,
+  simp only [theta_prod, (by norm_num : (6 : ℤ) = 2 + 2 + 2),
     mul_slash_SL2 (2 + 2) 2 T _ _, mul_slash_SL2 2 2 T _ _,
     H₂_T_action, H₃_T_action, H₄_T_action]
-  ext z
-  simp [Pi.mul_apply, Pi.neg_apply]
-  ring
+  ext z; simp [Pi.mul_apply, Pi.neg_apply]; ring
 
-private noncomputable def theta_prod_sq : ℍ → ℂ := fun z => (H₂ z * H₃ z * H₄ z) ^ 2
+private noncomputable def theta_prod_sq : ℍ → ℂ := (H₂ * H₃ * H₄) ^ 2
 
 private lemma theta_prod_sq_eq_mul : theta_prod_sq = theta_prod * theta_prod := by
   ext z
   simp [theta_prod_sq, theta_prod, sq, Pi.mul_apply]
 
 private lemma theta_prod_sq_S_action : (theta_prod_sq ∣[(12 : ℤ)] S) = theta_prod_sq := by
-  rw [theta_prod_sq_eq_mul, show (12 : ℤ) = 6 + 6 from by norm_num,
+  rw [theta_prod_sq_eq_mul, (by norm_num : (12 : ℤ) = 6 + 6),
     mul_slash_SL2 6 6 S _ _, theta_prod_S_action, neg_mul_neg]
 
 private lemma theta_prod_sq_T_action : (theta_prod_sq ∣[(12 : ℤ)] T) = theta_prod_sq := by
-  rw [theta_prod_sq_eq_mul, show (12 : ℤ) = 6 + 6 from by norm_num,
+  rw [theta_prod_sq_eq_mul, (by norm_num : (12 : ℤ) = 6 + 6),
     mul_slash_SL2 6 6 T _ _, theta_prod_T_action, neg_mul_neg]
 
 private lemma theta_prod_sq_SL2Z_invariant :
@@ -171,8 +159,7 @@ private lemma theta_prod_sq_SL2Z_invariant :
     theta_prod_sq_S_action theta_prod_sq_T_action
 
 private lemma theta_prod_sq_MDifferentiable : MDiff theta_prod_sq := by
-  change MDiff (fun z => (H₂ z * H₃ z * H₄ z) ^ 2)
-  exact ((H₂_SIF_MDifferentiable.mul H₃_SIF_MDifferentiable).mul H₄_SIF_MDifferentiable).pow 2
+  unfold theta_prod_sq; fun_prop
 
 private lemma theta_prod_sq_tendsto_atImInfty : Tendsto theta_prod_sq atImInfty (𝓝 0) := by
   change Tendsto (fun z => (H₂ z * H₃ z * H₄ z) ^ 2) atImInfty (𝓝 0)
@@ -221,26 +208,18 @@ private lemma H₂_div_exp_tendsto :
       ring
     rw [he, mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
   simp_rw [h_eq]
-  have h16 : (2 : ℂ) ^ 4 = (16 : ℂ) := by norm_num
-  rw [← h16]
-  exact jacobiTheta₂_half_mul_apply_tendsto_atImInfty.pow 4
+  convert jacobiTheta₂_half_mul_apply_tendsto_atImInfty.pow 4 using 1; norm_num
 
-lemma Delta_eq_H₂_H₃_H₄ (τ : ℍ) :
-    Delta τ = ((H₂ τ) * (H₃ τ) * (H₄ τ))^2 / (256 : ℂ) := by
+lemma Delta_eq_H₂_H₃_H₄ : (Delta : ℍ → ℂ) = (1 / 256 : ℂ) • (H₂ * H₃ * H₄) ^ 2 := by
   obtain ⟨c, hc⟩ := theta_prod_sq_proportional
-  have hc_pw : ∀ z : ℍ, c * Delta z = theta_prod_sq z := by
-    intro z
-    have h := DFunLike.congr_fun hc z
-    rw [show (c • Delta : CuspForm _ _) z = c * Delta z from rfl] at h
-    rwa [theta_prod_sq_CF_apply] at h
+  have hc_pw : ∀ z : ℍ, c * Delta z = theta_prod_sq z :=
+    fun z => (DFunLike.congr_fun hc z).trans (theta_prod_sq_CF_apply z)
   have hc_eq : c = 256 := by
-    have hD_asymp : Tendsto (fun z : ℍ ↦ Delta z / cexp (2 * ↑π * I * ↑z))
-        atImInfty (nhds 1) := by
+    have hD_asymp : Tendsto (fun z : ℍ ↦ Delta z / cexp (2 * ↑π * I * ↑z)) atImInfty (nhds 1) := by
       have h_eq : ∀ z : ℍ, Delta z / cexp (2 * ↑π * I * ↑z) =
           ∏' (n : ℕ), (1 - cexp (2 * ↑π * I * (↑n + 1) * ↑z)) ^ 24 := by
         intro z
-        rw [Delta_apply, Δ]
-        rw [mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
+        rw [Delta_apply, Δ, mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
       simp_rw [h_eq]
       exact Delta_boundedfactor
     have hP_asymp : Tendsto (fun z : ℍ ↦ theta_prod_sq z / cexp (2 * ↑π * I * ↑z))
@@ -251,25 +230,26 @@ lemma Delta_eq_H₂_H₃_H₄ (τ : ℍ) :
         have hq : cexp (2 * ↑π * I * ↑z) = cexp (↑π * I * ↑z) ^ 2 := by
           rw [← Complex.exp_nat_mul]
           ring_nf
-        simp only [theta_prod_sq]
+        simp only [theta_prod_sq, Pi.mul_apply, Pi.pow_apply]
         rw [hq]
         field_simp
       simp_rw [h_rewrite]
       have : (256 : ℂ) = 16 ^ 2 * 1 ^ 2 * 1 ^ 2 := by norm_num
       rw [this]
-      exact ((H₂_div_exp_tendsto.pow 2).mul (H₃_tendsto_atImInfty.pow 2)).mul
-        (H₄_tendsto_atImInfty.pow 2)
+      have := H₂_div_exp_tendsto
+      have := H₃_tendsto_atImInfty
+      have := H₄_tendsto_atImInfty
+      tendsto_cont
     have h_eq_fns : ∀ z : ℍ, c * (Delta z / cexp (2 * ↑π * I * ↑z)) =
         theta_prod_sq z / cexp (2 * ↑π * I * ↑z) := by
       intro z
       rw [← mul_div_assoc, hc_pw]
     have hc_lim : Tendsto (fun z : ℍ ↦ c * (Delta z / cexp (2 * ↑π * I * ↑z)))
-        atImInfty (nhds c) := by
-      have := hD_asymp.const_mul c
-      rwa [mul_one] at this
+        atImInfty (nhds c) := by simpa using hD_asymp.const_mul c
     exact tendsto_nhds_unique (hc_lim.congr h_eq_fns) hP_asymp
-  have h := hc_pw τ
+  ext z
+  have h := hc_pw z
   rw [hc_eq] at h
-  simp only [theta_prod_sq] at h
-  rw [eq_div_iff (show (256 : ℂ) ≠ 0 by norm_num), mul_comm]
-  exact h
+  simp only [theta_prod_sq, Pi.mul_apply, Pi.pow_apply] at h
+  simp only [Pi.smul_apply, Pi.mul_apply, Pi.pow_apply, smul_eq_mul]
+  linear_combination (1 / (256 : ℂ)) * h

--- a/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
@@ -47,9 +47,7 @@ lemma jacobi_g_T_action : (jacobi_g ∣[(2 : ℤ)] T) = -jacobi_g := by
   ext z; simp only [Pi.add_apply, Pi.neg_apply]; ring
 
 /-- Rewrite `jacobi_f` as a pointwise product. -/
-lemma jacobi_f_eq_mul : jacobi_f = jacobi_g * jacobi_g := by
-  ext
-  simp [jacobi_f, sq]
+lemma jacobi_f_eq_mul : jacobi_f = jacobi_g * jacobi_g := sq jacobi_g
 
 /-- S-invariance of `f`: `f|[4]S = f`, because `g|[2]S = -g`. -/
 lemma jacobi_f_S_action : (jacobi_f ∣[(4 : ℤ)] S) = jacobi_f := by
@@ -70,17 +68,8 @@ noncomputable def jacobi_f_SIF : SlashInvariantForm (CongruenceSubgroup.Gamma 1)
   toFun := jacobi_f
   slash_action_eq' := slashaction_generators_GL2R jacobi_f 4 jacobi_f_S_action jacobi_f_T_action
 
-/-- `jacobi_g` is holomorphic since `H₂`, `H₃`, and `H₄` are. -/
-lemma jacobi_g_MDifferentiable : MDiff jacobi_g := by
-  unfold jacobi_g
-  fun_prop
-
 /-- `jacobi_f` is holomorphic since `jacobi_g` is. -/
-lemma jacobi_f_MDifferentiable : MDiff jacobi_f := by
-  unfold jacobi_f jacobi_g; fun_prop
-
-/-- `jacobi_f_SIF` is holomorphic. -/
-lemma jacobi_f_SIF_MDifferentiable : MDiff jacobi_f_SIF := jacobi_f_MDifferentiable
+lemma jacobi_f_MDifferentiable : MDiff jacobi_f := by unfold jacobi_f jacobi_g; fun_prop
 
 end JacobiIdentity
 
@@ -107,8 +96,7 @@ theorem jacobi_f_tendsto_atImInfty : Tendsto jacobi_f atImInfty (𝓝 0) := by
   tendsto_cont
 
 private noncomputable def jacobi_f_CF : CuspForm (Γ 1) 4 :=
-  cuspFormOfSIFTendstoZero jacobi_f_SIF jacobi_f_SIF_MDifferentiable
-    jacobi_f_tendsto_atImInfty
+  cuspFormOfSIFTendstoZero jacobi_f_SIF jacobi_f_MDifferentiable jacobi_f_tendsto_atImInfty
 
 /-- `jacobi_f = 0` by dimension argument: weight-4 cusp forms vanish. -/
 theorem jacobi_f_eq_zero : jacobi_f = 0 :=
@@ -141,9 +129,7 @@ private lemma theta_prod_T_action : (theta_prod ∣[(6 : ℤ)] T) = -theta_prod 
 
 private noncomputable def theta_prod_sq : ℍ → ℂ := (H₂ * H₃ * H₄) ^ 2
 
-private lemma theta_prod_sq_eq_mul : theta_prod_sq = theta_prod * theta_prod := by
-  ext z
-  simp [theta_prod_sq, theta_prod, sq, Pi.mul_apply]
+private lemma theta_prod_sq_eq_mul : theta_prod_sq = theta_prod * theta_prod := sq theta_prod
 
 private lemma theta_prod_sq_S_action : (theta_prod_sq ∣[(12 : ℤ)] S) = theta_prod_sq := by
   rw [theta_prod_sq_eq_mul, (by norm_num : (12 : ℤ) = 6 + 6),
@@ -192,21 +178,14 @@ private lemma theta_prod_sq_proportional :
     ∃ c : ℂ, c • Delta = theta_prod_sq_CF :=
   (finrank_eq_one_iff_of_nonzero' Delta Delta_ne_zero).mp finrank_cuspform_12 theta_prod_sq_CF
 
-private lemma Θ₂_div_exp_tendsto :
-    Tendsto (fun z : ℍ ↦ Θ₂ z / cexp (π * I * ↑z / 4)) atImInfty (nhds 2) := by
-  simp_rw [Θ₂_as_jacobiTheta₂, mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
-  exact jacobiTheta₂_half_mul_apply_tendsto_atImInfty
-
 private lemma H₂_div_exp_tendsto :
     Tendsto (fun z : ℍ ↦ H₂ z / cexp (↑π * I * ↑z)) atImInfty (nhds 16) := by
   have h_eq : ∀ z : ℍ, H₂ z / cexp (↑π * I * ↑z) = (jacobiTheta₂ (↑z / 2) ↑z) ^ 4 := by
     intro z
-    rw [H₂, Θ₂_as_jacobiTheta₂, mul_pow]
-    have he : cexp (↑π * I * ↑z / 4) ^ 4 = cexp (↑π * I * ↑z) := by
-      rw [← Complex.exp_nat_mul]
-      congr 1
-      ring
-    rw [he, mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
+    rw [H₂, Θ₂_as_jacobiTheta₂, mul_pow,
+      show cexp (↑π * I * ↑z / 4) ^ 4 = cexp (↑π * I * ↑z) from by
+        rw [← Complex.exp_nat_mul]; ring_nf,
+      mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
   simp_rw [h_eq]
   convert jacobiTheta₂_half_mul_apply_tendsto_atImInfty.pow 4 using 1; norm_num
 
@@ -227,11 +206,9 @@ lemma Delta_eq_H₂_H₃_H₄ : (Delta : ℍ → ℂ) = (1 / 256 : ℂ) • (H�
       have h_rewrite : ∀ z : ℍ, theta_prod_sq z / cexp (2 * ↑π * I * ↑z) =
           (H₂ z / cexp (↑π * I * ↑z)) ^ 2 * (H₃ z) ^ 2 * (H₄ z) ^ 2 := by
         intro z
-        have hq : cexp (2 * ↑π * I * ↑z) = cexp (↑π * I * ↑z) ^ 2 := by
-          rw [← Complex.exp_nat_mul]
-          ring_nf
         simp only [theta_prod_sq, Pi.mul_apply, Pi.pow_apply]
-        rw [hq]
+        rw [show cexp (2 * ↑π * I * ↑z) = cexp (↑π * I * ↑z) ^ 2 from by
+          rw [← Complex.exp_nat_mul]; ring_nf]
         field_simp
       simp_rw [h_rewrite]
       have : (256 : ℂ) = 16 ^ 2 * 1 ^ 2 * 1 ^ 2 := by norm_num


### PR DESCRIPTION
## Summary
- Golf `JacobiIdentity.lean`: term-mode `sq`, dead code removal, subproof inlining, point-free definitions
- Golf `Derivative.lean`: replace calc blocks with `linear_combination`, `simpa`, lemma inlining, deduplicate `H_sum_sq_eq_mul`, line wrapping
- Trim verbose docstrings and remove "Phase *" section headers
- Remove unused lambda-form MDifferentiable lemmas from `MDifferentiableFunProp.lean`

## Dependencies
Depends on #392

## Test plan
- [x] `lake build` passes (only pre-existing `sorry` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)