### PR TITLE
Golf imaginary axis proofs in JacobiTheta/Basic.lean

### DIFF
--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -606,77 +606,61 @@ Properties of theta functions when restricted to the positive imaginary axis z =
 
 section ImagAxisProperties
 
-/-- Each term Θ₂_term n (I*t) has zero imaginary part for t > 0. -/
+/-- `im` distributes over tsum when each term has zero imaginary part. -/
+lemma Complex.im_tsum_eq_zero_of_im_eq_zero {ι : Type*} {f : ι → ℂ}
+    (hf : Summable f) (him : ∀ n, (f n).im = 0) :
+    (∑' n, f n).im = 0 := by
+  rw [Complex.im_tsum hf]; simp [him]
+
+private lemma summable_Θ₂_term_imagAxis (t : ℝ) (ht : 0 < t) :
+    Summable fun n : ℤ => Θ₂_term n ⟨I * t, by simp [ht]⟩ := by
+  simp_rw [Θ₂_term_as_jacobiTheta₂_term]
+  apply Summable.mul_left
+  rw [summable_jacobiTheta₂_term_iff]
+  exact (⟨I * t, by simp [ht]⟩ : ℍ).im_pos
+
+private lemma summable_Θ₄_term_imagAxis (t : ℝ) (ht : 0 < t) :
+    Summable fun n : ℤ => Θ₄_term n ⟨I * t, by simp [ht]⟩ := by
+  simp_rw [Θ₄_term_as_jacobiTheta₂_term, summable_jacobiTheta₂_term_iff]
+  exact (⟨I * t, by simp [ht]⟩ : ℍ).im_pos
+
+/-- Each term `Θ₂_term n (I*t)` has zero imaginary part for `t > 0`. -/
 lemma Θ₂_term_imag_axis_real (n : ℤ) (t : ℝ) (ht : 0 < t) :
     (Θ₂_term n ⟨I * t, by simp [ht]⟩).im = 0 := by
   unfold Θ₂_term
   change (cexp (Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * t))).im = 0
-  have hexpr : Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
-      (-(Real.pi * ((n : ℝ) + 1/2) ^ 2 * t) : ℝ) := by
-    have hI : I ^ 2 = -1 := I_sq
-    push_cast
-    ring_nf
-    simp only [hI]
-    ring
-  rw [hexpr]
+  rw [show Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
+        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) from by
+      push_cast
+      linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq]
   exact exp_ofReal_im _
 
-/-- `im` distributes over tsum when each term has zero imaginary part. -/
-lemma Complex.im_tsum_eq_zero_of_im_eq_zero (f : ℤ → ℂ)
-    (hf : Summable f) (him : ∀ n, (f n).im = 0) :
-    (∑' n : ℤ, f n).im = 0 := by
-  rw [Complex.im_tsum hf]
-  simp [him]
-
-/-- Θ₂(I*t) has zero imaginary part for t > 0. -/
+/-- `Θ₂(I*t)` has zero imaginary part for `t > 0`. -/
 lemma Θ₂_imag_axis_real (t : ℝ) (ht : 0 < t) :
-    (Θ₂ ⟨I * t, by simp [ht]⟩).im = 0 := by
-  unfold Θ₂
-  let z : ℍ := ⟨I * t, by simp [ht]⟩
-  have hsum : Summable fun n : ℤ => Θ₂_term n z := by
-    simp_rw [Θ₂_term_as_jacobiTheta₂_term]
-    apply Summable.mul_left
-    rw [summable_jacobiTheta₂_term_iff]
-    exact z.im_pos
-  apply Complex.im_tsum_eq_zero_of_im_eq_zero _ hsum
-  intro n
-  exact Θ₂_term_imag_axis_real n t ht
+    (Θ₂ ⟨I * t, by simp [ht]⟩).im = 0 :=
+  Complex.im_tsum_eq_zero_of_im_eq_zero (summable_Θ₂_term_imagAxis t ht)
+    (fun n => Θ₂_term_imag_axis_real n t ht)
 
 /-- `(-1 : ℂ)^n` has zero imaginary part for any integer n. -/
 lemma neg_one_zpow_im_eq_zero (n : ℤ) : ((-1 : ℂ) ^ n).im = 0 := by
   rcases Int.even_or_odd n with hn | hn <;> (rw [hn.neg_one_zpow]; simp)
 
-/-- Each term Θ₄_term n (I*t) has zero imaginary part for t > 0. -/
+/-- Each term `Θ₄_term n (I*t)` has zero imaginary part for `t > 0`. -/
 lemma Θ₄_term_imag_axis_real (n : ℤ) (t : ℝ) (ht : 0 < t) :
     (Θ₄_term n ⟨I * t, by simp [ht]⟩).im = 0 := by
   unfold Θ₄_term
   change ((-1 : ℂ) ^ n * cexp (Real.pi * I * (n : ℂ) ^ 2 * (I * t))).im = 0
-  -- Simplify the exponent: π * I * n² * (I*t) = -π * n² * t
-  have hexpr : Real.pi * I * (n : ℂ) ^ 2 * (I * t) =
-      (-(Real.pi * (n : ℝ) ^ 2 * t) : ℝ) := by
-    have hI : I ^ 2 = -1 := I_sq
-    push_cast
-    ring_nf
-    simp only [hI]
-    ring
-  rw [hexpr]
-  -- Now we have (-1)^n * exp(real), both are real
-  have hexp_real : (cexp (-(Real.pi * (n : ℝ) ^ 2 * t) : ℝ)).im = 0 := exp_ofReal_im _
-  have hneg_one_real : ((-1 : ℂ) ^ n).im = 0 := neg_one_zpow_im_eq_zero n
-  simp only [Complex.mul_im, hneg_one_real, hexp_real, mul_zero, zero_mul, add_zero]
+  rw [show Real.pi * I * (n : ℂ) ^ 2 * (I * ↑t) = ((-(Real.pi * (n : ℝ) ^ 2 * t) : ℝ) : ℂ) by
+      push_cast
+      linear_combination ((Real.pi : ℂ) * (n : ℂ) ^ 2 * ↑t) * I_sq]
+  simp only [Complex.mul_im, neg_one_zpow_im_eq_zero, exp_ofReal_im,
+    mul_zero, zero_mul, add_zero]
 
-/-- Θ₄(I*t) has zero imaginary part for t > 0. -/
+/-- `Θ₄(I*t)` has zero imaginary part for `t > 0`. -/
 lemma Θ₄_imag_axis_real (t : ℝ) (ht : 0 < t) :
-    (Θ₄ ⟨I * t, by simp [ht]⟩).im = 0 := by
-  unfold Θ₄
-  let z : ℍ := ⟨I * t, by simp [ht]⟩
-  have hsum : Summable fun n : ℤ => Θ₄_term n z := by
-    simp_rw [Θ₄_term_as_jacobiTheta₂_term]
-    rw [summable_jacobiTheta₂_term_iff]
-    exact z.im_pos
-  apply Complex.im_tsum_eq_zero_of_im_eq_zero _ hsum
-  intro n
-  exact Θ₄_term_imag_axis_real n t ht
+    (Θ₄ ⟨I * t, by simp [ht]⟩).im = 0 :=
+  Complex.im_tsum_eq_zero_of_im_eq_zero (summable_Θ₄_term_imagAxis t ht)
+    (fun n => Θ₄_term_imag_axis_real n t ht)
 
 /--
 `H₂(it)` is real for all `t > 0`.
@@ -685,62 +669,37 @@ Proof strategy: H₂ = Θ₂^4 where Θ₂(it) = ∑ₙ exp(-π(n+1/2)²t) is a 
 exponentials.
 -/
 @[fun_prop]
-theorem H₂_imag_axis_real : ResToImagAxis.Real H₂ := by
-  intro t ht
+theorem H₂_imag_axis_real : ResToImagAxis.Real H₂ := fun t ht => by
   simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte, H₂]
-  -- H₂ = Θ₂^4, and Θ₂(I*t) has zero imaginary part,
-  -- so H₂(I*t) = Θ₂(I*t)^4 has zero imaginary part
-  have hΘ₂_im := Θ₂_imag_axis_real t ht
-  exact Complex.im_pow_eq_zero_of_im_eq_zero hΘ₂_im 4
+  exact Complex.im_pow_eq_zero_of_im_eq_zero (Θ₂_imag_axis_real t ht) 4
 
-/-- Each term Θ₂_term n (I*t) has positive real part equal to exp(-π(n+1/2)²t) for t > 0. -/
+/-- Each term `Θ₂_term n (I*t)` has real part `exp(-π(n+1/2)²t)` for `t > 0`. -/
 lemma Θ₂_term_imag_axis_re (n : ℤ) (t : ℝ) (ht : 0 < t) :
     (Θ₂_term n ⟨I * t, by simp [ht]⟩).re =
       Real.exp (-Real.pi * ((n : ℝ) + 1/2) ^ 2 * t) := by
   unfold Θ₂_term
   change (cexp (Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * t))).re = _
-  have hexpr : Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
-      (-(Real.pi * ((n : ℝ) + 1/2) ^ 2 * t) : ℝ) := by
-    have hI : I ^ 2 = -1 := I_sq
-    push_cast
-    ring_nf
-    simp only [hI]
-    ring
-  rw [hexpr]
-  rw [Complex.exp_ofReal_re]
+  rw [show Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
+        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) by
+      push_cast
+      linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq,
+    Complex.exp_ofReal_re]
   ring_nf
 
-/-- Each term Θ₂_term n (I*t) has positive real part for t > 0. -/
+/-- Each term `Θ₂_term n (I*t)` has positive real part for `t > 0`. -/
 lemma Θ₂_term_imag_axis_re_pos (n : ℤ) (t : ℝ) (ht : 0 < t) :
     0 < (Θ₂_term n ⟨I * t, by simp [ht]⟩).re := by
   rw [Θ₂_term_imag_axis_re n t ht]
   exact Real.exp_pos _
 
-/-- Θ₂(I*t) has positive real part for t > 0.
-Proof: Each term Θ₂_term n (I*t) = exp(-π(n+1/2)²t) is a positive real.
-The sum of positive reals is positive. -/
+/-- `Θ₂(I*t)` has positive real part for `t > 0`.
+Each term `Θ₂_term n (I*t) = exp(-π(n+1/2)²t)` is a positive real, so the tsum is too. -/
 lemma Θ₂_imag_axis_re_pos (t : ℝ) (ht : 0 < t) :
     0 < (Θ₂ ⟨I * t, by simp [ht]⟩).re := by
-  -- Θ₂(it) = ∑ₙ exp(-π(n+1/2)²t) where each term is positive real
-  -- The sum of positive terms (at least one nonzero) is positive
-  let z : ℍ := ⟨I * t, by simp [ht]⟩
-  -- Summability of the complex series
-  have hsum : Summable fun n : ℤ => Θ₂_term n z := by
-    simp_rw [Θ₂_term_as_jacobiTheta₂_term]
-    apply Summable.mul_left
-    rw [summable_jacobiTheta₂_term_iff]
-    exact z.im_pos
-  -- Convert complex tsum to real part of tsum
-  unfold Θ₂
-  rw [Complex.re_tsum hsum]
-  -- Summability of the real series
-  have hsum_re : Summable fun n : ℤ => (Θ₂_term n z).re := by
-    obtain ⟨x, hx⟩ := hsum
-    exact ⟨x.re, Complex.hasSum_re hx⟩
-  -- Each term is positive
-  have hpos : ∀ n : ℤ, 0 < (Θ₂_term n z).re := fun n => Θ₂_term_imag_axis_re_pos n t ht
-  -- Use that sum of positive terms is positive
-  exact Summable.tsum_pos hsum_re (fun n => le_of_lt (hpos n)) 0 (hpos 0)
+  have hsum := summable_Θ₂_term_imagAxis t ht
+  rw [Θ₂, Complex.re_tsum hsum]
+  exact (Complex.hasSum_re hsum.hasSum).summable.tsum_pos
+    (fun n => (Θ₂_term_imag_axis_re_pos n t ht).le) 0 (Θ₂_term_imag_axis_re_pos 0 t ht)
 
 /--
 `H₂(it) > 0` for all `t > 0`.
@@ -749,106 +708,49 @@ Proof strategy: Each term exp(-π(n+1/2)²t) > 0, so Θ₂(it) > 0, hence H₂ =
 -/
 @[fun_prop]
 theorem H₂_imag_axis_pos : ResToImagAxis.Pos H₂ := by
-  constructor
-  · exact H₂_imag_axis_real
-  · intro t ht
-    simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte, H₂]
-    -- H₂ = Θ₂^4 where Θ₂(it) is real and positive
-    -- For z with z.im = 0 and z.re > 0, (z^4).re = (z.re)^4 > 0
-    have hΘ₂_im := Θ₂_imag_axis_real t ht
-    have hΘ₂_re_pos := Θ₂_imag_axis_re_pos t ht
-    -- z^4 for z real equals z.re^4
-    have hpow : (Θ₂ ⟨I * t, by simp [ht]⟩ ^ 4).re =
-        (Θ₂ ⟨I * t, by simp [ht]⟩).re ^ 4 := by
-      set z := Θ₂ ⟨I * t, by simp [ht]⟩ with hz_def
-      have hz_real : z.im = 0 := hΘ₂_im
-      -- When im = 0, z = z.re (as complex), so z^4 = (z.re)^4
-      have hz_eq : z = (z.re : ℂ) := by
-        apply Complex.ext
-        · simp
-        · simp [hz_real]
-      rw [hz_eq]
-      norm_cast
-    rw [hpow]
-    exact pow_pos hΘ₂_re_pos 4
+  refine ⟨H₂_imag_axis_real, fun t ht => ?_⟩
+  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte, H₂]
+  set z := Θ₂ ⟨I * t, by simp [ht]⟩ with hz_def
+  have hcast : z = (z.re : ℂ) :=
+    Complex.ext rfl ((Θ₂_imag_axis_real t ht).trans (ofReal_im _).symm)
+  rw [hcast, ← Complex.ofReal_pow, ofReal_re]
+  exact pow_pos (Θ₂_imag_axis_re_pos t ht) 4
 
 /--
 `H₄(it)` is real for all `t > 0`.
 Blueprint: Corollary 6.43 - follows from Θ₄ being real on the imaginary axis.
 -/
 @[fun_prop]
-theorem H₄_imag_axis_real : ResToImagAxis.Real H₄ := by
-  intro t ht
+theorem H₄_imag_axis_real : ResToImagAxis.Real H₄ := fun t ht => by
   simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte, H₄]
-  have hΘ₄_im := Θ₄_imag_axis_real t ht
-  exact Complex.im_pow_eq_zero_of_im_eq_zero hΘ₄_im 4
+  exact Complex.im_pow_eq_zero_of_im_eq_zero (Θ₄_imag_axis_real t ht) 4
 
 /--
 `H₄(it) > 0` for all `t > 0`.
 Blueprint: Corollary 6.43 - H₄ is positive on the imaginary axis.
 
 Proof strategy: Use the modular S-transformation relating H₄ and H₂.
-From H₄_S_action: (H₄ ∣[2] S) = -H₂
-From ResToImagAxis.SlashActionS: relates values at t and 1/t.
-This gives H₂(i/t) = t² * H₄(it), so H₄(it) > 0 follows from H₂(i/t) > 0.
+From `H₄_S_action : (H₄ ∣[2] S) = -H₂` and `ResToImagAxis.SlashActionS`, we get
+`H₂(i/t) = t² · H₄(it)`, so `H₄(it) > 0` follows from `H₂(i/t) > 0`.
 -/
 @[fun_prop]
 theorem H₄_imag_axis_pos : ResToImagAxis.Pos H₄ := by
-  constructor
-  · exact H₄_imag_axis_real
-  · intro t ht
-    -- Strategy: Use H₄_S_action and ResToImagAxis.SlashActionS to relate
-    -- H₄ positivity to H₂ positivity via the modular S-transformation
-    have h1t_pos : 0 < 1 / t := one_div_pos.mpr ht
-    -- Apply SlashActionS at 1/t
-    have hSlash := ResToImagAxis.SlashActionS H₄ 2 h1t_pos
-    -- Use H₄_S_action: (H₄ ∣[2] S) = -H₂
-    rw [H₄_S_action] at hSlash
-    -- Now hSlash : (-H₂).resToImagAxis (1/t) = I^(-2) * (1/t)^(-2) * H₄.resToImagAxis t
-    -- Simplify: I^(-2) = -1
-    have hI_neg2 : (I : ℂ) ^ (-2 : ℤ) = -1 := by
-      change (I ^ 2)⁻¹ = -1
-      rw [I_sq]
-      norm_num
-    -- Simplify: (1/t)^(-2) = t^2
-    have h1t_neg2 : ((1 / t : ℝ) : ℂ) ^ (-2 : ℤ) = (t : ℂ) ^ 2 := by
-      have ht_ne : (t : ℂ) ≠ 0 := ofReal_ne_zero.mpr (ne_of_gt ht)
-      simp only [one_div, ofReal_inv, zpow_neg]
-      -- Goal: ((↑t)⁻¹ ^ 2)⁻¹ = ↑t ^ 2
-      field_simp
-    -- Simplify 1/(1/t) = t
-    have h1_div_1t : 1 / (1 / t) = t := by field_simp
-    -- The negation of resToImagAxis
-    have hNeg : (-H₂).resToImagAxis (1 / t) = -(H₂.resToImagAxis (1 / t)) := by
-      simp only [Function.resToImagAxis_apply, ResToImagAxis, h1t_pos, ↓reduceDIte, Pi.neg_apply]
-    -- Substitute into hSlash
-    rw [hNeg, hI_neg2, h1t_neg2, h1_div_1t] at hSlash
-    -- hSlash : -(H₂.resToImagAxis (1/t)) = -1 * t^2 * H₄.resToImagAxis t
-    -- Simplify: H₂.resToImagAxis (1/t) = t^2 * H₄.resToImagAxis t
-    have hEq : H₂.resToImagAxis (1 / t) = (t : ℂ) ^ 2 * H₄.resToImagAxis t := by
-      have h : -H₂.resToImagAxis (1 / t) = -(↑t ^ 2 * H₄.resToImagAxis t) := by
-        simp only [neg_mul, one_mul] at hSlash ⊢
-        exact hSlash
-      exact neg_inj.mp h
-    -- H₂.resToImagAxis (1/t).re > 0 from H₂_imag_axis_pos
-    have hH₂_pos := H₂_imag_axis_pos.2 (1 / t) h1t_pos
-    -- H₄.resToImagAxis t is real (im = 0)
-    have hH₄_real := H₄_imag_axis_real t ht
-    -- From hEq, extract real parts
-    have hRe : (H₂.resToImagAxis (1 / t)).re = ((t : ℂ) ^ 2 * H₄.resToImagAxis t).re := by
-      rw [hEq]
-    -- Since t^2 is real positive and H₄.resToImagAxis t is real:
-    -- (t^2 * H₄.resToImagAxis t).re = t^2 * (H₄.resToImagAxis t).re
-    have hProd_re : ((t : ℂ) ^ 2 * H₄.resToImagAxis t).re =
-        (t : ℝ) ^ 2 * (H₄.resToImagAxis t).re := by
-      simp only [Function.resToImagAxis_apply, ResToImagAxis, ht, ↓reduceDIte] at hH₄_real ⊢
-      simp only [sq, Complex.mul_re, ofReal_re, ofReal_im, zero_mul, sub_zero]
-      ring_nf
-      simp only [hH₄_real, mul_zero, sub_zero]
-    -- Combine: t^2 * (H₄.resToImagAxis t).re > 0 and t^2 > 0 imply (H₄.resToImagAxis t).re > 0
-    rw [hRe, hProd_re] at hH₂_pos
-    have ht2_pos : 0 < (t : ℝ) ^ 2 := sq_pos_of_pos ht
-    rw [mul_comm] at hH₂_pos
-    exact pos_of_mul_pos_left hH₂_pos (le_of_lt ht2_pos)
+  refine ⟨H₄_imag_axis_real, fun t ht => ?_⟩
+  have ht' : 0 < 1 / t := one_div_pos.mpr ht
+  have hSlash := ResToImagAxis.SlashActionS H₄ 2 ht'
+  rw [H₄_S_action] at hSlash
+  have hI2 : (I : ℂ) ^ (-2 : ℤ) = -1 := by
+    change (I ^ 2)⁻¹ = -1; rw [I_sq]; norm_num
+  have h1t2 : ((1 / t : ℝ) : ℂ) ^ (-2 : ℤ) = (t : ℂ) ^ 2 := by
+    have : (t : ℂ) ≠ 0 := ofReal_ne_zero.mpr ht.ne'
+    simp only [one_div, ofReal_inv, zpow_neg]; field_simp
+  have hNeg : (-H₂).resToImagAxis (1 / t) = -(H₂.resToImagAxis (1 / t)) := by
+    simp only [Function.resToImagAxis_apply, ResToImagAxis, ht', ↓reduceDIte, Pi.neg_apply]
+  rw [hNeg, hI2, h1t2, one_div_one_div] at hSlash
+  have hEq : H₂.resToImagAxis (1 / t) = (t : ℂ) ^ 2 * H₄.resToImagAxis t := by
+    linear_combination -hSlash
+  have hH₂_pos := H₂_imag_axis_pos.2 (1 / t) ht'
+  rw [hEq, ← Complex.ofReal_pow, Complex.re_ofReal_mul] at hH₂_pos
+  exact (mul_pos_iff_of_pos_left (sq_pos_of_pos ht)).mp hH₂_pos
 
 end ImagAxisProperties

--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -101,7 +101,6 @@ lemma H₂_S_action : (H₂ ∣[(2 : ℤ)] S) = -H₄ := by
 
 lemma H₃_S_action : (H₃ ∣[(2 : ℤ)] S) = -H₃ := by
   ext x
-  have hx' := x.ne_zero
   have := jacobiTheta₂_functional_equation 0
   simp [-one_div] at this
   simp [modular_slash_S_apply, Pi.neg_apply, H₃, Θ₃_as_jacobiTheta₂]
@@ -111,7 +110,7 @@ lemma H₃_S_action : (H₃ ∣[(2 : ℤ)] S) = -H₃ := by
   rw [div_pow, one_pow, ← cpow_mul_nat, show (1 / 2 * (4 : ℕ) : ℂ) = 2 by norm_num,
     mul_neg, neg_neg, Complex.cpow_two, mul_pow, I_sq, neg_one_mul, inv_pow,
     one_div, ← neg_inv, inv_inv, neg_mul]
-  exact congrArg Neg.neg (mul_inv_cancel₀ (pow_ne_zero _ hx'))
+  exact congrArg Neg.neg (mul_inv_cancel₀ (pow_ne_zero _ x.ne_zero))
 
 lemma H₄_S_action : (H₄ ∣[(2 : ℤ)] S) = - H₂ := by
   rw [← neg_eq_iff_eq_neg.mpr H₂_S_action, neg_slash, ← slash_mul, modular_S_sq,

--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -629,10 +629,11 @@ lemma Θ₂_term_imag_axis_real (n : ℤ) (t : ℝ) (ht : 0 < t) :
     (Θ₂_term n ⟨I * t, by simp [ht]⟩).im = 0 := by
   unfold Θ₂_term
   change (cexp (Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * t))).im = 0
-  rw [show Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
-        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) from by
-      push_cast
-      linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq]
+  have : Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
+        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) := by
+    push_cast
+    linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq
+  rw [this]
   exact exp_ofReal_im _
 
 /-- `Θ₂(I*t)` has zero imaginary part for `t > 0`. -/
@@ -650,9 +651,10 @@ lemma Θ₄_term_imag_axis_real (n : ℤ) (t : ℝ) (ht : 0 < t) :
     (Θ₄_term n ⟨I * t, by simp [ht]⟩).im = 0 := by
   unfold Θ₄_term
   change ((-1 : ℂ) ^ n * cexp (Real.pi * I * (n : ℂ) ^ 2 * (I * t))).im = 0
-  rw [show Real.pi * I * (n : ℂ) ^ 2 * (I * ↑t) = ((-(Real.pi * (n : ℝ) ^ 2 * t) : ℝ) : ℂ) by
-      push_cast
-      linear_combination ((Real.pi : ℂ) * (n : ℂ) ^ 2 * ↑t) * I_sq]
+  have : Real.pi * I * (n : ℂ) ^ 2 * (I * ↑t) = ((-(Real.pi * (n : ℝ) ^ 2 * t) : ℝ) : ℂ) := by
+    push_cast
+    linear_combination ((Real.pi : ℂ) * (n : ℂ) ^ 2 * ↑t) * I_sq
+  rw [this]
   simp only [Complex.mul_im, neg_one_zpow_im_eq_zero, exp_ofReal_im,
     mul_zero, zero_mul, add_zero]
 
@@ -679,11 +681,11 @@ lemma Θ₂_term_imag_axis_re (n : ℤ) (t : ℝ) (ht : 0 < t) :
       Real.exp (-Real.pi * ((n : ℝ) + 1/2) ^ 2 * t) := by
   unfold Θ₂_term
   change (cexp (Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * t))).re = _
-  rw [show Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
-        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) by
-      push_cast
-      linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq,
-    Complex.exp_ofReal_re]
+  have : Real.pi * I * ((n : ℂ) + 1 / 2) ^ 2 * (I * ↑t) =
+        ((-(Real.pi * ((n : ℝ) + 1 / 2) ^ 2 * t) : ℝ) : ℂ) := by
+    push_cast
+    linear_combination ((Real.pi : ℂ) * ((n : ℂ) + 1 / 2) ^ 2 * ↑t) * I_sq
+  rw [this, Complex.exp_ofReal_re]
   ring_nf
 
 /-- Each term `Θ₂_term n (I*t)` has positive real part for `t > 0`. -/

--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -33,48 +33,31 @@ lemma H₂_T_action : (H₂ ∣[(2 : ℤ)] T) = -H₂ := by
     simp_rw [modular_slash_T_apply, Pi.neg_apply, H₂, hΘ₂, mul_pow, ← Complex.exp_nat_mul,
       mul_comm ((4 : ℕ) : ℂ), Nat.cast_ofNat, div_mul_cancel₀ (b := (4 : ℂ)) _ (by simp),
       Complex.exp_pi_mul_I, neg_one_mul]
-  calc
-  _ = ∑' (n : ℤ), cexp (π * I * (n + 1 / 2) ^ 2 * ((1 : ℝ) +ᵥ x)) := by
-    simp_rw [Θ₂, Θ₂_term]
-  _ = ∑' (n : ℤ), cexp (π * I / 4) * cexp (π * I * (n ^ 2 + n) + π * I * (n + 1 / 2) ^ 2 * x) := by
-    apply tsum_congr fun b ↦ ?_
-    rw [coe_vadd, ofReal_one]
-    repeat rw [← Complex.exp_add]
-    congr
-    ring_nf
-  _ = cexp (π * I / 4) * ∑' (n : ℤ), cexp (π * I * (n ^ 2 + n) + π * I * (n + 1 / 2) ^ 2 * x) := by
-    rw [tsum_mul_left]
-  _ = _ := by
-    simp_rw [Θ₂, Θ₂_term]
-    congr 1
-    apply tsum_congr fun b ↦ ?_
-    have : Even (b ^ 2 + b) := by
-      convert Int.even_mul_succ_self b using 1
-      ring_nf
-    norm_cast
-    rw [Complex.exp_add]
-    rw [mul_comm (π * I), Complex.exp_int_mul, Complex.exp_pi_mul_I, this.neg_one_zpow, one_mul]
+  simp_rw [Θ₂, Θ₂_term, ← tsum_mul_left]
+  refine tsum_congr fun b ↦ ?_
+  rw [coe_vadd, ofReal_one, ← Complex.exp_add]
+  have h : Even (b ^ 2 + b) := by convert Int.even_mul_succ_self b using 1; ring
+  rw [show (↑π * I * (↑b + 1 / 2) ^ 2 * (1 + ↑x) : ℂ)
+        = ↑π * I / 4 + (↑(b ^ 2 + b) * (↑π * I) + ↑π * I * (↑b + 1 / 2) ^ 2 * ↑x) by
+        push_cast; ring]
+  simp_rw [Complex.exp_add, Complex.exp_int_mul, Complex.exp_pi_mul_I, h.neg_one_zpow, one_mul]
 
 lemma H₃_T_action : (H₃ ∣[(2 : ℤ)] T) = H₄ := by
   ext x
   simp_rw [modular_slash_T_apply, H₃, H₄, Θ₃, Θ₄, Θ₃_term, Θ₄_term]
   congr 1
-  apply tsum_congr fun b ↦ ?_
+  refine tsum_congr fun b ↦ ?_
   rw [coe_vadd, ofReal_one, mul_add, Complex.exp_add, mul_one, mul_comm (π * I), ← Int.cast_pow,
     Complex.exp_int_mul, Complex.exp_pi_mul_I]
   congr 1
-  rcases Int.even_or_odd b with (hb | hb)
-  · rw [hb.neg_one_zpow, Even.neg_one_zpow]
-    simp [sq, hb]
-  · rw [hb.neg_one_zpow, Odd.neg_one_zpow]
-    simp [sq, hb]
+  rcases Int.even_or_odd b with hb | hb <;>
+    simp [sq, hb, hb.neg_one_zpow, Even.neg_one_zpow, Odd.neg_one_zpow]
 
 lemma H₄_T_action : (H₄ ∣[(2 : ℤ)] T) = H₃ := by
   -- H₄|T = H₃|T^2 = Θ₂(0, z + 2) = Θ₂(0, z) = H₃
   ext x
-  simp_rw [← H₃_T_action, modular_slash_T_apply, H₃, Θ₃_as_jacobiTheta₂, coe_vadd, ← add_assoc]
-  norm_num
-  rw [add_comm, jacobiTheta₂_add_right]
+  simp_rw [← H₃_T_action, modular_slash_T_apply, H₃, Θ₃_as_jacobiTheta₂, coe_vadd, ← add_assoc,
+    show ((1 : ℝ) : ℂ) + ((1 : ℝ) : ℂ) = 2 by norm_num, add_comm (2 : ℂ), jacobiTheta₂_add_right]
 
 lemma H₂_T_inv_action : (H₂ ∣[(2 : ℤ)] T⁻¹) = -H₂ := by
   nth_rw 1 [← neg_eq_iff_eq_neg.mpr H₂_T_action, neg_slash, ← slash_mul, mul_inv_cancel, slash_one]
@@ -99,69 +82,36 @@ lemma H₄_α_action : (H₄ ∣[(2 : ℤ)] α.1) = H₄ := by
 lemma H₂_S_action : (H₂ ∣[(2 : ℤ)] S) = -H₄ := by
   ext ⟨x, hx⟩
   have hx' : x ≠ 0 := by simp [Complex.ext_iff, hx.ne.symm]
-  calc
-  _ = cexp (-π * I / x) * jacobiTheta₂ (-1 / (2 * x)) (-1 / x) ^ 4 * x ^ (-2 : ℤ) := by
-    rw [modular_slash_S_apply, H₂, Θ₂_as_jacobiTheta₂]
-    simp only [inv_neg, mul_neg, mul_pow, ← Complex.exp_nat_mul, Nat.cast_ofNat, Int.reduceNeg,
-      zpow_neg, neg_mul, mul_eq_mul_right_iff, inv_eq_zero]
-    rw [mul_comm 4, div_mul_cancel₀ _ (by norm_num)]
-    left
-    congr 3
-    · rw [← div_eq_mul_inv, neg_div]
-    · rw [← one_div, neg_div, div_div, mul_comm, neg_div]
-    · rw [← one_div, neg_div]
-  _ = cexp (-π * I / x) * x ^ (-2 : ℤ)
-        * (1 / (I / x) ^ ((1 : ℂ) / 2) * cexp (π * I / (4 * x)) * jacobiTheta₂ (1 / 2) x) ^ 4 := by
-    rw [mul_right_comm, jacobiTheta₂_functional_equation]
-    congr 4
-    · ring_nf
-    · congr 1
-      rw [neg_mul, neg_div, one_div, neg_div, div_neg, neg_mul, neg_div, neg_neg]
-      ring_nf
-      simp [sq, ← mul_assoc, inv_mul_cancel_right₀ hx']
-    · ring_nf; simp [hx']
-    · ring_nf; simp [inv_inv]
-  _ = cexp (-π * I / x) * x ^ (-2 : ℤ)
-        * ((1 / (I / x) ^ ((1 : ℂ) / 2)) ^ 4 * cexp (π * I / (4 * x)) ^ 4
-          * jacobiTheta₂ (1 / 2) x ^ 4) := by
-    simp [mul_pow]
-  _ = cexp (-π * I / x) * x ^ (-2 : ℤ)
-        * ((1 / (I / x) ^ (2 : ℂ)) * cexp (π * I / (4 * x)) ^ 4 * jacobiTheta₂ (1 / 2) x ^ 4) := by
-    congr 3
-    simp only [div_pow, one_pow, ← cpow_mul_nat]
-    ring_nf
-  _ = cexp (-π * I / x) * (x ^ (-2 : ℤ) * (-x ^ (2 : ℤ)))
-        * cexp (π * I / (4 * x)) ^ 4 * jacobiTheta₂ (1 / 2) x ^ 4 := by
-    repeat rw [← mul_assoc]
-    congr 4
-    rw [cpow_ofNat, div_pow, one_div_div, I_sq, div_neg, div_one]
-    rfl
-  _ = -cexp (-π * I / x) * cexp (π * I / x) * jacobiTheta₂ (1 / 2) x ^ 4 := by
-    rw [mul_neg, ← zpow_add₀ hx', neg_add_cancel, mul_neg, zpow_zero, mul_one]
-    congr 2
-    rw [← Complex.exp_nat_mul]
-    ring_nf
-  _ = -jacobiTheta₂ (1 / 2) x ^ 4 := by
-    rw [neg_mul, ← Complex.exp_add, neg_mul (π : ℂ), neg_div, neg_add_cancel, Complex.exp_zero,
-      neg_one_mul]
-  _ = -H₄ ⟨x, hx⟩ := by
-    simp [H₄, Θ₄_as_jacobiTheta₂]
+  have hfe := jacobiTheta₂_functional_equation (-x⁻¹/2) (-x⁻¹)
+  rw [show (-x⁻¹ / 2 / -x⁻¹ : ℂ) = 1/2 by field_simp,
+      show (-1 / -x⁻¹ : ℂ) = x by field_simp,
+      show ((-I * -x⁻¹) : ℂ) = I * x⁻¹ by ring] at hfe
+  simp only [modular_slash_S_apply, Pi.neg_apply, H₂, Θ₂_as_jacobiTheta₂, H₄, Θ₄_as_jacobiTheta₂]
+  rw [show ((-x : ℂ))⁻¹ = -x⁻¹ by simp, hfe, mul_pow, mul_pow, mul_pow, div_pow, one_pow,
+      ← cpow_mul_nat, show ((1:ℂ)/2 * (4:ℕ)) = 2 by push_cast; ring, Complex.cpow_two, mul_pow,
+      I_sq, ← Complex.exp_nat_mul, ← Complex.exp_nat_mul]
+  have hexp : cexp ((4:ℕ) * (↑π * I * -x⁻¹ / 4)) *
+              cexp ((4:ℕ) * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹)) = 1 := by
+    rw [← Complex.exp_add, show ((4 : ℕ) : ℂ) * (↑π * I * -x⁻¹ / 4) +
+      (4 : ℕ) * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹) = 0 by field_simp; ring, Complex.exp_zero]
+  have hzpow : (1 / (-1 * x⁻¹ ^ 2) * x ^ (-2 : ℤ) : ℂ) = -1 := by
+    rw [zpow_neg, zpow_ofNat]; field_simp
+  linear_combination hexp * (1 / (-1 * x⁻¹ ^ 2) * x ^ (-2 : ℤ) * jacobiTheta₂ (1 / 2) x ^ 4) +
+    hzpow * jacobiTheta₂ (1 / 2) x ^ 4
 
 lemma H₃_S_action : (H₃ ∣[(2 : ℤ)] S) = -H₃ := by
   ext x
-  have hx' : (x : ℂ) ≠ 0 := by obtain ⟨x, hx⟩ := x; change x ≠ 0; simp [Complex.ext_iff, hx.ne.symm]
+  have hx' := x.ne_zero
   have := jacobiTheta₂_functional_equation 0
   simp [-one_div] at this
   simp [modular_slash_S_apply, Pi.neg_apply, H₃, Θ₃_as_jacobiTheta₂]
   rw [this, mul_pow, neg_div, div_neg, neg_neg, one_div (x : ℂ)⁻¹, inv_inv,
     mul_right_comm, ← neg_one_mul (_ ^ 4)]
   congr
-  rw [div_pow, ← cpow_mul_nat, mul_neg, neg_neg]
-  ring_nf!
-  rw [← mul_inv, cpow_ofNat, sq, ← mul_assoc, zpow_two]
-  ring_nf!
-  rw [inv_pow, inv_I, even_two.neg_pow, I_sq, mul_neg_one, inv_inv, neg_mul, inv_mul_cancel₀]
-  exact pow_ne_zero _ hx'
+  rw [div_pow, one_pow, ← cpow_mul_nat, show (1 / 2 * (4 : ℕ) : ℂ) = 2 by norm_num,
+    mul_neg, neg_neg, Complex.cpow_two, mul_pow, I_sq, neg_one_mul, inv_pow,
+    one_div, ← neg_inv, inv_inv, neg_mul]
+  exact congrArg Neg.neg (mul_inv_cancel₀ (pow_ne_zero _ hx'))
 
 lemma H₄_S_action : (H₄ ∣[(2 : ℤ)] S) = - H₂ := by
   rw [← neg_eq_iff_eq_neg.mpr H₂_S_action, neg_slash, ← slash_mul, modular_S_sq,
@@ -189,26 +139,17 @@ lemma H₄_S_inv_action : (H₄ ∣[(2 : ℤ)] S⁻¹) = -H₂ := by
   rw [← neg_eq_iff_eq_neg.mpr H₂_S_action, neg_slash, ← slash_mul, mul_inv_cancel, slash_one]
 
 /-- Use β = -S * α^(-1) * S -/
-lemma H₂_β_action : (H₂ ∣[(2 : ℤ)] β.1) = H₂ := calc
-  _ = (((H₂ ∣[(2 : ℤ)] negI.1) ∣[(2 : ℤ)] S) ∣[(2 : ℤ)] α.1⁻¹) ∣[(2 : ℤ)] S := by
-    simp [β_eq_negI_mul_S_mul_α_inv_mul_S, slash_mul]
-  _ = _ := by
-    rw [H₂_negI_action, H₂_S_action, neg_slash, neg_slash, α_eq_T_sq]
-    simp [sq, slash_mul, H₄_T_inv_action, H₃_T_inv_action, H₄_S_action]
+lemma H₂_β_action : (H₂ ∣[(2 : ℤ)] β.1) = H₂ := by
+  simp [β_eq_negI_mul_S_mul_α_inv_mul_S, α_eq_T_sq, sq, slash_mul, H₂_negI_action,
+    H₂_S_action, H₄_T_inv_action, H₃_T_inv_action, H₄_S_action, neg_slash]
 
-lemma H₃_β_action : (H₃ ∣[(2 : ℤ)] β.1) = H₃ := calc
-  _ = (((H₃ ∣[(2 : ℤ)] negI.1) ∣[(2 : ℤ)] S) ∣[(2 : ℤ)] α.1⁻¹) ∣[(2 : ℤ)] S := by
-    simp [β_eq_negI_mul_S_mul_α_inv_mul_S, slash_mul]
-  _ = _ := by
-    rw [H₃_negI_action, H₃_S_action, neg_slash, neg_slash, α_eq_T_sq]
-    simp [sq, slash_mul, H₄_T_inv_action, H₃_T_inv_action, H₃_S_action]
+lemma H₃_β_action : (H₃ ∣[(2 : ℤ)] β.1) = H₃ := by
+  simp [β_eq_negI_mul_S_mul_α_inv_mul_S, α_eq_T_sq, sq, slash_mul, H₃_negI_action,
+    H₃_S_action, H₄_T_inv_action, H₃_T_inv_action, neg_slash]
 
-lemma H₄_β_action : (H₄ ∣[(2 : ℤ)] β.1) = H₄ := calc
-  _ = (((H₄ ∣[(2 : ℤ)] negI.1) ∣[(2 : ℤ)] S) ∣[(2 : ℤ)] α.1⁻¹) ∣[(2 : ℤ)] S := by
-    simp [β_eq_negI_mul_S_mul_α_inv_mul_S, slash_mul]
-  _ = _ := by
-    rw [H₄_negI_action, H₄_S_action, neg_slash, neg_slash, α_eq_T_sq]
-    simp [sq, slash_mul, H₂_T_inv_action, H₂_S_action]
+lemma H₄_β_action : (H₄ ∣[(2 : ℤ)] β.1) = H₄ := by
+  simp [β_eq_negI_mul_S_mul_α_inv_mul_S, α_eq_T_sq, sq, slash_mul, H₄_negI_action,
+    H₄_S_action, H₂_T_inv_action, H₂_S_action, neg_slash]
 
 /-- H₂, H₃, H₄ are modular forms of weight 2 and level Γ(2) -/
 noncomputable def H₂_SIF : SlashInvariantForm (Γ 2) 2 where
@@ -238,20 +179,15 @@ variable (γ : SL(2, ℤ))
 -- TODO: Isolate this somewhere
 lemma jacobiTheta₂_term_half_apply (n : ℤ) (z : ℂ) :
     jacobiTheta₂_term n (z / 2) z = cexp (π * I * (n ^ 2 + n) * z) := by
-  rw [jacobiTheta₂_term]
-  ring_nf
+  rw [jacobiTheta₂_term]; ring_nf
 
 lemma jacobiTheta₂_rel_aux (n : ℤ) (t : ℝ) :
     rexp (-π * (n + 1 / 2) ^ 2 * t)
       = rexp (-π * t / 4) * jacobiTheta₂_term n (I * t / 2) (I * t) := by
   rw [jacobiTheta₂_term_half_apply, ofReal_exp, ofReal_exp, ← Complex.exp_add, ofReal_mul]
-  congr
-  ring_nf
-  simp
-  ring_nf!
-
--- lemma Complex.norm_exp (z : ℂ) : ‖cexp z‖ = rexp z.re := by
--- simp [abs_exp]
+  congr 1
+  push_cast
+  linear_combination -((π : ℂ) * (n ^ 2 + n) * t) * I_sq
 
 lemma Complex.norm_exp_mul_I (z : ℂ) : ‖cexp (z * I)‖ = rexp (-z.im) := by
   simp [norm_exp]
@@ -276,41 +212,27 @@ theorem isBoundedAtImInfty_H₂ : IsBoundedAtImInfty H₂ := by
     _ = ∑' (n : ℤ), ‖rexp (-π * ((n + 1 / 2) ^ 2 : ℝ) * z.im)‖ := by
       simp_rw [im_ofReal_mul, UpperHalfPlane.im, ← mul_assoc]
     _ ≤ _ := Summable.tsum_le_tsum (fun b ↦ ?_) ?_ ?_
-  · -- TODO: simplify and refactor this proof with subproof 3 & 4
-    have (n : ℤ) : cexp (π * I * (n + 1 / 2) ^ 2 * z)
+  · have (n : ℤ) : cexp (π * I * (n + 1 / 2) ^ 2 * z)
         = cexp (π * I * z / 4) * jacobiTheta₂_term n (z / 2) z := by
-      rw [jacobiTheta₂_term_half_apply, ← Complex.exp_add]
-      ring_nf
+      rw [jacobiTheta₂_term_half_apply, ← Complex.exp_add]; ring_nf
     simp_rw [this, ← smul_eq_mul (a := cexp _)]
-    apply Summable.norm
-    apply Summable.const_smul
-    rw [summable_jacobiTheta₂_term_iff, coe_im]
-    linarith
+    exact (((summable_jacobiTheta₂_term_iff _ z).mpr (by rw [coe_im]; linarith)).const_smul
+      (cexp (π * I * z / 4))).norm
   · rw [Real.norm_eq_abs, Real.abs_exp]
-    apply Real.exp_monotone
-    repeat rw [neg_mul]
-    apply neg_le_neg
-    have : (b : ℝ) + 1 / 2 ≠ 0 := by
-      intro hb
-      rw [add_eq_zero_iff_eq_neg] at hb
-      have : (2 * b : ℝ) = -1 := by simp [hb]
-      norm_cast at this
-      exact Int.not_odd_iff_even.mpr (even_two_mul b) (by rw [this]; simp)
-    convert (mul_le_mul_iff_right₀ (mul_pos pi_pos (sq_pos_of_ne_zero this))).mpr hz using 1
-    rw [mul_one]
-  · apply Summable.norm
-    apply summable_ofReal.mp
+    refine Real.exp_monotone ?_
+    have hb : (b : ℝ) + 1 / 2 ≠ 0 := fun h => by
+      have : (2 * b + 1 : ℤ) = 0 := by exact_mod_cast (show (2 * b + 1 : ℝ) = 0 by linarith)
+      omega
+    nlinarith [sq_pos_of_ne_zero hb, pi_pos, hz, mul_pos pi_pos (sq_pos_of_ne_zero hb)]
+  · apply (summable_ofReal.mp ?_).norm
     simp_rw [jacobiTheta₂_rel_aux, ofReal_exp, ← smul_eq_mul (a := cexp _)]
-    apply Summable.const_smul
-    rw [summable_jacobiTheta₂_term_iff, I_mul_im, ofReal_re]
-    linarith
+    exact ((summable_jacobiTheta₂_term_iff _ _).mpr
+      (by rw [I_mul_im, ofReal_re]; linarith)).const_smul _
   · apply summable_ofReal.mp
-    have (n : ℤ) := jacobiTheta₂_rel_aux n 1
-    simp_rw [mul_one] at this
-    simp_rw [this, ← smul_eq_mul]
-    apply Summable.const_smul
-    rw [summable_jacobiTheta₂_term_iff]
-    simp
+    have h (n : ℤ) := jacobiTheta₂_rel_aux n 1
+    simp_rw [mul_one] at h
+    simp_rw [h, ← smul_eq_mul]
+    exact ((summable_jacobiTheta₂_term_iff _ _).mpr (by simp)).const_smul _
 
 -- We isolate this lemma out as it's also used in the proof for Θ₄
 lemma isBoundedAtImInfty_H₃_aux (z : ℍ) (hz : 1 ≤ z.im) :
@@ -325,18 +247,11 @@ lemma isBoundedAtImInfty_H₃_aux (z : ℍ) (hz : 1 ≤ z.im) :
       at this
     simpa using summable_ofReal.mp this
   calc
-    _ = ∑' (n : ℤ), ‖cexp (π * (n : ℂ) ^ 2 * z * I)‖ := by simp_rw [Θ₃_term, mul_right_comm _ I]
-    _ = ∑' (n : ℤ), rexp (-π * (n : ℂ) ^ 2 * z).im := by simp_rw [Complex.norm_exp_mul_I]; simp
     _ = ∑' (n : ℤ), rexp (-π * (n : ℝ) ^ 2 * z.im) := by
-      congr with n
-      rw [← ofReal_neg, ← coe_im, ← im_ofReal_mul]
-      simp
-    _ ≤ _ := Summable.tsum_le_tsum (fun b ↦ ?_) ?_ ?_
-  · apply exp_monotone
-    simp only [neg_mul, neg_le_neg_iff]
-    exact le_mul_of_one_le_right (by positivity) hz
-  · exact h_sum z
-  · simpa using h_sum UpperHalfPlane.I
+      simp_rw [Θ₃_term, mul_right_comm _ I, Complex.norm_exp_mul_I, h_rw]
+    _ ≤ _ := Summable.tsum_le_tsum
+      (fun b ↦ exp_monotone <| by simpa using le_mul_of_one_le_right (by positivity) hz)
+      (h_sum z) (by simpa using h_sum UpperHalfPlane.I)
 
 theorem isBoundedAtImInfty_H₃ : IsBoundedAtImInfty H₃ := by
   simp_rw [UpperHalfPlane.isBoundedAtImInfty_iff, H₃, Θ₃]
@@ -344,7 +259,6 @@ theorem isBoundedAtImInfty_H₃ : IsBoundedAtImInfty H₃ := by
   intro z hz
   rw [norm_pow]
   gcongr
-  -- rw [← ]
   apply (norm_tsum_le_tsum_norm ?_).trans (isBoundedAtImInfty_H₃_aux z hz)
   simp_rw [Θ₃_term_as_jacobiTheta₂_term]
   apply Summable.norm
@@ -444,14 +358,10 @@ theorem jacobiTheta₂_half_mul_apply_tendsto_atImInfty :
     have (n : ℤ) := jacobiTheta₂_rel_aux n 1
     simp_rw [mul_one] at this
     simp_rw [ofReal_mul, this, ← smul_eq_mul]
-    apply Summable.const_smul
-    apply Summable.const_smul
-    rw [summable_jacobiTheta₂_term_iff]
-    simp
+    refine (Summable.const_smul _ ?_).const_smul _
+    rw [summable_jacobiTheta₂_term_iff]; simp
   · intro n
-    have : n = -1 ∨ n = 0 ∨ n ∉ ({-1, 0} : Set ℤ) := by
-      rw [Set.mem_insert_iff, Set.mem_singleton_iff]
-      tauto
+    have : n = -1 ∨ n = 0 ∨ n ∉ ({-1, 0} : Set ℤ) := by simp; tauto
     rcases this with (rfl | rfl | hn) <;> ring_nf
     · simp
     · simp
@@ -460,30 +370,25 @@ theorem jacobiTheta₂_half_mul_apply_tendsto_atImInfty :
       have h₁ (n : ℤ) (z : ℂ) : (π * I * n * z + π * I * n ^ 2 * z) = π * (n + n ^ 2) * z * I := by
         ring_nf
       have h_base' : rexp (-π) ^ ((n : ℝ) + n ^ 2) < 1 := by
-        apply Real.rpow_lt_one
-        · positivity
-        · apply Real.exp_lt_one_iff.mpr (by simp; positivity)
-        convert_to 0 < ((n * (n + 1) : ℤ) : ℝ)
-        · push_cast
-          ring_nf
-        · apply Int.cast_pos.mpr
-          by_cases hn' : 0 < n
-          · apply mul_pos hn' (by omega)
-          · rw [Set.mem_insert_iff, Set.mem_singleton_iff] at hn
-            exact mul_pos_of_neg_of_neg (by omega) (by omega)
+        apply Real.rpow_lt_one (Real.exp_nonneg _)
+          (Real.exp_lt_one_iff.mpr (by simp; positivity))
+        rw [Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at hn
+        have h2 : (n : ℝ) + n ^ 2 = ((n * (n + 1) : ℤ) : ℝ) := by push_cast; ring
+        rw [h2, Int.cast_pos]
+        rcases lt_or_gt_of_ne hn.2 with h | h
+        · exact mul_pos_of_neg_of_neg h (by omega)
+        · exact mul_pos h (by omega)
       simp_rw [h₁, norm_exp_mul_I, mul_assoc, im_ofReal_mul, ← Int.cast_pow, ← Int.cast_add,
         ← ofReal_intCast, im_ofReal_mul, ← mul_assoc, Int.cast_add, Int.cast_pow, ← neg_mul,
         Real.exp_mul, coe_im]
       refine (tendsto_rpow_atTop_of_base_lt_one _ ?_ h_base').comp tendsto_im_atImInfty
       exact neg_one_lt_zero.trans (by positivity)
   · rw [eventually_atImInfty]
-    use 1
-    intro z hz k
+    refine ⟨1, fun z hz k ↦ ?_⟩
     simp_rw [← Real.exp_add]
     ring_nf
     trans ‖cexp (((π * k + π * k ^ 2 : ℝ) * z) * I)‖
-    · apply le_of_eq
-      simpa [add_mul] using by ring_nf
+    · exact le_of_eq (by simpa [add_mul] using by ring_nf)
     · rw [norm_exp_mul_I, im_ofReal_mul]
       have (n : ℤ) : 0 ≤ (n : ℝ) ^ 2 + n := by
         nth_rw 2 [← mul_one n]
@@ -507,22 +412,18 @@ theorem jacobiTheta₂_zero_apply_tendsto_atImInfty :
   · apply summable_ofReal.mp
     have := (summable_jacobiTheta₂_term_iff 0 I).mpr (by simp)
     rw [← summable_norm_iff, ← summable_ofReal] at this
-    simp_rw [jacobiTheta₂_term, mul_zero, zero_add, mul_right_comm _ I, mul_assoc, ← sq, I_sq,
-      mul_neg_one, norm_exp, re_ofReal_mul, neg_re, mul_neg, ← neg_mul, ← ofReal_intCast,
-      ← ofReal_pow, ofReal_re] at this
-    exact this
+    simpa [jacobiTheta₂_term, mul_right_comm _ I, mul_assoc, ← sq, I_sq, norm_exp,
+      ← ofReal_intCast, ← ofReal_pow] using this
   · intro k
     simp only
     split_ifs with hk
-    · subst hk
-      simp
+    · subst hk; simp
     · rw [tendsto_zero_iff_norm_tendsto_zero]
       simp_rw [mul_right_comm _ I, norm_exp_mul_I, mul_assoc, im_ofReal_mul, ← ofReal_intCast,
         ← ofReal_pow, im_ofReal_mul, ← mul_assoc]
       simpa using tendsto_im_atImInfty.const_mul_atTop (by positivity)
   · rw [eventually_atImInfty]
-    use 1, fun z hz k ↦ ?_
-    simp only
+    refine ⟨1, fun z hz k ↦ ?_⟩
     simp_rw [mul_right_comm _ I, norm_exp_mul_I]
     simpa [← ofReal_intCast, ← ofReal_pow] using le_mul_of_one_le_right (by positivity) hz
 
@@ -542,29 +443,22 @@ theorem jacobiTheta₂_half_apply_tendsto_atImInfty :
   · apply summable_ofReal.mp
     have := (summable_jacobiTheta₂_term_iff 0 I).mpr (by simp)
     rw [← summable_norm_iff, ← summable_ofReal] at this
-    simp_rw [jacobiTheta₂_term, mul_zero, zero_add, mul_right_comm _ I, mul_assoc, ← sq, I_sq,
-      mul_neg_one, norm_exp, re_ofReal_mul, neg_re, mul_neg, ← neg_mul, ← ofReal_intCast,
-      ← ofReal_pow, ofReal_re] at this
-    exact this
+    simpa [jacobiTheta₂_term, mul_right_comm _ I, mul_assoc, ← sq, I_sq, norm_exp,
+      ← ofReal_intCast, ← ofReal_pow] using this
   · intro k
     simp only
     split_ifs with hk
-    · subst hk
-      simp
+    · subst hk; simp
     · rw [tendsto_zero_iff_norm_tendsto_zero]
       simp_rw [hnorm]
-      have hk2_pos : 0 < (k : ℝ) ^ 2 := by
-        exact sq_pos_of_ne_zero (Int.cast_ne_zero.mpr hk)
-      exact (Real.tendsto_exp_atBot).comp
-        (tendsto_im_atImInfty.const_mul_atTop_of_neg (by nlinarith [Real.pi_pos, hk2_pos]))
+      have hk2_pos : 0 < (k : ℝ) ^ 2 := sq_pos_of_ne_zero (Int.cast_ne_zero.mpr hk)
+      exact Real.tendsto_exp_atBot.comp
+        (tendsto_im_atImInfty.const_mul_atTop_of_neg (by nlinarith [Real.pi_pos]))
   · rw [eventually_atImInfty]
-    use 1, fun z hz k ↦ ?_
+    refine ⟨1, fun z hz k ↦ ?_⟩
     rw [hnorm]
-    have hcoef_nonpos : (-π * (k : ℝ) ^ 2) ≤ 0 := by
-      nlinarith [Real.pi_pos, sq_nonneg (k : ℝ)]
-    have hmul : (-π * (k : ℝ) ^ 2) * z.im ≤ (-π * (k : ℝ) ^ 2) * 1 := by
-      exact mul_le_mul_of_nonpos_left hz hcoef_nonpos
-    simpa using Real.exp_le_exp.mpr hmul
+    refine Real.exp_le_exp.mpr (mul_le_mul_of_nonpos_left hz ?_) |>.trans_eq (by simp)
+    nlinarith [Real.pi_pos, sq_nonneg (k : ℝ)]
 
 theorem Θ₂_tendsto_atImInfty : Tendsto Θ₂ atImInfty (𝓝 0) := by
   rw [funext Θ₂_as_jacobiTheta₂, ← zero_mul (2 : ℂ)]
@@ -587,16 +481,13 @@ theorem Θ₄_tendsto_atImInfty : Tendsto Θ₄ atImInfty (𝓝 1) := by
   simpa [funext Θ₄_as_jacobiTheta₂] using jacobiTheta₂_half_apply_tendsto_atImInfty
 
 theorem H₂_tendsto_atImInfty : Tendsto H₂ atImInfty (𝓝 0) := by
-  convert Θ₂_tendsto_atImInfty.pow 4
-  norm_num
+  simpa [H₂] using Θ₂_tendsto_atImInfty.pow 4
 
 theorem H₃_tendsto_atImInfty : Tendsto H₃ atImInfty (𝓝 1) := by
-  convert Θ₃_tendsto_atImInfty.pow 4
-  norm_num
+  simpa [H₃] using Θ₃_tendsto_atImInfty.pow 4
 
 theorem H₄_tendsto_atImInfty : Tendsto H₄ atImInfty (𝓝 1) := by
-  convert Θ₄_tendsto_atImInfty.pow 4
-  norm_num
+  simpa [H₄] using Θ₄_tendsto_atImInfty.pow 4
 
 /-!
 ## Imaginary Axis Properties

--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -31,7 +31,7 @@ lemma H₂_T_action : (H₂ ∣[(2 : ℤ)] T) = -H₂ := by
   ext x
   suffices hΘ₂ : Θ₂ ((1 : ℝ) +ᵥ x) = cexp (π * I / 4) * Θ₂ x by
     simp_rw [modular_slash_T_apply, Pi.neg_apply, H₂, hΘ₂, mul_pow, ← Complex.exp_nat_mul,
-      mul_comm ((4 : ℕ) : ℂ), Nat.cast_ofNat, div_mul_cancel₀ (b := (4 : ℂ)) _ (by simp),
+      Nat.cast_ofNat, mul_comm (4 : ℂ), div_mul_cancel₀ (b := (4 : ℂ)) _ (by simp),
       Complex.exp_pi_mul_I, neg_one_mul]
   simp_rw [Θ₂, Θ₂_term, ← tsum_mul_left]
   refine tsum_congr fun b ↦ ?_
@@ -57,7 +57,7 @@ lemma H₄_T_action : (H₄ ∣[(2 : ℤ)] T) = H₃ := by
   -- H₄|T = H₃|T^2 = Θ₂(0, z + 2) = Θ₂(0, z) = H₃
   ext x
   simp_rw [← H₃_T_action, modular_slash_T_apply, H₃, Θ₃_as_jacobiTheta₂, coe_vadd, ← add_assoc,
-    show ((1 : ℝ) : ℂ) + ((1 : ℝ) : ℂ) = 2 by norm_num, add_comm (2 : ℂ), jacobiTheta₂_add_right]
+    ofReal_one, show (1 : ℂ) + 1 = 2 by norm_num, add_comm (2 : ℂ), jacobiTheta₂_add_right]
 
 lemma H₂_T_inv_action : (H₂ ∣[(2 : ℤ)] T⁻¹) = -H₂ := by
   nth_rw 1 [← neg_eq_iff_eq_neg.mpr H₂_T_action, neg_slash, ← slash_mul, mul_inv_cancel, slash_one]
@@ -88,12 +88,12 @@ lemma H₂_S_action : (H₂ ∣[(2 : ℤ)] S) = -H₄ := by
       show ((-I * -x⁻¹) : ℂ) = I * x⁻¹ by ring] at hfe
   simp only [modular_slash_S_apply, Pi.neg_apply, H₂, Θ₂_as_jacobiTheta₂, H₄, Θ₄_as_jacobiTheta₂]
   rw [show ((-x : ℂ))⁻¹ = -x⁻¹ by simp, hfe, mul_pow, mul_pow, mul_pow, div_pow, one_pow,
-      ← cpow_mul_nat, show ((1:ℂ)/2 * (4:ℕ)) = 2 by push_cast; ring, Complex.cpow_two, mul_pow,
-      I_sq, ← Complex.exp_nat_mul, ← Complex.exp_nat_mul]
-  have hexp : cexp ((4:ℕ) * (↑π * I * -x⁻¹ / 4)) *
-              cexp ((4:ℕ) * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹)) = 1 := by
-    rw [← Complex.exp_add, show ((4 : ℕ) : ℂ) * (↑π * I * -x⁻¹ / 4) +
-      (4 : ℕ) * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹) = 0 by field_simp; ring, Complex.exp_zero]
+      ← cpow_mul_nat, show ((1 : ℂ) / 2 * (4 : ℕ)) = 2 by norm_num, Complex.cpow_two, mul_pow,
+      I_sq, ← Complex.exp_nat_mul, ← Complex.exp_nat_mul, Nat.cast_ofNat]
+  have hexp : cexp ((4 : ℂ) * (↑π * I * -x⁻¹ / 4)) *
+              cexp ((4 : ℂ) * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹)) = 1 := by
+    rw [← Complex.exp_add, show (4 : ℂ) * (↑π * I * -x⁻¹ / 4) +
+      4 * (-↑π * I * (-x⁻¹ / 2) ^ 2 / -x⁻¹) = 0 by field_simp; ring, Complex.exp_zero]
   have hzpow : (1 / (-1 * x⁻¹ ^ 2) * x ^ (-2 : ℤ) : ℂ) = -1 := by
     rw [zpow_neg, zpow_ofNat]; field_simp
   linear_combination hexp * (1 / (-1 * x⁻¹ ^ 2) * x ^ (-2 : ℤ) * jacobiTheta₂ (1 / 2) x ^ 4) +
@@ -634,7 +634,7 @@ theorem H₄_imag_axis_pos : ResToImagAxis.Pos H₄ := by
   rw [H₄_S_action] at hSlash
   have hI2 : (I : ℂ) ^ (-2 : ℤ) = -1 := by
     change (I ^ 2)⁻¹ = -1; rw [I_sq]; norm_num
-  have h1t2 : ((1 / t : ℝ) : ℂ) ^ (-2 : ℤ) = (t : ℂ) ^ 2 := by
+  have h1t2 : (↑(1 / t : ℝ) : ℂ) ^ (-2 : ℤ) = (t : ℂ) ^ 2 := by
     have : (t : ℂ) ≠ 0 := ofReal_ne_zero.mpr ht.ne'
     simp only [one_div, ofReal_inv, zpow_neg]; field_simp
   have hNeg : (-H₂).resToImagAxis (1 / t) = -(H₂.resToImagAxis (1 / t)) := by


### PR DESCRIPTION
## Summary
- Golf the `ImagAxisProperties` section of `JacobiTheta/Basic.lean` from ~255 to ~150 lines
- Consolidate repeated summability arguments into two private helpers (`summable_Θ₂_term_imagAxis`, `summable_Θ₄_term_imagAxis`) and generalize `Complex.im_tsum_eq_zero_of_im_eq_zero` to `{ι : Type*}`
- Replace multi-step `push_cast; ring_nf; simp [I_sq]; ring` chains with `push_cast; linear_combination (...) * I_sq`
- Derive `H₄_imag_axis_pos` from `H₂_imag_axis_pos` via the `S`-slash action (`H₄_S_action`) rather than a fresh positivity argument

Stacked on top of #392.

## Test plan
- [x] `lake env lean SpherePacking/ModularForms/JacobiTheta/Basic.lean` — clean
- [x] `lake env lean SpherePacking/ModularForms/FG.lean` — clean (only pre-existing `sorry` warnings)
- [x] `lake env lean SpherePacking/ModularForms/JacobiTheta/MDifferentiable.lean` — clean
- [x] `lake env lean SpherePacking/ModularForms/QExpansion.lean` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)