### PR TITLE
Prepare defs for mathlib

### DIFF
--- a/SpherePacking/Basic/E8.lean
+++ b/SpherePacking/Basic/E8.lean
@@ -605,6 +605,7 @@ lemma E8_ℤBasis_ofZLatticeBasis_apply (i : Fin 8) :
 section Packing
 
 open scoped Real
+open EuclideanSpace
 
 noncomputable def E8Packing : PeriodicSpherePacking 8 where
   separation := √2
@@ -629,7 +630,7 @@ lemma E8Packing_separation : E8Packing.separation = √2 := rfl
 lemma E8Packing_lattice : E8Packing.lattice = E8Lattice := rfl
 
 lemma E8Packing_numReps : E8Packing.numReps = 1 :=
-  PeriodicSpherePacking.numReps_eq_one _ rfl
+  Metric.PeriodicSpherePacking.numReps_eq_one _ rfl
 
 lemma E8Basis_apply_norm : ∀ i : Fin 8, ‖WithLp.toLp 2 (E8Basis ℝ i)‖ ≤ 2 := by
   have : √2 ≤ 2 := by
@@ -669,8 +670,8 @@ lemma E8_ℤBasis_ofZLatticeBasis_volume :
 
 open MeasureTheory ZSpan in
 theorem E8Packing_density : E8Packing.density = ENNReal.ofReal π ^ 4 / 384 := by
-  rw [PeriodicSpherePacking.density_eq E8_ℤBasis ?_ (by omega) (L := 16)]
-  · rw [E8Packing_numReps, Nat.cast_one, one_mul, volume_ball, finrank_euclideanSpace,
+  rw [Metric.PeriodicSpherePacking.density_eq E8_ℤBasis ?_ (by omega) (L := 16)]
+  · rw [E8Packing_numReps, Nat.cast_one, one_mul, volume_ball,
       Fintype.card_fin, Nat.cast_ofNat]
     simp only [E8Packing]
     have {x : ℝ} (hx : 0 ≤ x := by positivity) : √x ^ 8 = x ^ 4 := calc

--- a/SpherePacking/Basic/PeriodicPacking.lean
+++ b/SpherePacking/Basic/PeriodicPacking.lean
@@ -7,11 +7,11 @@ module
 
 public import Mathlib.Algebra.Module.ZLattice.Covolume
 public import Mathlib.Dynamics.Ergodic.Action.Regular
+import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 
 public import SpherePacking.Basic.SpherePacking
 public import SpherePacking.ForMathlib.ENNReal
 public import SpherePacking.ForMathlib.Encard
-public import SpherePacking.ForMathlib.ENat
 public import SpherePacking.ForMathlib.ZLattice
 
 @[expose] public section
@@ -88,8 +88,8 @@ theorem aux3 {ι τ : Type*} {s : Set ι} {f : ι → Set (EuclideanSpace ℝ τ
         refine lt_of_le_of_lt ((ENNReal.le_div_iff_mul_le ?_ ?_).mpr h₁) <|
           ENNReal.div_lt_top ?_ hc.ne.symm
         · left; positivity
-        · right; exact (volume_ball_lt_top _).ne
-        · exact (volume_ball_lt_top _).ne
+        · right; exact measure_ball_lt_top.ne
+        · exact measure_ball_lt_top.ne
       · exact ENNReal.summable
       · exact ENNReal.summable
       · intro x
@@ -107,7 +107,7 @@ lemma aux4 (hD_isBounded : IsBounded D) (hd : 0 < d) : Finite ↑(S.centers ∩ 
   · intro x hx y hy hxy
     apply ball_disjoint_ball
     simpa [add_halves] using S.centers_dist' _ _ hx.left hy.left hxy
-  · apply volume_ball_pos
+  · apply measure_ball_pos
     linarith [S.separation_pos]
   · intros
     exact measurableSet_ball
@@ -735,7 +735,7 @@ theorem aux_big_le
   _ ≤ (S.centers ∩ ball 0 (R + S.separation / 2)).encard
       * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) :=
-    S.finiteDensity_le hd R
+    S.finiteDensity_le R
   _ ≤ S.numReps
         • (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + S.separation / 2 + L)).encard
           * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -772,7 +772,7 @@ theorem aux_big_ge
   _ ≥ (S.centers ∩ ball 0 (R - S.separation / 2)).encard
       * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) :=
-    S.finiteDensity_ge hd R
+    S.finiteDensity_ge R
   _ ≥ S.numReps
         • (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R - S.separation / 2 - L)).encard
           * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -840,8 +840,8 @@ theorem volume_ball_ratio_tendsto_nhds_one {C : ℝ} (hd : 0 < d) (hC : 0 ≤ C)
     use 1
     intro b hb
     rw [ENNReal.div_self, Pi.one_apply]
-    · exact (volume_ball_pos _ (by linarith)).ne.symm
-    · exact (volume_ball_lt_top _).ne
+    · exact (measure_ball_pos volume 0 (by positivity)).ne.symm
+    · exact measure_ball_lt_top.ne
   · have (R : ℝ) (hR : 0 ≤ R) : volume (ball (0 : EuclideanSpace ℝ (Fin d)) R)
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + C))
           = ENNReal.ofReal (R ^ d / (R + C) ^ d) := by
@@ -875,9 +875,9 @@ theorem volume_ball_ratio_tendsto_nhds_one'
     intro R hR
     have hR' : 0 < R := by linarith
     rw [ENNReal.div_div_div_cancel_left]
-    · exact (volume_ball_pos _ hR').ne.symm
-    · exact (volume_ball_lt_top _).ne
-    · exact (volume_ball_lt_top _).ne
+    · exact (measure_ball_pos volume 0 hR').ne.symm
+    · exact (measure_ball_lt_top).ne
+    · exact (measure_ball_lt_top).ne
   · convert ENNReal.Tendsto.div (volume_ball_ratio_tendsto_nhds_one hd hC') ?_
       (volume_ball_ratio_tendsto_nhds_one hd hC) ?_ <;> simp
 

--- a/SpherePacking/Basic/PeriodicPacking.lean
+++ b/SpherePacking/Basic/PeriodicPacking.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.ZLattice.Covolume
 public import Mathlib.Dynamics.Ergodic.Action.Regular
-import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
+public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 
 public import SpherePacking.Basic.SpherePacking
 public import SpherePacking.ForMathlib.ENNReal

--- a/SpherePacking/Basic/PeriodicPacking.lean
+++ b/SpherePacking/Basic/PeriodicPacking.lean
@@ -16,8 +16,6 @@ public import SpherePacking.ForMathlib.ZLattice
 
 @[expose] public section
 
--- import Mathlib
-
 /- In this file, we establish results about density of periodic packings. This roughly corresponds
 to Section 2.2, "Bounds on Finite Density of Periodic Packing". -/
 
@@ -29,11 +27,11 @@ density within a fundamental domain w.r.t. any basis.
 -/
 
 open scoped ENNReal
-open SpherePacking EuclideanSpace MeasureTheory Metric ZSpan Bornology Module
+open MeasureTheory Metric ZSpan Bornology Module EuclideanSpace
 
 section aux_lemmas
 
-variable {d : ℕ} (S : PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
+variable {d : ℕ} (S : EuclideanSpace.PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
 
 lemma aux1 (hD_isBounded : IsBounded D) :
     IsBounded (⋃ x ∈ S.centers ∩ D, ball x (S.separation / 2)) := by
@@ -53,7 +51,7 @@ lemma aux2 (D : Set (EuclideanSpace ℝ (Fin d))) :
   intro x hx y hy hxy
   apply ball_disjoint_ball
   rw [add_halves]
-  exact S.centers_dist' _ _ hx.left hy.left hxy
+  exact S.centers_dist' hx.left hy.left hxy
 
 theorem aux3 {ι τ : Type*} {s : Set ι} {f : ι → Set (EuclideanSpace ℝ τ)} {c : ℝ≥0∞} (hc : 0 < c)
     [Fintype τ] [NoAtoms (volume : Measure (EuclideanSpace ℝ τ))]
@@ -106,7 +104,7 @@ lemma aux4 (hD_isBounded : IsBounded D) (hd : 0 < d) : Finite ↑(S.centers ∩ 
     simp [Measure.addHaar_ball_center]
   · intro x hx y hy hxy
     apply ball_disjoint_ball
-    simpa [add_halves] using S.centers_dist' _ _ hx.left hy.left hxy
+    simpa [add_halves] using S.centers_dist' hx.left hy.left hxy
   · apply measure_ball_pos
     linarith [S.separation_pos]
   · intros
@@ -125,11 +123,11 @@ lemma aux4''
 end aux_lemmas
 
 section instances
-variable {d : ℕ} (S : PeriodicSpherePacking d)
+variable {d : ℕ} (S : EuclideanSpace.PeriodicSpherePacking d)
 open scoped Pointwise
 
 -- TODO: rename + move
-theorem PeriodicSpherePacking.fract_centers
+theorem Metric.PeriodicSpherePacking.fract_centers
     {ι : Type*} [Fintype ι] (b : Basis ι ℤ S.lattice) (s : S.centers) :
     fract (b.ofZLatticeBasis ℝ _) s.val ∈ S.centers := by
   have := (floor (b.ofZLatticeBasis ℝ _) s).prop
@@ -138,7 +136,7 @@ theorem PeriodicSpherePacking.fract_centers
   apply S.lattice_action (neg_mem this) s.prop
 
 -- TODO: rename + move
-theorem PeriodicSpherePacking.orbitRel_fract
+theorem Metric.PeriodicSpherePacking.orbitRel_fract
     {ι : Type*} [Fintype ι] (b : Basis ι ℤ S.lattice) (a : S.centers) :
     (S.addAction.orbitRel).r ⟨fract (b.ofZLatticeBasis ℝ _) a, S.fract_centers _ _⟩ a := by
   rw [AddAction.orbitRel_apply, AddAction.orbit, Set.mem_range]
@@ -150,7 +148,7 @@ theorem PeriodicSpherePacking.orbitRel_fract
   · simp_rw [fract_apply, sub_eq_neg_add]
     rfl
 
-noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv
+noncomputable def Metric.PeriodicSpherePacking.addActionOrbitRelEquiv
     (D : Set (EuclideanSpace ℝ (Fin d))) (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) :
     Quotient S.addAction.orbitRel ≃ ↑(S.centers ∩ D) where
   toFun := by
@@ -195,7 +193,7 @@ noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv
       set_option backward.isDefEq.respectTransparency false in
       simpa using hx.right
 
-noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv'
+noncomputable def Metric.PeriodicSpherePacking.addActionOrbitRelEquiv'
     {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) :
     Quotient S.addAction.orbitRel ≃ ↑(S.centers ∩ (fundamentalDomain (b.ofZLatticeBasis ℝ _))) := by
   refine S.addActionOrbitRelEquiv _ ?_
@@ -213,7 +211,7 @@ noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv'
     rw [← Submodule.coe_toAddSubgroup, Basis.ofZLatticeBasis_span]
     rfl
 
-noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv''
+noncomputable def Metric.PeriodicSpherePacking.addActionOrbitRelEquiv''
     {ι : Type*} [Fintype ι] (b : Basis ι ℤ S.lattice) (v : EuclideanSpace ℝ (Fin d)) :
     Quotient S.addAction.orbitRel ≃
       ↑(S.centers ∩ (v +ᵥ fundamentalDomain (b.ofZLatticeBasis ℝ _))) := by
@@ -261,10 +259,10 @@ noncomputable def PeriodicSpherePacking.addActionOrbitRelEquiv''
           simp
   }
 
-instance (S : PeriodicSpherePacking 0) : Subsingleton S.centers := inferInstance
-instance (S : PeriodicSpherePacking 0) : Finite S.centers := inferInstance
+instance (S : EuclideanSpace.PeriodicSpherePacking 0) : Subsingleton S.centers := inferInstance
+instance (S : EuclideanSpace.PeriodicSpherePacking 0) : Finite S.centers := inferInstance
 
-noncomputable instance PeriodicSpherePacking.finiteOrbitRelQuotient :
+noncomputable instance Metric.PeriodicSpherePacking.finiteOrbitRelQuotient :
     Finite (Quotient S.addAction.orbitRel) := by
   -- We choose an arbitrary ℤ-basis of S.lattice
   let b : Basis _ ℤ S.lattice := (ZLattice.module_free ℝ S.lattice).chooseBasis
@@ -287,16 +285,17 @@ section numReps
 open scoped Pointwise
 
 
-variable {d : ℕ} (S : PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
+variable {d : ℕ} (S : EuclideanSpace.PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
 
-noncomputable instance PeriodicSpherePacking.instCentersSetoid : Setoid S.centers :=
+noncomputable instance Metric.PeriodicSpherePacking.instCentersSetoid : Setoid S.centers :=
   S.addAction.orbitRel
 
 -- TODO: rename
-noncomputable def PeriodicSpherePacking.numReps : ℕ :=
+noncomputable def Metric.PeriodicSpherePacking.numReps : ℕ :=
   Fintype.card (Quotient S.addAction.orbitRel)
 
-theorem PeriodicSpherePacking.numReps_eq_one (hS : S.centers = S.lattice) : S.numReps = 1 := by
+theorem Metric.PeriodicSpherePacking.numReps_eq_one (hS : S.centers = S.lattice) :
+    S.numReps = 1 := by
   rw [numReps]
   apply le_antisymm
   · rw [Fintype.card_le_one_iff_subsingleton, ← AddAction.pretransitive_iff_subsingleton_quotient]
@@ -309,7 +308,7 @@ theorem PeriodicSpherePacking.numReps_eq_one (hS : S.centers = S.lattice) : S.nu
     let zero : S.centers := ⟨0, by rw [hS]; exact zero_mem _⟩
     use ⟦zero⟧, by simp [zero]
 
-theorem PeriodicSpherePacking.card_centers_inter_isFundamentalDomain
+theorem Metric.PeriodicSpherePacking.card_centers_inter_isFundamentalDomain
     (hD_isBounded : IsBounded D)
     (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D)
     (hd : 0 < d) :
@@ -319,7 +318,7 @@ theorem PeriodicSpherePacking.card_centers_inter_isFundamentalDomain
   convert Finset.card_eq_of_equiv_fintype ?_
   simpa [Set.mem_toFinset] using (S.addActionOrbitRelEquiv D hD_unique_covers).symm
 
-theorem PeriodicSpherePacking.encard_centers_inter_isFundamentalDomain
+theorem Metric.PeriodicSpherePacking.encard_centers_inter_isFundamentalDomain
     (hD_isBounded : IsBounded D)
     (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D)
     (hd : 0 < d) :
@@ -327,7 +326,7 @@ theorem PeriodicSpherePacking.encard_centers_inter_isFundamentalDomain
   rw [← S.card_centers_inter_isFundamentalDomain D hD_isBounded hD_unique_covers hd]
   convert Set.encard_eq_coe_toFinset_card _
 
-theorem PeriodicSpherePacking.card_centers_inter_fundamentalDomain (hd : 0 < d)
+theorem Metric.PeriodicSpherePacking.card_centers_inter_fundamentalDomain (hd : 0 < d)
     {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) :
     haveI := @Fintype.ofFinite _ <| aux4' S b hd
     (S.centers ∩ (fundamentalDomain (b.ofZLatticeBasis ℝ _))).toFinset.card = S.numReps := by
@@ -335,13 +334,13 @@ theorem PeriodicSpherePacking.card_centers_inter_fundamentalDomain (hd : 0 < d)
   convert Finset.card_eq_of_equiv_fintype ?_
   simpa [Set.mem_toFinset] using (S.addActionOrbitRelEquiv' b).symm
 
-theorem PeriodicSpherePacking.encard_centers_inter_fundamentalDomain (hd : 0 < d)
+theorem Metric.PeriodicSpherePacking.encard_centers_inter_fundamentalDomain (hd : 0 < d)
     {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) :
     (S.centers ∩ (fundamentalDomain (b.ofZLatticeBasis ℝ _))).encard = S.numReps := by
   rw [← S.card_centers_inter_fundamentalDomain hd b]
   convert Set.encard_eq_coe_toFinset_card _
 
-theorem PeriodicSpherePacking.card_centers_inter_vadd_fundamentalDomain (hd : 0 < d)
+theorem Metric.PeriodicSpherePacking.card_centers_inter_vadd_fundamentalDomain (hd : 0 < d)
     {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) (v : EuclideanSpace ℝ (Fin d)) :
     haveI := @Fintype.ofFinite _ <| aux4'' S b hd v
     (S.centers ∩ (v +ᵥ fundamentalDomain (b.ofZLatticeBasis ℝ _))).toFinset.card = S.numReps := by
@@ -350,7 +349,7 @@ theorem PeriodicSpherePacking.card_centers_inter_vadd_fundamentalDomain (hd : 0 
   convert Finset.card_eq_of_equiv_fintype ?_
   simpa [Set.mem_toFinset] using (S.addActionOrbitRelEquiv'' b _).symm
 
-theorem PeriodicSpherePacking.encard_centers_inter_vadd_fundamentalDomain (hd : 0 < d)
+theorem Metric.PeriodicSpherePacking.encard_centers_inter_vadd_fundamentalDomain (hd : 0 < d)
     {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) (v : EuclideanSpace ℝ (Fin d)) :
     (S.centers ∩ (v +ᵥ fundamentalDomain (b.ofZLatticeBasis ℝ _))).encard = S.numReps := by
   have := Fintype.ofFinite ι
@@ -368,39 +367,42 @@ section numReps_aux
 
 variable {d : ℕ}
 
-noncomputable instance PeriodicSpherePacking.instFintypeNumReps'
-  (S : PeriodicSpherePacking d) (hd : 0 < d)
+noncomputable instance Metric.PeriodicSpherePacking.instFintypeNumReps'
+  (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d)
   {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D) :
   Fintype ↑(S.centers ∩ D) := @Fintype.ofFinite _ <| aux4 S D hD_isBounded hd
 
-noncomputable def PeriodicSpherePacking.numReps' (S : PeriodicSpherePacking d) (hd : 0 < d)
-  {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D) : ℕ :=
+noncomputable def Metric.PeriodicSpherePacking.numReps'
+    (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d)
+    {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D) : ℕ :=
   letI := S.instFintypeNumReps' hd hD_isBounded
   Fintype.card ↑(S.centers ∩ D)
 
-theorem PeriodicSpherePacking.numReps'_nonneg (S : PeriodicSpherePacking d) (hd : 0 < d)
-  {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D) :
-  0 ≤ S.numReps' hd hD_isBounded := by
+theorem Metric.PeriodicSpherePacking.numReps'_nonneg
+    (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d)
+    {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D) :
+    0 ≤ S.numReps' hd hD_isBounded := by
   letI := S.instFintypeNumReps' hd hD_isBounded
   rw [PeriodicSpherePacking.numReps']
   exact Nat.zero_le (Fintype.card ↑(S.centers ∩ D))
 
-theorem PeriodicSpherePacking.numReps_eq_numReps' (S : PeriodicSpherePacking d) (hd : 0 < d)
-  {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D)
-  (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) :
-  S.numReps = S.numReps' hd hD_isBounded := by
+theorem Metric.PeriodicSpherePacking.numReps_eq_numReps'
+    (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d)
+    {D : Set (EuclideanSpace ℝ (Fin d))} (hD_isBounded : IsBounded D)
+    (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) :
+    S.numReps = S.numReps' hd hD_isBounded := by
   letI := S.instFintypeNumReps' hd hD_isBounded
   rw [PeriodicSpherePacking.numReps']
   rw [← S.card_centers_inter_isFundamentalDomain D hD_isBounded hD_unique_covers hd]
   exact Set.toFinset_card (S.centers ∩ D)
 
--- theorem PeriodicSpherePacking.numReps_ne_zero (S : PeriodicSpherePacking d)
+-- theorem PeriodicSpherePacking.numReps_ne_zero (S : EuclideanSpace.PeriodicSpherePacking d)
 
 end numReps_aux
 
 section theorem_2_3
 
-variable {d : ℕ} (S : PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
+variable {d : ℕ} (S : EuclideanSpace.PeriodicSpherePacking d) (D : Set (EuclideanSpace ℝ (Fin d)))
 
 open scoped Pointwise
 
@@ -422,7 +424,7 @@ private theorem aux
     _ = R := by ring
 
 -- Theorem 2.3, lower bound
-theorem PeriodicSpherePacking.aux_ge
+theorem Metric.PeriodicSpherePacking.aux_ge
     (hd : 0 < d) {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice)
     {L : ℝ} (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (R : ℝ) :
     (↑S.centers ∩ ball 0 R).encard ≥
@@ -486,7 +488,7 @@ private theorem aux'
     exact fract_mem_fundamentalDomain (b.ofZLatticeBasis ℝ _) x
 
 -- Theorem 2.3, upper bound - the proof is similar to lower bound
-theorem PeriodicSpherePacking.aux_le
+theorem Metric.PeriodicSpherePacking.aux_le
     (hd : 0 < d) {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice)
     {L : ℝ} (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (R : ℝ) :
     (↑S.centers ∩ ball 0 R).encard
@@ -550,7 +552,7 @@ either :)
 -/
 
 open scoped Pointwise
-variable {d : ℕ} (S : PeriodicSpherePacking d)
+variable {d : ℕ} (S : EuclideanSpace.PeriodicSpherePacking d)
   {ι : Type*} [Finite ι]
   (D : Set (EuclideanSpace ℝ (Fin d))) {L : ℝ} (R : ℝ)
 
@@ -597,7 +599,7 @@ instance (E : Type*) [AddCommGroup E] [MeasurableSpace E] [MeasurableAdd E] [Mod
   inferInstanceAs <| VAddInvariantMeasure s.toAddSubgroup E μ
 
 -- Theorem 2.2, lower bound
-theorem PeriodicSpherePacking.aux2_ge
+theorem Metric.PeriodicSpherePacking.aux2_ge
     (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) (hD_measurable : MeasurableSet D)
     (hL : ∀ x ∈ D, ‖x‖ ≤ L) (hd : 0 < d) :
     (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R).encard
@@ -643,7 +645,7 @@ theorem aux8 (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) (hL 
     _ < R + L := add_lt_add_of_lt_of_le hi_ball this
 
 -- Theorem 2.2, upper bound
-theorem PeriodicSpherePacking.aux2_le
+theorem Metric.PeriodicSpherePacking.aux2_le
     (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) (hD_measurable : MeasurableSet D)
     (hL : ∀ x ∈ D, ‖x‖ ≤ L) (hd : 0 < d) :
     (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R).encard
@@ -681,7 +683,7 @@ open ZSpan
 variable (b : Basis ι ℤ S.lattice)
 
 -- Theorem 2.2 lower bound, in terms of fundamental domain of Z-lattice
-theorem PeriodicSpherePacking.aux2_ge'
+theorem Metric.PeriodicSpherePacking.aux2_ge'
     (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (hd : 0 < d) :
     (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R).encard
       ≥ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R - L))
@@ -698,7 +700,7 @@ theorem PeriodicSpherePacking.aux2_ge'
     exact hy
 
 -- Theorem 2.2 upper bound, in terms of fundamental domain of Z-lattice
-theorem PeriodicSpherePacking.aux2_le'
+theorem Metric.PeriodicSpherePacking.aux2_le'
     (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (hd : 0 < d) :
     (↑S.lattice ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R).encard
       ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + L))
@@ -721,7 +723,7 @@ section finiteDensity_limit
 open MeasureTheory Measure Metric ZSpan
 
 variable
-  {d : ℕ} {S : PeriodicSpherePacking d}
+  {d : ℕ} {S : EuclideanSpace.PeriodicSpherePacking d}
   {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) {L : ℝ} (R : ℝ)
 
 theorem aux_big_le
@@ -914,10 +916,10 @@ end VolumeBallRatio
 section DensityEqFdDensity
 
 variable
-  {d : ℕ} {S : PeriodicSpherePacking d}
+  {d : ℕ} {S : EuclideanSpace.PeriodicSpherePacking d}
   {ι : Type*} [Finite ι] (b : Basis ι ℤ S.lattice) {L : ℝ} (R : ℝ)
 
-private lemma PeriodicSpherePacking.tendsto_finiteDensity
+private lemma Metric.PeriodicSpherePacking.tendsto_finiteDensity
     (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (hd : 0 < d) :
     Tendsto S.finiteDensity atTop
       (𝓝 (S.numReps * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -939,7 +941,7 @@ private lemma PeriodicSpherePacking.tendsto_finiteDensity
     · left
       exact one_ne_zero
 
-theorem PeriodicSpherePacking.density_eq
+theorem Metric.PeriodicSpherePacking.density_eq
     (hL : ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L) (hd : 0 < d) :
     S.density
       = S.numReps * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -951,17 +953,18 @@ end DensityEqFdDensity
 section ConstantEqNormalizedConstant
 
 theorem periodic_constant_eq_periodic_constant_normalized (hd : 0 < d) :
-    PeriodicSpherePackingConstant d = ⨆ (S : PeriodicSpherePacking d) (_ : S.separation = 1),
-    S.density := by
+    PeriodicSpherePackingConstant d =
+      ⨆ (S : EuclideanSpace.PeriodicSpherePacking d) (_ : S.separation = 1), S.density := by
   -- Argument almost identical to `constant_eq_constant_normalized`, courtesy Gareth
   rw [iSup_subtype', PeriodicSpherePackingConstant]
   apply le_antisymm
   · apply iSup_le
     intro S
     have h := inv_mul_cancel₀ S.separation_pos.ne.symm
-    have := le_iSup (fun x : { x : PeriodicSpherePacking d // x.separation = 1 } ↦ x.val.density)
+    have := le_iSup
+        (fun x : { x : EuclideanSpace.PeriodicSpherePacking d // x.separation = 1 } ↦ x.val.density)
         ⟨S.scale (inv_pos.mpr S.separation_pos), h⟩
-    rw [← scale_density hd]
+    rw [← Metric.SpherePacking.scale_density hd]
     · exact this
     · rw [inv_pos]
       exact S.separation_pos
@@ -974,11 +977,11 @@ end ConstantEqNormalizedConstant
 
 section Disjoint_Covering_of_Centers
 
-theorem PeriodicSpherePacking.unique_covers_of_centers (S : PeriodicSpherePacking d) -- (hd : 0 < d)
-  {D : Set (EuclideanSpace ℝ (Fin d))} -- (hD_isBounded : IsBounded D)
-  (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) -- (hD_measurable : MeasurableSet D)
-  :
-  ∀ x : S.centers, ∃! g : S.lattice, (g +ᵥ x : EuclideanSpace ℝ (Fin d)) ∈ S.centers ∩ D := by
+theorem Metric.PeriodicSpherePacking.unique_covers_of_centers
+    (S : EuclideanSpace.PeriodicSpherePacking d)
+    {D : Set (EuclideanSpace ℝ (Fin d))}
+    (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) :
+    ∀ x : S.centers, ∃! g : S.lattice, (g +ᵥ x : EuclideanSpace ℝ (Fin d)) ∈ S.centers ∩ D := by
   intro x
   obtain ⟨g, hg₁, hg₂⟩ := hD_unique_covers (x : EuclideanSpace ℝ (Fin d))
   use g
@@ -988,7 +991,8 @@ theorem PeriodicSpherePacking.unique_covers_of_centers (S : PeriodicSpherePackin
   · intro a ha hmem
     exact hg₂ a ha hmem
 
-theorem PeriodicSpherePacking.centers_union_over_lattice (S : PeriodicSpherePacking d)
+theorem Metric.PeriodicSpherePacking.centers_union_over_lattice
+    (S : EuclideanSpace.PeriodicSpherePacking d)
     {D : Set (EuclideanSpace ℝ (Fin d))}
     (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) :
     S.centers = ⋃ (g : S.lattice), (g +ᵥ S.centers ∩ D) := by
@@ -1025,7 +1029,8 @@ theorem PeriodicSpherePacking.centers_union_over_lattice (S : PeriodicSpherePack
 -- This is true but unnecessary (for now). What's more important is expressing it as a disjoint
 -- union over points in X / Λ = X ∩ D of translates of the lattice by points in X / Λ = X ∩ D or
 -- something like that, because that's what's needed for `tsum_finset_bUnion_disjoint`.
--- theorem PeriodicSpherePacking.translates_disjoint (S : PeriodicSpherePacking d) -- (hd : 0 < d)
+-- theorem PeriodicSpherePacking.translates_disjoint
+-- (S : EuclideanSpace.PeriodicSpherePacking d) -- (hd : 0 < d)
 -- {D : Set (EuclideanSpace ℝ (Fin d))} -- (hD_isBounded : IsBounded D)
 -- (hD_unique_covers : ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ D) -- (hD_measurable : MeasurableSet D)
 -- : Set.Pairwise ⊤ (Disjoint on (fun (g : S.lattice) => g +ᵥ S.centers ∩ D)) -- why the error?
@@ -1050,7 +1055,7 @@ section Fundamental_Domains_in_terms_of_Basis
 
 open Submodule
 
-variable (S : PeriodicSpherePacking d) (b : Basis (Fin d) ℤ S.lattice)
+variable (S : EuclideanSpace.PeriodicSpherePacking d) (b : Basis (Fin d) ℤ S.lattice)
 
 -- I include the following because some lemmas in `PeriodicPacking` have them as assumptions, and
 -- I'd like to replace all instances of `D` with `fundamentalDomain (b.ofZLatticeBasis ℝ _)` and
@@ -1058,13 +1063,13 @@ variable (S : PeriodicSpherePacking d) (b : Basis (Fin d) ℤ S.lattice)
 
 -- Note that we have `ZSpan.fundamentalDomain_isBounded`. We can use this to prove the following,
 -- which is necessary for `PeriodicSpherePacking.density_eq`.
-theorem PeriodicSpherePacking.exists_bound_on_fundamental_domain :
+theorem Metric.PeriodicSpherePacking.exists_bound_on_fundamental_domain :
   ∃ L : ℝ, ∀ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _), ‖x‖ ≤ L :=
   isBounded_iff_forall_norm_le.1 (fundamentalDomain_isBounded (Basis.ofZLatticeBasis ℝ S.lattice b))
 
 -- Note that we have `ZSpan.exist_unique_vadd_mem_fundamentalDomain`. We can use this to prove the
 -- following.
-theorem PeriodicSpherePacking.fundamental_domain_unique_covers :
+theorem Metric.PeriodicSpherePacking.fundamental_domain_unique_covers :
    ∀ x, ∃! g : S.lattice, g +ᵥ x ∈ fundamentalDomain (b.ofZLatticeBasis ℝ _) := by
   have : S.lattice = span ℤ (Set.range (b.ofZLatticeBasis ℝ _)) :=
     Eq.symm (Basis.ofZLatticeBasis_span ℝ S.lattice b)
@@ -1107,16 +1112,18 @@ noncomputable def ZLattice.basis_index_equiv (Λ : Submodule ℤ (EuclideanSpace
       ZLattice.rank ℝ Λ,
       finrank_euclideanSpace, Fintype.card_fin]
 
-noncomputable def PeriodicSpherePacking.basis_index_equiv (P : PeriodicSpherePacking d) :
-  (Module.Free.ChooseBasisIndex ℤ ↥P.lattice) ≃ (Fin d) := ZLattice.basis_index_equiv P.lattice
+noncomputable def Metric.PeriodicSpherePacking.basis_index_equiv
+    (P : EuclideanSpace.PeriodicSpherePacking d) :
+    (Module.Free.ChooseBasisIndex ℤ ↥P.lattice) ≃ (Fin d) :=
+  ZLattice.basis_index_equiv P.lattice
 
 /- Here's a version of `PeriodicSpherePacking.density_eq` that
 1. does not require the `hL` hypothesis that the original one does
 2. uses `ZLattice.covolume` instead of the `volume` of a basis-dependent `fundamentalDomain`
 -/
 @[simp]
-theorem PeriodicSpherePacking.density_eq'
-  (S : PeriodicSpherePacking d) (hd : 0 < d) : S.density =
+theorem Metric.PeriodicSpherePacking.density_eq'
+  (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d) : S.density =
   (ENat.toENNReal (S.numReps : ENat)) *
   volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2)) /
   Real.toNNReal (ZLattice.covolume S.lattice) := by
@@ -1140,8 +1147,9 @@ end Periodic_Density_Formula
 
 section Empty_Centers
 
-theorem PeriodicSpherePacking.density_of_centers_empty (S : PeriodicSpherePacking d) (hd : 0 < d)
-  [instEmpty : IsEmpty S.centers] : S.density = 0 := by
+theorem Metric.PeriodicSpherePacking.density_of_centers_empty
+    (S : EuclideanSpace.PeriodicSpherePacking d) (hd : 0 < d)
+    [instEmpty : IsEmpty S.centers] : S.density = 0 := by
   -- Idea: Use formula
   -- (We are using `IsEmpty` in order to do cases on `isEmpty_or_nonempty` in proofs)
   rw [S.density_eq' hd]
@@ -1163,14 +1171,15 @@ theorem PeriodicSpherePacking.density_of_centers_empty (S : PeriodicSpherePackin
     exact Set.empty_inter D
   exact Set.isEmpty_coe_sort.mp instEmpty
 
-theorem SpherePacking.density_of_centers_empty (S : SpherePacking d) (hd : 0 < d)
-  [instEmpty : IsEmpty S.centers] : S.density = 0 := by
+theorem Metric.SpherePacking.density_of_centers_empty
+    (S : EuclideanSpace.SpherePacking d) (hd : 0 < d)
+    [instEmpty : IsEmpty S.centers] : S.density = 0 := by
   -- Idea: construct a periodic sphere packing with some lattice and the same set of centres
   -- Show that its toSpherePacking is the same as S
   -- Then use formula
   let b : Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis
   let Λ := Submodule.span ℤ (Set.range b)
-  let P : PeriodicSpherePacking d := {
+  let P : EuclideanSpace.PeriodicSpherePacking d := {
     centers := S.centers
     separation := S.separation
     separation_pos := S.separation_pos

--- a/SpherePacking/Basic/SpherePacking.lean
+++ b/SpherePacking/Basic/SpherePacking.lean
@@ -17,8 +17,6 @@ public import SpherePacking.ForMathlib.VolumeOfBalls
 
 @[expose] public section
 
-open BigOperators MeasureTheory Metric
-
 /-!
 # Density of Sphere Packings
 
@@ -29,17 +27,21 @@ the sphere packing centers.
 We also define the *density* of the configuration.
 -/
 
+open BigOperators MeasureTheory Metric Pointwise Filter Module
 open scoped ENNReal
-open BigOperators Pointwise Filter Module
 
 section Definitions
 
+/-- A sphere packing in dimension `d` is a set of points in `ℝ^d` (the *centers*) such that any two
+distinct points are at distance at least `separation` apart. -/
 structure SpherePacking (d : ℕ) where
   centers : Set (EuclideanSpace ℝ (Fin d))
   separation : ℝ
   separation_pos : 0 < separation := by positivity
   centers_dist : Pairwise (separation ≤ dist · · : centers → centers → Prop)
 
+/-- A periodic sphere packing in dimension `d` is a sphere packing whose centers are invariant
+under translation by a `ℤ`-lattice in `ℝ^d`. -/
 structure PeriodicSpherePacking (d : ℕ) extends SpherePacking d where
   lattice : Submodule ℤ (EuclideanSpace ℝ (Fin d))
   lattice_action : ∀ ⦃x y⦄, x ∈ lattice → y ∈ centers → x + y ∈ centers
@@ -51,12 +53,8 @@ variable {d : ℕ}
 theorem SpherePacking.centers_dist' (S : SpherePacking d) (x y : EuclideanSpace ℝ (Fin d))
     (hx : x ∈ S.centers) (hy : y ∈ S.centers) (hxy : x ≠ y) :
     S.separation ≤ dist x y := by
-  have : (⟨x, hx⟩ : S.centers) ≠ ⟨y, hy⟩ := Subtype.coe_ne_coe.mp hxy
-  -- The following fails. Reason unknown.
-  -- exact S.centers_dist this
-  have := S.centers_dist this
-  simp only at this
-  exact this
+  have := S.centers_dist (Subtype.coe_ne_coe.mp hxy : (⟨x, hx⟩ : S.centers) ≠ ⟨y, hy⟩)
+  simpa using this
 
 instance PeriodicSpherePacking.instLatticeDiscrete (S : PeriodicSpherePacking d) :
     DiscreteTopology S.lattice :=
@@ -67,16 +65,8 @@ instance PeriodicSpherePacking.instIsZLattice (S : PeriodicSpherePacking d) :
   S.lattice_isZLattice
 
 instance SpherePacking.instCentersDiscrete (S : SpherePacking d) :
-    DiscreteTopology S.centers := by
-  simp_rw [discreteTopology_iff_isOpen_singleton, Metric.isOpen_iff]
-  intro ⟨u, hu⟩ ⟨v, hv⟩ huv
-  simp_rw [Set.subset_singleton_iff, mem_ball, Subtype.forall, Subtype.mk.injEq]
-  rw [Set.mem_singleton_iff, Subtype.mk.injEq] at huv
-  subst huv
-  use S.separation, S.separation_pos
-  intro a ha h_dist
-  contrapose! h_dist
-  exact S.centers_dist <| Subtype.coe_ne_coe.mp h_dist
+    DiscreteTopology S.centers :=
+  .of_forall_le_dist S.separation_pos S.centers_dist
 
 noncomputable instance PeriodicSpherePacking.addAction (S : PeriodicSpherePacking d) :
     AddAction S.lattice S.centers where
@@ -97,26 +87,17 @@ theorem PeriodicSpherePacking.addAction_vadd (S : PeriodicSpherePacking d)
       x +ᵥ y = ⟨x.val + y.val, S.lattice_action x.prop y.prop⟩ :=
   rfl
 
+/-- The union of open balls of radius `S.separation / 2` around the centers of a sphere packing. -/
 abbrev SpherePacking.balls (S : SpherePacking d) : Set (EuclideanSpace ℝ (Fin d)) :=
   ⋃ x : S.centers, ball (x : EuclideanSpace ℝ (Fin d)) (S.separation / 2)
 
+/-- The finite density of a sphere packing inside the ball of radius `R` centered at the origin. -/
 noncomputable def SpherePacking.finiteDensity (S : SpherePacking d) (R : ℝ) : ℝ≥0∞ :=
   volume (S.balls ∩ ball 0 R) / (volume (ball (0 : EuclideanSpace ℝ (Fin d)) R))
 
+/-- The density of a sphere packing, defined as the `limsup` of its finite densities. -/
 noncomputable def SpherePacking.density (S : SpherePacking d) : ℝ≥0∞ :=
   limsup S.finiteDensity atTop
-
--- Here is one way to choose a basis, but I think for our purpose we can just supply one.
--- /-- Returns a ℝ-basis of ℝ^d such that the its ℤ-span is `S.lattice`. -/
--- noncomputable def PeriodicSpherePacking.lattice_basis (S : PeriodicSpherePacking d) :
--- Basis (Module.Free.ChooseBasisIndex ℤ S.lattice) ℝ (EuclideanSpace ℝ (Fin d)) :=
--- ((ZLattice.module_free ℝ S.lattice).chooseBasis).ofZLatticeBasis _ _
-
--- Rendered unnecessary by bump to 4.13.0-rc3
--- theorem Submodule.toIntSubmodule_eq_iff_eq_toAddSubgroup {G : Type*} [AddCommGroup G]
--- {A : AddSubgroup G} {B : Submodule ℤ G} :
--- AddSubgroup.toIntSubmodule A = B ↔ A = B.toAddSubgroup := by
--- constructor <;> rintro rfl <;> rfl
 
 theorem PeriodicSpherePacking.basis_Z_span
     (S : PeriodicSpherePacking d) {ι : Type*} (b : Basis ι ℤ S.lattice) :
@@ -139,8 +120,7 @@ section Scaling
 variable {d : ℕ}
 open Real
 
--- Unfortunately I can't define a SMul ℝ (SpherePacking d) because we require 0 < c
--- Perhaps we can define a monoid action instead - Sid
+/-- Scale a sphere packing by a positive real factor `c`. -/
 def SpherePacking.scale (S : SpherePacking d) {c : ℝ} (hc : 0 < c) : SpherePacking d where
   centers := c • S.centers
   separation := c * S.separation
@@ -156,14 +136,19 @@ def SpherePacking.scale (S : SpherePacking d) {c : ℝ} (hc : 0 < c) : SpherePac
     have := S.centers_dist this
     exact (mul_le_mul_iff_right₀ hc).mpr this
 
-lemma scale_lattice_discrete (S : PeriodicSpherePacking d) {c : ℝ} (hc : 0 < c) :
+namespace PeriodicSpherePacking
+
+lemma scale_lattice_discrete_aux (S : PeriodicSpherePacking d) {c : ℝ} (hc : 0 < c) :
     DiscreteTopology ↥(c • S.lattice) := by
   letI : DiscreteTopology S.lattice := S.lattice_discrete
-  change DiscreteTopology ↥((Homeomorph.smulOfNeZero c hc.ne.symm) '' (S.lattice :
-    Set (EuclideanSpace ℝ (Fin d))))
+  change DiscreteTopology
+    ↥((Homeomorph.smulOfNeZero c hc.ne.symm) '' (S.lattice : Set (EuclideanSpace ℝ (Fin d))))
   exact (Homeomorph.image (Homeomorph.smulOfNeZero c hc.ne.symm)
     (S.lattice : Set (EuclideanSpace ℝ (Fin d)))).discreteTopology
 
+end PeriodicSpherePacking
+
+/-- Scale a periodic sphere packing by a positive real factor `c`. -/
 noncomputable def PeriodicSpherePacking.scale (S : PeriodicSpherePacking d) {c : ℝ} (hc : 0 < c) :
   PeriodicSpherePacking d := {
   S.toSpherePacking.scale hc with
@@ -173,9 +158,10 @@ noncomputable def PeriodicSpherePacking.scale (S : PeriodicSpherePacking d) {c :
     obtain ⟨x, hx, rfl⟩ := hx
     obtain ⟨y, hy, rfl⟩ := hy
     use x + y, S.lattice_action hx hy, smul_add ..
-  lattice_discrete := scale_lattice_discrete S hc
+  lattice_discrete := PeriodicSpherePacking.scale_lattice_discrete_aux S hc
   lattice_isZLattice := by
-    letI : DiscreteTopology ↥(c • S.lattice) := scale_lattice_discrete S hc
+    letI : DiscreteTopology ↥(c • S.lattice) :=
+      PeriodicSpherePacking.scale_lattice_discrete_aux S hc
     refine ⟨?_⟩
     rw [← S.lattice_isZLattice.span_top]
     ext v
@@ -199,8 +185,7 @@ noncomputable def PeriodicSpherePacking.scale (S : PeriodicSpherePacking d) {c :
 lemma PeriodicSpherePacking.scale_toSpherePacking
     {S : PeriodicSpherePacking d} {c : ℝ} (hc : 0 < c) :
     (S.scale hc).toSpherePacking = S.toSpherePacking.scale hc := by
-  cases S
-  rfl
+  cases S; rfl
 
 lemma SpherePacking.scale_balls {S : SpherePacking d} {c : ℝ} (hc : 0 < c) :
     (S.scale hc).balls = c • S.balls := by
@@ -230,8 +215,8 @@ lemma SpherePacking.scale_balls {S : SpherePacking d} {c : ℝ} (hc : 0 < c) :
     gcongr
 
 lemma PeriodicSpherePacking.scale_balls {S : PeriodicSpherePacking d} {c : ℝ} (hc : 0 < c) :
-    (S.scale hc).balls = c • S.balls := by
-  exact S.scale_toSpherePacking hc ▸ SpherePacking.scale_balls (S := S.toSpherePacking) hc
+    (S.scale hc).balls = c • S.balls :=
+  S.scale_toSpherePacking hc ▸ SpherePacking.scale_balls (S := S.toSpherePacking) hc
 
 end Scaling
 
@@ -239,13 +224,12 @@ noncomputable section Density
 
 variable {d : ℕ} (S : SpherePacking d)
 
-/-- The `PeriodicSpherePackingConstant` in dimension d is the supremum of the density of all
-periodic packings. See also `<TODO>` for specifying the separation radius of the packings. -/
+/-- The `PeriodicSpherePackingConstant` in dimension `d` is the supremum of the density of all
+periodic packings. -/
 def PeriodicSpherePackingConstant (d : ℕ) : ℝ≥0∞ :=
   ⨆ S : PeriodicSpherePacking d, S.density
 
-/-- The `SpherePackingConstant` in dimension d is the supremum of the density of all packings. See
-also `<TODO>` for specifying the separation radius of the packings. -/
+/-- The `SpherePackingConstant` in dimension `d` is the supremum of the density of all packings. -/
 def SpherePackingConstant (d : ℕ) : ℝ≥0∞ :=
   ⨆ S : SpherePacking d, S.density
 
@@ -256,22 +240,16 @@ namespace SpherePacking
 
 lemma finiteDensity_le_one {d : ℕ} (S : SpherePacking d) (R : ℝ) : S.finiteDensity R ≤ 1 := by
   rw [finiteDensity]
-  apply ENNReal.div_le_of_le_mul
-  rw [one_mul]
-  exact volume.mono Set.inter_subset_right
+  exact ENNReal.div_le_of_le_mul <| by simpa using volume.mono Set.inter_subset_right
 
 lemma density_le_one {d : ℕ} (S : SpherePacking d) : S.density ≤ 1 := by
   rw [density]
-  apply limsup_le_iSup.trans
-  apply iSup_le
-  intro
-  exact finiteDensity_le_one _ _
+  exact limsup_le_iSup.trans <| iSup_le fun _ ↦ finiteDensity_le_one _ _
 
 /-- Finite density of a scaled packing. -/
 @[simp]
 lemma scale_finiteDensity {d : ℕ} (_ : 0 < d) (S : SpherePacking d) {c : ℝ} (hc : 0 < c) (R : ℝ) :
     (S.scale hc).finiteDensity (c * R) = S.finiteDensity R := by
-  -- haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd -- (_ : 0 < d) unnecessary
   have : ball (0 : EuclideanSpace ℝ (Fin d)) (c * R) = c • ball 0 R := by
     convert (_root_.smul_ball hc.ne.symm (0 : EuclideanSpace ℝ (Fin d)) R).symm
     · exact Eq.symm (DistribMulAction.smul_zero c)
@@ -294,7 +272,6 @@ lemma scale_density {d : ℕ} (hd : 0 < d) (S : SpherePacking d) {c : ℝ} (hc :
     (S.scale hc).density = S.density := by
   simp only [density, limsup, limsSup, eventually_map, eventually_atTop]
   apply le_antisymm
-  -- The following are almost identical. Can we condense the proof?
   · simp only [sInf_le_iff, le_sInf_iff, Set.mem_setOf_eq, lowerBounds]
     intro x hx y hy
     rcases hx with ⟨a, ha⟩
@@ -331,30 +308,17 @@ theorem constant_eq_constant_normalized {d : ℕ} (hd : 0 < d) :
 end SpherePacking
 end DensityLemmas
 
-section PeriodicDensity
-
-/- In this subsection, we prove that PeriodicDensity is equivalent to Density. This would allow us
-to compute density of a periodic sphere packing easier. -/
-
--- TODO: state the theorem lol (first need to define PeriodicDensity in PeriodicPacking.lean
--- Probably also using dot notation under PeriodicSpherePacking namespace
-
-end PeriodicDensity
-
 section BasicResults
 open scoped ENNReal
 open EuclideanSpace
 
 variable {d : ℕ} (S : SpherePacking d)
 
-/- In this section we establish basic results about FiniteDensity and Density of different types of
-packings. -/
-
 lemma biUnion_inter_balls_subset_biUnion_balls_inter
     (X : Set (EuclideanSpace ℝ (Fin d))) (r R : ℝ) :
     ⋃ x ∈ X ∩ ball 0 R, ball x r ⊆ (⋃ x ∈ X, ball x r) ∩ ball 0 (R + r) := by
   intro x hx
-  simp at hx ⊢
+  simp only [Set.mem_inter_iff, mem_ball, dist_zero_right, Set.mem_iUnion, exists_prop] at hx ⊢
   obtain ⟨y, ⟨hy₁, hy₂⟩⟩ := hx
   use ⟨y, ⟨hy₁.left, hy₂⟩⟩
   apply lt_of_le_of_lt <| norm_le_norm_add_norm_sub' x y
@@ -364,7 +328,7 @@ lemma biUnion_balls_inter_subset_biUnion_inter_balls
     (X : Set (EuclideanSpace ℝ (Fin d))) (r R : ℝ) :
     (⋃ x ∈ X, ball x r) ∩ ball 0 (R - r) ⊆ ⋃ x ∈ X ∩ ball 0 R, ball x r := by
   intro x hx
-  simp at hx ⊢
+  simp only [Set.mem_inter_iff, mem_ball, dist_zero_right, Set.mem_iUnion, exists_prop] at hx ⊢
   obtain ⟨⟨y, ⟨hy₁, hy₂⟩⟩, hx⟩ := hx
   use y, ⟨hy₁, ?_⟩, hy₂
   calc
@@ -417,7 +381,7 @@ theorem SpherePacking.inter_ball_encard_ge (hd : 0 < d) (R : ℝ) :
   · exact (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
   · exact (volume_ball_lt_top _).ne
 
-theorem aux6 (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
+theorem SpherePacking.centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
   apply Set.encard_lt_top_iff.mp
   by_cases hd : 0 < d
   · haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
@@ -433,8 +397,7 @@ theorem aux6 (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
       rw [← Set.Finite.cast_ncard_eq (Set.toFinite _), Nat.cast_le_one]
       exact Set.ncard_le_one_of_subsingleton _
     subst hd
-    apply lt_of_le_of_lt (Set.encard_mono inf_le_right)
-    apply lt_of_le_of_lt this (by decide)
+    exact (Set.encard_mono inf_le_right).trans_lt (this.trans_lt (by decide))
 
 theorem SpherePacking.finiteDensity_ge (hd : 0 < d) (R : ℝ) :
     S.finiteDensity R

--- a/SpherePacking/Basic/SpherePacking.lean
+++ b/SpherePacking/Basic/SpherePacking.lean
@@ -54,7 +54,7 @@ theorem SpherePacking.centers_dist' (S : SpherePacking d) (x y : EuclideanSpace 
     (hx : x ∈ S.centers) (hy : y ∈ S.centers) (hxy : x ≠ y) :
     S.separation ≤ dist x y := by
   have := S.centers_dist (Subtype.coe_ne_coe.mp hxy : (⟨x, hx⟩ : S.centers) ≠ ⟨y, hy⟩)
-  simpa using this
+  exact this
 
 instance PeriodicSpherePacking.instLatticeDiscrete (S : PeriodicSpherePacking d) :
     DiscreteTopology S.lattice :=
@@ -117,7 +117,9 @@ theorem PeriodicSpherePacking.basis_R_span
 end Definitions
 
 section Scaling
+
 variable {d : ℕ}
+
 open Real
 
 /-- Scale a sphere packing by a positive real factor `c`. -/
@@ -236,6 +238,7 @@ def SpherePackingConstant (d : ℕ) : ℝ≥0∞ :=
 end Density
 
 section DensityLemmas
+
 namespace SpherePacking
 
 lemma finiteDensity_le_one {d : ℕ} (S : SpherePacking d) (R : ℝ) : S.finiteDensity R ≤ 1 := by
@@ -306,10 +309,13 @@ theorem constant_eq_constant_normalized {d : ℕ} (hd : 0 < d) :
     exact le_iSup density S
 
 end SpherePacking
+
 end DensityLemmas
 
 section BasicResults
+
 open scoped ENNReal
+
 open EuclideanSpace
 
 variable {d : ℕ} (S : SpherePacking d)

--- a/SpherePacking/Basic/SpherePacking.lean
+++ b/SpherePacking/Basic/SpherePacking.lean
@@ -6,14 +6,9 @@ Authors: Sidharth Hariharan, Gareth Ma
 module
 
 public import Mathlib.Algebra.Module.ZLattice.Basic
-public import Mathlib.Data.Real.StarOrdered
+public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
+public import Mathlib.Data.ENat.Lattice
 public import Mathlib.Order.CompletePartialOrder
-public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
-public import Mathlib.Topology.Metrizable.Basic
-public import Mathlib.Topology.Compactness.Lindelof
-public import Mathlib.Topology.EMetricSpace.Paracompact
-
-public import SpherePacking.ForMathlib.VolumeOfBalls
 
 @[expose] public section
 
@@ -400,7 +395,7 @@ theorem SpherePacking.volume_iUnion_balls_eq_tsum
 
 /-- This gives an upper bound on the number of points in the sphere packing X with norm less than R.
 -/
-theorem SpherePacking.inter_ball_encard_le (hd : 0 < d) (R : ℝ) :
+theorem SpherePacking.inter_ball_encard_le (R : ℝ) :
     (S.centers ∩ ball 0 R).encard ≤
       volume (S.balls ∩ ball 0 (R + S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2)) := by
@@ -409,14 +404,13 @@ theorem SpherePacking.inter_ball_encard_le (hd : 0 < d) (R : ℝ) :
   change volume _ ≤ volume _ at h
   simp_rw [Set.biUnion_eq_iUnion, S.volume_iUnion_balls_eq_tsum R (le_refl _),
     Measure.addHaar_ball_center, ENNReal.tsum_set_const] at h
-  haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
   rwa [← ENNReal.le_div_iff_mul_le] at h <;> left
-  · exact (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
-  · exact (volume_ball_lt_top _).ne
+  · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
+  · exact measure_ball_lt_top.ne
 
 /-- This gives an upper bound on the number of points in the sphere packing X with norm less than R.
 -/
-theorem SpherePacking.inter_ball_encard_ge (hd : 0 < d) (R : ℝ) :
+theorem SpherePacking.inter_ball_encard_ge (R : ℝ) :
     (S.centers ∩ ball 0 R).encard ≥
       volume (S.balls ∩ ball 0 (R - S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2)) := by
@@ -425,22 +419,22 @@ theorem SpherePacking.inter_ball_encard_ge (hd : 0 < d) (R : ℝ) :
   change volume _ ≤ volume _ at h
   simp_rw [Set.biUnion_eq_iUnion, S.volume_iUnion_balls_eq_tsum _ (le_refl _),
     Measure.addHaar_ball_center, ENNReal.tsum_set_const] at h
-  haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
   rwa [← ENNReal.div_le_iff_le_mul] at h <;> left
-  · exact (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
-  · exact (volume_ball_lt_top _).ne
+  · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
+  · exact measure_ball_lt_top.ne
 
 theorem SpherePacking.centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
   apply Set.encard_lt_top_iff.mp
   by_cases hd : 0 < d
   · haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
     apply ENat.toENNReal_lt.mp
-    apply lt_of_le_of_lt (S.inter_ball_encard_le hd R)
-    apply ENNReal.div_lt_top ?_ (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
+    apply lt_of_le_of_lt (S.inter_ball_encard_le R)
+    apply ENNReal.div_lt_top ?_ (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
     rw [← lt_top_iff_ne_top]
     calc
-      _ ≤ volume (ball 0 (R + S.separation / 2)) := volume.mono Set.inter_subset_right
-      _ < ⊤ := EuclideanSpace.volume_ball_lt_top _
+      _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + S.separation / 2)) :=
+        volume.mono Set.inter_subset_right
+      _ < ⊤ := measure_ball_lt_top
   · rw [not_lt, nonpos_iff_eq_zero] at hd
     have : (ball (0 : EuclideanSpace ℝ (Fin 0)) R).encard ≤ 1 := by
       rw [← Set.Finite.cast_ncard_eq (Set.toFinite _), Nat.cast_le_one]
@@ -448,32 +442,30 @@ theorem SpherePacking.centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers
     subst hd
     exact (Set.encard_mono inf_le_right).trans_lt (this.trans_lt (by decide))
 
-theorem SpherePacking.finiteDensity_ge (hd : 0 < d) (R : ℝ) :
+theorem SpherePacking.finiteDensity_ge (R : ℝ) :
     S.finiteDensity R
       ≥ (S.centers ∩ ball 0 (R - S.separation / 2)).encard
         * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
           / volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) := by
-  haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
   rw [finiteDensity, balls]
   apply ENNReal.div_le_div_right
   rw [← ENNReal.le_div_iff_mul_le] <;> try left
-  · have := S.inter_ball_encard_le hd (R - S.separation / 2)
+  · have := S.inter_ball_encard_le (R - S.separation / 2)
     rwa [sub_add_cancel] at this
-  · exact (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
-  · exact (volume_ball_lt_top _).ne
+  · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
+  · exact measure_ball_lt_top.ne
 
-theorem SpherePacking.finiteDensity_le (hd : 0 < d) (R : ℝ) :
+theorem SpherePacking.finiteDensity_le (R : ℝ) :
     S.finiteDensity R
       ≤ (S.centers ∩ ball 0 (R + S.separation / 2)).encard
         * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
           / volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) := by
-  haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
   rw [finiteDensity, balls]
   apply ENNReal.div_le_div_right
   rw [← ENNReal.div_le_iff_le_mul] <;> try left
-  · have := S.inter_ball_encard_ge hd (R + S.separation / 2)
+  · have := S.inter_ball_encard_ge (R + S.separation / 2)
     rwa [add_sub_cancel_right] at this
-  · exact (volume_ball_pos _ (by linarith [S.separation_pos])).ne.symm
-  · exact (volume_ball_lt_top _).ne
+  · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
+  · exact measure_ball_lt_top.ne
 
 end BasicResults

--- a/SpherePacking/Basic/SpherePacking.lean
+++ b/SpherePacking/Basic/SpherePacking.lean
@@ -18,16 +18,59 @@ public import SpherePacking.ForMathlib.VolumeOfBalls
 @[expose] public section
 
 /-!
-# Density of Sphere Packings
+# Sphere Packings
 
-Let `X ⊆ ℝ^d` be a set of points such that distinct points are at least distance `r` apart. Putting
-a ball of radius `r / 2` around each point, we have a configuration of *sphere packing*. We call `X`
-the sphere packing centers.
+A *sphere packing* in `ℝᵈ` is a set of *centers* `X ⊆ ℝᵈ` with a positive `separation` such
+that distinct centers are at distance at least `separation`. Placing an open ball of radius
+`separation / 2` around each center yields the packing's (disjoint) balls. In this file, we define
+sphere packings and periodic sphere packings in `ℝᵈ` and the notions of sphere packing density and
+the sphere packing constant and prove basic facts about these definitions.
 
-We also define the *density* of the configuration.
+## Main definitions
+
+* `SpherePacking d`: a sphere packing in dimension `d`, with `centers` and `separation`.
+* `PeriodicSpherePacking d`: a packing whose centers are invariant under a `ℤ`-lattice.
+* `SpherePacking.balls`: union of open balls of radius `separation / 2` around the centers.
+* `SpherePacking.finiteDensity S R`: fraction of `ball 0 R` covered by `S.balls`.
+* `SpherePacking.density`: the `limsup` of `finiteDensity` as `R → ∞`.
+* `SpherePackingConstant d`, `PeriodicSpherePackingConstant d`: supremum of densities.
+* `SpherePacking.scale`: scale a (periodic) packing by a positive real factor.
+
+## Main results
+
+* `SpherePacking.density_le_one`: every packing has density at most `1`.
+* `SpherePacking.scale_density`: density is invariant under scaling.
+* `SpherePacking.constant_eq_constant_normalized`: for `0 < d`, attained at `separation = 1`.
+* `SpherePacking.finiteDensity_le`/`finiteDensity_ge`: two-sided bounds via center counts.
+* `SpherePacking.centers_inter_ball_finite`: each ball contains only finitely many centers.
+
+## Implementation notes
+
+`PeriodicSpherePacking` bundles `DiscreteTopology`/`IsZLattice` on its lattice; the induced
+`AddAction S.lattice S.centers` is `noncomputable` due to subtype repackaging.
+
+## Scope for Further Work
+
+While sphere packings can be defined in arbitrary metric spaces, we consciously focus on Euclidean
+spaces here because we are more interested in the theory of sphere packing densities than we are in
+more general notions, and densities can be quite poorly behaved in other settings. We do believe
+that it may be valuable to develop the theory in more general settings in the future, and invite
+contributions in that directions that are supported by formalisations of their applications.
+
+## Reference
+
+These definitions were developed as part of the Sphere Packing Project, which aims to formalise the
+solution to the sphere packing problem in dimension 8 by Viazovska. The primary references for this
+file are:
+* C. Birkbeck, S. Hariharan, S. Lee, G. Ma, B. Mehta, and M. Viazovska. Sphere Packing in Lean -
+  Project Blueprint, Sections 1 and 2.
+  https://thefundamentaltheor3m.github.io/Sphere-Packing-Lean/blueprint/index.html.
+* M. S. Viazovska. The sphere packing problem in dimension 8. Annals of Mathematics,
+  185(3):991–1015, 2017.
 -/
 
 open BigOperators MeasureTheory Metric Pointwise Filter Module
+
 open scoped ENNReal
 
 section Definitions

--- a/SpherePacking/Basic/SpherePacking.lean
+++ b/SpherePacking/Basic/SpherePacking.lean
@@ -70,44 +70,62 @@ open scoped ENNReal
 
 section Definitions
 
-/-- A sphere packing in dimension `d` is a set of points in `ℝ^d` (the *centers*) such that any two
-distinct points are at distance at least `separation` apart. -/
-structure SpherePacking (d : ℕ) where
-  centers : Set (EuclideanSpace ℝ (Fin d))
+namespace Metric
+
+/-- A sphere packing in a metric space `X` is a set of points in `X` (the *centers*) such that any
+two distinct points are at distance at least `separation` apart. -/
+structure SpherePacking (X : Type*) [MetricSpace X] where
+  centers : Set X
   separation : ℝ
   separation_pos : 0 < separation := by positivity
   centers_dist : Pairwise (separation ≤ dist · · : centers → centers → Prop)
 
-/-- A periodic sphere packing in dimension `d` is a sphere packing whose centers are invariant
+/-- A periodic sphere packing in a normed  a sphere packing whose centers are invariant
 under translation by a `ℤ`-lattice in `ℝ^d`. -/
-structure PeriodicSpherePacking (d : ℕ) extends SpherePacking d where
-  lattice : Submodule ℤ (EuclideanSpace ℝ (Fin d))
+structure PeriodicSpherePacking (K E : Type*) [NormedField K] [NormedAddCommGroup E]
+    [NormedSpace K E] extends SpherePacking E where
+  lattice : Submodule ℤ E
   lattice_action : ∀ ⦃x y⦄, x ∈ lattice → y ∈ centers → x + y ∈ centers
   lattice_discrete : DiscreteTopology lattice := by infer_instance
-  lattice_isZLattice : IsZLattice ℝ lattice := by infer_instance
+  lattice_isZLattice : IsZLattice K lattice := by infer_instance
 
-variable {d : ℕ}
+end Metric
 
-theorem SpherePacking.centers_dist' (S : SpherePacking d) (x y : EuclideanSpace ℝ (Fin d))
-    (hx : x ∈ S.centers) (hy : y ∈ S.centers) (hxy : x ≠ y) :
+namespace EuclideanSpace
+
+/-- A sphere packing in dimension `d` is a sphere packing in the metric space
+`EuclideanSpace ℝ (Fin d)`. -/
+abbrev SpherePacking (d : ℕ) := Metric.SpherePacking (EuclideanSpace ℝ (Fin d))
+
+/-- A sphere packing in dimension `d` is a sphere packing in the metric space
+`EuclideanSpace ℝ (Fin d)`. -/
+abbrev PeriodicSpherePacking (d : ℕ) := Metric.PeriodicSpherePacking ℝ (EuclideanSpace ℝ (Fin d))
+
+end EuclideanSpace
+
+theorem Metric.SpherePacking.centers_dist' {X : Type*} [MetricSpace X] (S : SpherePacking X)
+    {x y : X} (hx : x ∈ S.centers) (hy : y ∈ S.centers) (hxy : x ≠ y) :
     S.separation ≤ dist x y := by
   have := S.centers_dist (Subtype.coe_ne_coe.mp hxy : (⟨x, hx⟩ : S.centers) ≠ ⟨y, hy⟩)
   exact this
 
-instance PeriodicSpherePacking.instLatticeDiscrete (S : PeriodicSpherePacking d) :
-    DiscreteTopology S.lattice :=
+instance Metric.PeriodicSpherePacking.instLatticeDiscrete
+    {K E : Type*} [NormedField K] [NormedAddCommGroup E] [NormedSpace K E]
+    (S : PeriodicSpherePacking K E) : DiscreteTopology S.lattice :=
   S.lattice_discrete
 
-instance PeriodicSpherePacking.instIsZLattice (S : PeriodicSpherePacking d) :
-    IsZLattice ℝ S.lattice :=
+instance Metric.PeriodicSpherePacking.instIsZLattice
+    {K E : Type*} [NormedField K] [NormedAddCommGroup E] [NormedSpace K E]
+    (S : PeriodicSpherePacking K E) : IsZLattice K S.lattice :=
   S.lattice_isZLattice
 
-instance SpherePacking.instCentersDiscrete (S : SpherePacking d) :
-    DiscreteTopology S.centers :=
+instance Metric.SpherePacking.instCentersDiscrete
+    {X : Type*} [MetricSpace X] (S : SpherePacking X) : DiscreteTopology S.centers :=
   .of_forall_le_dist S.separation_pos S.centers_dist
 
-noncomputable instance PeriodicSpherePacking.addAction (S : PeriodicSpherePacking d) :
-    AddAction S.lattice S.centers where
+noncomputable instance Metric.PeriodicSpherePacking.addAction
+    {K E : Type*} [NormedField K] [NormedAddCommGroup E] [NormedSpace K E]
+    (S : PeriodicSpherePacking K E) : AddAction S.lattice S.centers where
   vadd x y := ⟨↑x + ↑y, S.lattice_action x.prop y.prop⟩
   zero_vadd := by
     intro ⟨v, hv⟩
@@ -118,90 +136,101 @@ noncomputable instance PeriodicSpherePacking.addAction (S : PeriodicSpherePackin
     apply Subtype.ext
     exact add_assoc u v p
 
-alias PeriodicSpherePacking.instAddAction := PeriodicSpherePacking.addAction
+alias Metric.PeriodicSpherePacking.instAddAction := Metric.PeriodicSpherePacking.addAction
 
-theorem PeriodicSpherePacking.addAction_vadd (S : PeriodicSpherePacking d)
-    {x : S.lattice} {y : S.centers} :
+theorem Metric.PeriodicSpherePacking.addAction_vadd
+    {K E : Type*} [NormedField K] [NormedAddCommGroup E] [NormedSpace K E]
+    (S : PeriodicSpherePacking K E) {x : S.lattice} {y : S.centers} :
       x +ᵥ y = ⟨x.val + y.val, S.lattice_action x.prop y.prop⟩ :=
   rfl
 
 /-- The union of open balls of radius `S.separation / 2` around the centers of a sphere packing. -/
-abbrev SpherePacking.balls (S : SpherePacking d) : Set (EuclideanSpace ℝ (Fin d)) :=
-  ⋃ x : S.centers, ball (x : EuclideanSpace ℝ (Fin d)) (S.separation / 2)
+abbrev Metric.SpherePacking.balls {X : Type*} [MetricSpace X] (S : SpherePacking X) : Set X :=
+  ⋃ x : S.centers, ball (x : X) (S.separation / 2)
 
 /-- The finite density of a sphere packing inside the ball of radius `R` centered at the origin. -/
-noncomputable def SpherePacking.finiteDensity (S : SpherePacking d) (R : ℝ) : ℝ≥0∞ :=
+noncomputable def Metric.SpherePacking.finiteDensity {d : ℕ}
+    (S : EuclideanSpace.SpherePacking d) (R : ℝ) : ℝ≥0∞ :=
   volume (S.balls ∩ ball 0 R) / (volume (ball (0 : EuclideanSpace ℝ (Fin d)) R))
 
 /-- The density of a sphere packing, defined as the `limsup` of its finite densities. -/
-noncomputable def SpherePacking.density (S : SpherePacking d) : ℝ≥0∞ :=
+noncomputable def Metric.SpherePacking.density {d : ℕ}
+    (S : EuclideanSpace.SpherePacking d) : ℝ≥0∞ :=
   limsup S.finiteDensity atTop
 
-theorem PeriodicSpherePacking.basis_Z_span
-    (S : PeriodicSpherePacking d) {ι : Type*} (b : Basis ι ℤ S.lattice) :
-    Submodule.span ℤ (Set.range (b.ofZLatticeBasis ℝ _)) = S.lattice :=
-  Basis.ofZLatticeBasis_span ℝ S.lattice b
+theorem Metric.PeriodicSpherePacking.basis_Z_span
+    {K E : Type*} [NormedField K] [LinearOrder K] [IsStrictOrderedRing K] [HasSolidNorm K]
+    [FloorRing K] [NormedAddCommGroup E] [NormedSpace K E] [FiniteDimensional K E] [ProperSpace E]
+    (S : PeriodicSpherePacking K E) {ι : Type*} (b : Basis ι ℤ S.lattice) :
+    Submodule.span ℤ (Set.range (b.ofZLatticeBasis K _)) = S.lattice :=
+  Basis.ofZLatticeBasis_span K S.lattice b
 
-theorem PeriodicSpherePacking.mem_basis_Z_span
-    (S : PeriodicSpherePacking d) {ι : Type*} (b : Basis ι ℤ S.lattice) (v) :
-    v ∈ Submodule.span ℤ (Set.range (b.ofZLatticeBasis ℝ _)) ↔ v ∈ S.lattice :=
+theorem Metric.PeriodicSpherePacking.mem_basis_Z_span
+    {K E : Type*} [NormedField K] [LinearOrder K] [IsStrictOrderedRing K] [HasSolidNorm K]
+    [FloorRing K] [NormedAddCommGroup E] [NormedSpace K E] [FiniteDimensional K E] [ProperSpace E]
+    (S : PeriodicSpherePacking K E) {ι : Type*} (b : Basis ι ℤ S.lattice) (v) :
+    v ∈ Submodule.span ℤ (Set.range (b.ofZLatticeBasis K _)) ↔ v ∈ S.lattice :=
   SetLike.ext_iff.mp (S.basis_Z_span b) v
 
-theorem PeriodicSpherePacking.basis_R_span
-    (S : PeriodicSpherePacking d) {ι : Type*} (b : Basis ι ℤ S.lattice) :
-    Submodule.span ℝ (Set.range (b.ofZLatticeBasis ℝ _)) = ⊤ :=
+theorem Metric.PeriodicSpherePacking.basis_K_span
+    {K E : Type*} [NormedField K] [LinearOrder K] [IsStrictOrderedRing K] [HasSolidNorm K]
+    [FloorRing K] [NormedAddCommGroup E] [NormedSpace K E] [FiniteDimensional K E] [ProperSpace E]
+    (S : PeriodicSpherePacking K E) {ι : Type*} (b : Basis ι ℤ S.lattice) :
+    Submodule.span K (Set.range (b.ofZLatticeBasis K _)) = ⊤ :=
   Basis.span_eq _
 
 end Definitions
 
 section Scaling
 
-variable {d : ℕ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 open Real
 
 /-- Scale a sphere packing by a positive real factor `c`. -/
-def SpherePacking.scale (S : SpherePacking d) {c : ℝ} (hc : 0 < c) : SpherePacking d where
+def Metric.SpherePacking.scale (S : SpherePacking E) {c : ℝ} (hc : 0 < c) : SpherePacking E where
   centers := c • S.centers
   separation := c * S.separation
   separation_pos := mul_pos hc S.separation_pos
-  centers_dist := fun ⟨x, hx⟩ ⟨y, hy⟩ _ ↦ by
-    change c * S.separation ≤ ‖x - y‖
+  centers_dist := fun ⟨x, hx⟩ ⟨y, hy⟩ hxy ↦ by
+    change c * S.separation ≤ dist x y
+    rw [dist_eq_norm]
     obtain ⟨x', ⟨hx', rfl⟩⟩ := Set.mem_smul_set.mp hx
     obtain ⟨y', ⟨hy', rfl⟩⟩ := Set.mem_smul_set.mp hy
     rw [← smul_sub, norm_smul, norm_eq_abs, abs_eq_self.mpr hc.le]
     rw [ne_eq, Subtype.mk.injEq] at *
-    have : x' ≠ y' := by rintro rfl; tauto
-    have : (⟨x', hx'⟩ : S.centers) ≠ ⟨y', hy'⟩ := by simp [this]
-    have := S.centers_dist this
-    exact (mul_le_mul_iff_right₀ hc).mpr this
+    have hxy' : x' ≠ y' := by rintro rfl; tauto
+    have : (⟨x', hx'⟩ : S.centers) ≠ ⟨y', hy'⟩ := by simp [hxy']
+    have hd := S.centers_dist' hx' hy' hxy'
+    rw [dist_eq_norm] at hd
+    exact (mul_le_mul_iff_right₀ hc).mpr hd
 
-namespace PeriodicSpherePacking
+namespace Metric.PeriodicSpherePacking
 
-lemma scale_lattice_discrete_aux (S : PeriodicSpherePacking d) {c : ℝ} (hc : 0 < c) :
+lemma scale_lattice_discrete_aux (S : PeriodicSpherePacking ℝ E) {c : ℝ} (hc : 0 < c) :
     DiscreteTopology ↥(c • S.lattice) := by
   letI : DiscreteTopology S.lattice := S.lattice_discrete
   change DiscreteTopology
-    ↥((Homeomorph.smulOfNeZero c hc.ne.symm) '' (S.lattice : Set (EuclideanSpace ℝ (Fin d))))
+    ↥((Homeomorph.smulOfNeZero c hc.ne.symm) '' (S.lattice : Set E))
   exact (Homeomorph.image (Homeomorph.smulOfNeZero c hc.ne.symm)
-    (S.lattice : Set (EuclideanSpace ℝ (Fin d)))).discreteTopology
+    (S.lattice : Set E)).discreteTopology
 
-end PeriodicSpherePacking
+end Metric.PeriodicSpherePacking
 
 /-- Scale a periodic sphere packing by a positive real factor `c`. -/
-noncomputable def PeriodicSpherePacking.scale (S : PeriodicSpherePacking d) {c : ℝ} (hc : 0 < c) :
-  PeriodicSpherePacking d := {
+noncomputable def Metric.PeriodicSpherePacking.scale (S : PeriodicSpherePacking ℝ E)
+    {c : ℝ} (hc : 0 < c) : PeriodicSpherePacking ℝ E := {
   S.toSpherePacking.scale hc with
   lattice := c • S.lattice
   lattice_action := fun x y hx hy ↦ by
-    simp_all only [SpherePacking.scale, Set.mem_smul_set]
+    simp_all only [Metric.SpherePacking.scale, Set.mem_smul_set]
     obtain ⟨x, hx, rfl⟩ := hx
     obtain ⟨y, hy, rfl⟩ := hy
     use x + y, S.lattice_action hx hy, smul_add ..
-  lattice_discrete := PeriodicSpherePacking.scale_lattice_discrete_aux S hc
+  lattice_discrete := Metric.PeriodicSpherePacking.scale_lattice_discrete_aux S hc
   lattice_isZLattice := by
     letI : DiscreteTopology ↥(c • S.lattice) :=
-      PeriodicSpherePacking.scale_lattice_discrete_aux S hc
+      Metric.PeriodicSpherePacking.scale_lattice_discrete_aux S hc
     refine ⟨?_⟩
     rw [← S.lattice_isZLattice.span_top]
     ext v
@@ -222,12 +251,12 @@ noncomputable def PeriodicSpherePacking.scale (S : PeriodicSpherePacking d) {c :
         simpa [smul_smul, mul_inv_cancel₀ hc.ne.symm, one_smul]
 }
 
-lemma PeriodicSpherePacking.scale_toSpherePacking
-    {S : PeriodicSpherePacking d} {c : ℝ} (hc : 0 < c) :
+lemma Metric.PeriodicSpherePacking.scale_toSpherePacking
+    {S : PeriodicSpherePacking ℝ E} {c : ℝ} (hc : 0 < c) :
     (S.scale hc).toSpherePacking = S.toSpherePacking.scale hc := by
   cases S; rfl
 
-lemma SpherePacking.scale_balls {S : SpherePacking d} {c : ℝ} (hc : 0 < c) :
+lemma Metric.SpherePacking.scale_balls {S : SpherePacking E} {c : ℝ} (hc : 0 < c) :
     (S.scale hc).balls = c • S.balls := by
   ext x
   simp only [scale, Set.mem_iUnion, Set.iUnion_coe_set]
@@ -254,48 +283,47 @@ lemma SpherePacking.scale_balls {S : SpherePacking d} {c : ℝ} (hc : 0 < c) :
     rw [← smul_sub, norm_smul, Real.norm_eq_abs, abs_eq_self.mpr hc.le, mul_div_assoc]
     gcongr
 
-lemma PeriodicSpherePacking.scale_balls {S : PeriodicSpherePacking d} {c : ℝ} (hc : 0 < c) :
-    (S.scale hc).balls = c • S.balls :=
-  S.scale_toSpherePacking hc ▸ SpherePacking.scale_balls (S := S.toSpherePacking) hc
+lemma Metric.PeriodicSpherePacking.scale_balls {S : PeriodicSpherePacking ℝ E} {c : ℝ}
+    (hc : 0 < c) : (S.scale hc).balls = c • S.balls :=
+  S.scale_toSpherePacking hc ▸ Metric.SpherePacking.scale_balls (S := S.toSpherePacking) hc
 
 end Scaling
 
 noncomputable section Density
 
-variable {d : ℕ} (S : SpherePacking d)
-
 /-- The `PeriodicSpherePackingConstant` in dimension `d` is the supremum of the density of all
 periodic packings. -/
 def PeriodicSpherePackingConstant (d : ℕ) : ℝ≥0∞ :=
-  ⨆ S : PeriodicSpherePacking d, S.density
+  ⨆ S : EuclideanSpace.PeriodicSpherePacking d, S.toSpherePacking.density
 
 /-- The `SpherePackingConstant` in dimension `d` is the supremum of the density of all packings. -/
 def SpherePackingConstant (d : ℕ) : ℝ≥0∞ :=
-  ⨆ S : SpherePacking d, S.density
+  ⨆ S : EuclideanSpace.SpherePacking d, S.density
 
 end Density
 
 section DensityLemmas
 
-namespace SpherePacking
+namespace Metric.SpherePacking
 
-lemma finiteDensity_le_one {d : ℕ} (S : SpherePacking d) (R : ℝ) : S.finiteDensity R ≤ 1 := by
+lemma finiteDensity_le_one {d : ℕ} (S : EuclideanSpace.SpherePacking d) (R : ℝ) :
+    S.finiteDensity R ≤ 1 := by
   rw [finiteDensity]
   exact ENNReal.div_le_of_le_mul <| by simpa using volume.mono Set.inter_subset_right
 
-lemma density_le_one {d : ℕ} (S : SpherePacking d) : S.density ≤ 1 := by
+lemma density_le_one {d : ℕ} (S : EuclideanSpace.SpherePacking d) : S.density ≤ 1 := by
   rw [density]
   exact limsup_le_iSup.trans <| iSup_le fun _ ↦ finiteDensity_le_one _ _
 
 /-- Finite density of a scaled packing. -/
 @[simp]
-lemma scale_finiteDensity {d : ℕ} (_ : 0 < d) (S : SpherePacking d) {c : ℝ} (hc : 0 < c) (R : ℝ) :
-    (S.scale hc).finiteDensity (c * R) = S.finiteDensity R := by
+lemma scale_finiteDensity {d : ℕ} (_ : 0 < d) (S : EuclideanSpace.SpherePacking d) {c : ℝ}
+    (hc : 0 < c) (R : ℝ) : (S.scale hc).finiteDensity (c * R) = S.finiteDensity R := by
   have : ball (0 : EuclideanSpace ℝ (Fin d)) (c * R) = c • ball 0 R := by
     convert (_root_.smul_ball hc.ne.symm (0 : EuclideanSpace ℝ (Fin d)) R).symm
     · exact Eq.symm (DistribMulAction.smul_zero c)
     · rw [Real.norm_eq_abs, abs_eq_self.mpr hc.le]
-  rw [finiteDensity, scale_balls, this, ← Set.smul_set_inter₀ hc.ne.symm]
+  rw [finiteDensity, Metric.SpherePacking.scale_balls, this, ← Set.smul_set_inter₀ hc.ne.symm]
   repeat rw [Measure.addHaar_smul_of_nonneg _ hc.le]
   rw [ENNReal.mul_div_mul_left, finiteDensity]
   · rw [ne_eq, ENNReal.ofReal_eq_zero, not_le, finrank_euclideanSpace_fin]
@@ -303,14 +331,14 @@ lemma scale_finiteDensity {d : ℕ} (_ : 0 < d) (S : SpherePacking d) {c : ℝ} 
   · apply ENNReal.ofReal_ne_top
 
 @[simp]
-lemma scale_finiteDensity' {d : ℕ} (hd : 0 < d) (S : SpherePacking d) {c : ℝ} (hc : 0 < c) (R : ℝ) :
-    (S.scale hc).finiteDensity R = S.finiteDensity (R / c) := by
+lemma scale_finiteDensity' {d : ℕ} (hd : 0 < d) (S : EuclideanSpace.SpherePacking d) {c : ℝ}
+    (hc : 0 < c) (R : ℝ) : (S.scale hc).finiteDensity R = S.finiteDensity (R / c) := by
   rw [div_eq_mul_inv, ← scale_finiteDensity hd S hc, ← mul_assoc, mul_comm, ← mul_assoc,
     inv_mul_cancel₀ hc.ne.symm, one_mul]
 
 /-- Density of a scaled packing. -/
-lemma scale_density {d : ℕ} (hd : 0 < d) (S : SpherePacking d) {c : ℝ} (hc : 0 < c) :
-    (S.scale hc).density = S.density := by
+lemma scale_density {d : ℕ} (hd : 0 < d) (S : EuclideanSpace.SpherePacking d) {c : ℝ}
+    (hc : 0 < c) : (S.scale hc).density = S.density := by
   simp only [density, limsup, limsSup, eventually_map, eventually_atTop]
   apply le_antisymm
   · simp only [sInf_le_iff, le_sInf_iff, Set.mem_setOf_eq, lowerBounds]
@@ -333,20 +361,22 @@ lemma scale_density {d : ℕ} (hd : 0 < d) (S : SpherePacking d) {c : ℝ} (hc :
     exact (div_le_iff₀' hc).mp hb'
 
 theorem constant_eq_constant_normalized {d : ℕ} (hd : 0 < d) :
-    SpherePackingConstant d = ⨆ (S : SpherePacking d) (_ : S.separation = 1), S.density := by
+    SpherePackingConstant d =
+      ⨆ (S : EuclideanSpace.SpherePacking d) (_ : S.separation = 1), S.density := by
   rw [iSup_subtype', SpherePackingConstant]
   apply le_antisymm
   · apply iSup_le
     intro S
     have h := inv_mul_cancel₀ S.separation_pos.ne.symm
-    have := le_iSup (fun S : { S : SpherePacking d // S.separation = 1 } ↦ S.val.density)
+    have := le_iSup
+        (fun S : { S : EuclideanSpace.SpherePacking d // S.separation = 1 } ↦ S.val.density)
         ⟨S.scale (inv_pos.mpr S.separation_pos), h⟩
     simpa only [scale_density hd]
   · apply iSup_le
     intro ⟨S, _⟩
     exact le_iSup density S
 
-end SpherePacking
+end Metric.SpherePacking
 
 end DensityLemmas
 
@@ -356,9 +386,11 @@ open scoped ENNReal
 
 open EuclideanSpace
 
-variable {d : ℕ} (S : SpherePacking d)
+namespace Metric.SpherePacking
 
-lemma biUnion_inter_balls_subset_biUnion_balls_inter
+variable {d : ℕ} (S : EuclideanSpace.SpherePacking d)
+
+lemma _root_.biUnion_inter_balls_subset_biUnion_balls_inter
     (X : Set (EuclideanSpace ℝ (Fin d))) (r R : ℝ) :
     ⋃ x ∈ X ∩ ball 0 R, ball x r ⊆ (⋃ x ∈ X, ball x r) ∩ ball 0 (R + r) := by
   intro x hx
@@ -368,7 +400,7 @@ lemma biUnion_inter_balls_subset_biUnion_balls_inter
   apply lt_of_le_of_lt <| norm_le_norm_add_norm_sub' x y
   gcongr <;> tauto
 
-lemma biUnion_balls_inter_subset_biUnion_inter_balls
+lemma _root_.biUnion_balls_inter_subset_biUnion_inter_balls
     (X : Set (EuclideanSpace ℝ (Fin d))) (r R : ℝ) :
     (⋃ x ∈ X, ball x r) ∩ ball 0 (R - r) ⊆ ⋃ x ∈ X ∩ ball 0 R, ball x r := by
   intro x hx
@@ -381,7 +413,7 @@ lemma biUnion_balls_inter_subset_biUnion_inter_balls
     _ < R - r + r := by gcongr
     _ = R := by ring
 
-theorem SpherePacking.volume_iUnion_balls_eq_tsum
+theorem volume_iUnion_balls_eq_tsum
     (R : ℝ) {r' : ℝ} (hr' : r' ≤ S.separation / 2) :
     volume (⋃ x : ↑(S.centers ∩ ball 0 R), ball (x : EuclideanSpace ℝ (Fin d)) r')
       = ∑' x : ↑(S.centers ∩ ball 0 R), volume (ball (x : EuclideanSpace ℝ (Fin d)) r') := by
@@ -391,11 +423,11 @@ theorem SpherePacking.volume_iUnion_balls_eq_tsum
   intro ⟨x, hx⟩ ⟨y, hy⟩ h
   apply ball_disjoint_ball
   simp_rw [ne_eq, Subtype.mk.injEq] at h ⊢
-  linarith [S.centers_dist' x y hx.left hy.left h]
+  linarith [S.centers_dist' hx.left hy.left h]
 
 /-- This gives an upper bound on the number of points in the sphere packing X with norm less than R.
 -/
-theorem SpherePacking.inter_ball_encard_le (R : ℝ) :
+theorem inter_ball_encard_le (R : ℝ) :
     (S.centers ∩ ball 0 R).encard ≤
       volume (S.balls ∩ ball 0 (R + S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2)) := by
@@ -410,7 +442,7 @@ theorem SpherePacking.inter_ball_encard_le (R : ℝ) :
 
 /-- This gives an upper bound on the number of points in the sphere packing X with norm less than R.
 -/
-theorem SpherePacking.inter_ball_encard_ge (R : ℝ) :
+theorem inter_ball_encard_ge (R : ℝ) :
     (S.centers ∩ ball 0 R).encard ≥
       volume (S.balls ∩ ball 0 (R - S.separation / 2))
         / volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2)) := by
@@ -423,7 +455,7 @@ theorem SpherePacking.inter_ball_encard_ge (R : ℝ) :
   · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
   · exact measure_ball_lt_top.ne
 
-theorem SpherePacking.centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
+theorem centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers ∩ ball 0 R) := by
   apply Set.encard_lt_top_iff.mp
   by_cases hd : 0 < d
   · haveI : Nonempty (Fin d) := Fin.pos_iff_nonempty.mp hd
@@ -442,7 +474,7 @@ theorem SpherePacking.centers_inter_ball_finite (R : ℝ) : Finite ↑(S.centers
     subst hd
     exact (Set.encard_mono inf_le_right).trans_lt (this.trans_lt (by decide))
 
-theorem SpherePacking.finiteDensity_ge (R : ℝ) :
+theorem finiteDensity_ge (R : ℝ) :
     S.finiteDensity R
       ≥ (S.centers ∩ ball 0 (R - S.separation / 2)).encard
         * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -455,7 +487,7 @@ theorem SpherePacking.finiteDensity_ge (R : ℝ) :
   · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
   · exact measure_ball_lt_top.ne
 
-theorem SpherePacking.finiteDensity_le (R : ℝ) :
+theorem finiteDensity_le (R : ℝ) :
     S.finiteDensity R
       ≤ (S.centers ∩ ball 0 (R + S.separation / 2)).encard
         * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (S.separation / 2))
@@ -467,5 +499,7 @@ theorem SpherePacking.finiteDensity_le (R : ℝ) :
     rwa [add_sub_cancel_right] at this
   · exact (measure_ball_pos volume _ (by linarith [S.separation_pos])).ne.symm
   · exact measure_ball_lt_top.ne
+
+end Metric.SpherePacking
 
 end BasicResults

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -18,7 +18,7 @@ public import SpherePacking.Basic.PeriodicPacking
 @[expose] public section
 
 open scoped FourierTransform ENNReal SchwartzMap
-open SpherePacking Metric BigOperators Pointwise Filter MeasureTheory Complex Real ZSpan
+open EuclideanSpace Metric BigOperators Pointwise Filter MeasureTheory Complex Real ZSpan
   Bornology Summable Module
 
 variable {d : ℕ}

--- a/SpherePacking/MainTheorem.lean
+++ b/SpherePacking/MainTheorem.lean
@@ -4,7 +4,7 @@ public import SpherePacking.Basic.E8
 
 @[expose] public section
 
-open SpherePacking E8
+open EuclideanSpace E8
 
 theorem SpherePacking.MainTheorem : SpherePackingConstant 8 = E8Packing.density :=
   sorry

--- a/blueprint/src/subsections/lattice-periodic-packings.tex
+++ b/blueprint/src/subsections/lattice-periodic-packings.tex
@@ -25,7 +25,7 @@ There is also a corresponding dual notion, which will become relevant when we st
 
 We can now define periodic sphere packings.
 
-\begin{definition}\label{PeriodicSpherePacking}\lean{EuclideanSpace.PeriodicSpherePacking}\uses{SpherePacking, IsZLattice}\leanok
+\begin{definition}\label{PeriodicSpherePacking}\lean{Metric.PeriodicSpherePacking,EuclideanSpace.PeriodicSpherePacking}\uses{SpherePacking, IsZLattice}\leanok
   We say that a sphere packing $\Pa(X)$ is ($\Lambda$-)\emph{periodic} if there exists a lattice $\Lambda \subset \R^d$ such that for all $x \in X$ and $y \in \Lambda$, $x + y \in X$ (ie, $X$ is $\Lambda$-periodic).
 \end{definition}
 

--- a/blueprint/src/subsections/lattice-periodic-packings.tex
+++ b/blueprint/src/subsections/lattice-periodic-packings.tex
@@ -25,11 +25,11 @@ There is also a corresponding dual notion, which will become relevant when we st
 
 We can now define periodic sphere packings.
 
-\begin{definition}\label{PeriodicSpherePacking}\lean{PeriodicSpherePacking}\uses{SpherePacking, IsZLattice}\leanok
+\begin{definition}\label{PeriodicSpherePacking}\lean{EuclideanSpace.PeriodicSpherePacking}\uses{SpherePacking, IsZLattice}\leanok
   We say that a sphere packing $\Pa(X)$ is ($\Lambda$-)\emph{periodic} if there exists a lattice $\Lambda \subset \R^d$ such that for all $x \in X$ and $y \in \Lambda$, $x + y \in X$ (ie, $X$ is $\Lambda$-periodic).
 \end{definition}
 
-% \begin{lemma}\label{PeriodicSpherePacking.instAddAction}\lean{PeriodicSpherePacking.instAddAction}\uses{PeriodicSpherePacking}\leanok
+% \begin{lemma}\label{PeriodicSpherePacking.instAddAction}\lean{Metric.PeriodicSpherePacking.instAddAction}\uses{PeriodicSpherePacking}\leanok
 %   If $\Pa(X)$ is a $\Lambda$-periodic sphere packing, then $\Lambda$ acts on $X$ by translation.
 % \end{lemma}
 % \begin{proof}\leanok

--- a/blueprint/src/subsections/packings-density.tex
+++ b/blueprint/src/subsections/packings-density.tex
@@ -4,7 +4,7 @@ Note that some of the proofs in this section have only been sketched. The finer 
 
 Observe that the finite density evaluated at some $R > 0$ measures the density of sphere packings within a bounded, open ball of radius $R$. As one might expect, there is a relationship between the finite density and the number of centers in the ball of radius $R$.
 
-\begin{lemma}\label{lemma:sp-finite-density-bound}\lean{SpherePacking.finiteDensity_le,SpherePacking.finiteDensity_ge}\uses{SpherePacking.finiteDensity}\leanok
+\begin{lemma}\label{lemma:sp-finite-density-bound}\lean{Metric.SpherePacking.finiteDensity_le,Metric.SpherePacking.finiteDensity_ge}\uses{SpherePacking.finiteDensity}\leanok
   For any $R > 0$,
   \[
     \left|X \cap \mathcal{B}_d\left(R - \frac{r}{2}\right)\right| \cdot \frac{\mathrm{Vol}\left(\mathcal{B}_d\left(\frac{r}{2}\right)\right)}{\mathrm{Vol}(\mathcal{B}_d(R))}
@@ -18,7 +18,7 @@ Observe that the finite density evaluated at some $R > 0$ measures the density o
 
 Suppose further that $X$ is a periodic packing w.r.t. the lattice $\Lambda \subseteq \R^d$. Let $\mathcal{D}$ be a (bounded) fundamental region of $\Lambda$, say the parallelopiped $[0, 1]^n\Lambda$, and let $L$ be the bound on the norm of vectors in $\mathcal{D}$, i.e. a number satisfying $\forall x \in \mathcal{D}, \|x\| \leq L$.
 
-\begin{lemma}\label{lemma:lattice-points-bound}\lean{PeriodicSpherePacking.aux2_ge',PeriodicSpherePacking.aux2_le'}\leanok
+\begin{lemma}\label{lemma:lattice-points-bound}\lean{Metric.PeriodicSpherePacking.aux2_ge',Metric.PeriodicSpherePacking.aux2_le'}\leanok
   For all $R$, we have the following inequality relating the number of lattice points from $\Lambda$ in a ball with the volume of the ball and the fundamental region $\mathcal{D}$:
 
   \[
@@ -35,7 +35,7 @@ For the second inequality, we prove that $\bigcup_{x \in \Lambda \cap \mathcal{B
 
 To link \cref{lemma:sp-finite-density-bound} and \cref{lemma:lattice-points-bound}, we need a lemma relating $|\Lambda \cap \mathcal{B}|$ with $|X \cap \mathcal{B}|$, which is what the following lemma does:
 
-\begin{lemma}\label{lemma:periodic-points-bounds}\lean{PeriodicSpherePacking.aux_ge,PeriodicSpherePacking.aux_le}\leanok
+\begin{lemma}\label{lemma:periodic-points-bounds}\lean{Metric.PeriodicSpherePacking.aux_ge,Metric.PeriodicSpherePacking.aux_le}\leanok
   For all $R$, we have the following inequality relating the number of points from $X$ (periodic w.r.t. $\Lambda$) in a ball with the number of points from $\Lambda$:
   \[
     \left|\Lambda \cap \mathcal{B}_d(R - L)\right|\left|X / \Lambda\right|
@@ -72,7 +72,7 @@ When we combine the inequalities above, we need one additional computational lem
 
 Finally, we can relate the density of a periodic sphere packing to the natural definition of density given by any of its fundamental domain:
 
-\begin{theorem}\label{theorem:psp-density}\uses{SpherePacking.density}\lean{PeriodicSpherePacking.density_eq}\leanok
+\begin{theorem}\label{theorem:psp-density}\uses{SpherePacking.density}\lean{Metric.PeriodicSpherePacking.density_eq}\leanok
   For a periodic sphere packing $\mathcal{P} = \mathcal{P}(X)$ with centers $X$ periodic to the lattice $\Lambda$ and separation $r$,
 
   \[

--- a/blueprint/src/subsections/sphere-packings-scaling.tex
+++ b/blueprint/src/subsections/sphere-packings-scaling.tex
@@ -2,11 +2,11 @@
 
 Given that the problem involves the \emph{arrangement} of balls in space, it is intuitive not to worry about the radius of the balls (so long as they are all equal to each other). However, Definition~\ref{SpherePacking.balls} involves a choice of separation radius. In principle, we would want two sphere packing configurations that differ only in separation radii to `encode the same information'. In this brief subsection, we will describe how to change the separation radius of a sphere packing by \emph{scaling} the packing by a positive real number and prove that this does not affect its density. This will give us the freedom to choose any separation radius we like when attempting to define the optimal sphere packing in $\R^d$.
 
-\begin{definition}\label{SpherePacking.scale}\lean{SpherePacking.scale}\uses{SpherePacking}\leanok
+\begin{definition}\label{SpherePacking.scale}\lean{Metric.SpherePacking.scale}\uses{SpherePacking}\leanok
   Given a sphere packing $\Pa(X)$ with separation radius $r$, we defined the \emph{scaled packing} with respect to a real number $c > 0$ to be the packing $\Pa(cX)$, where $cX = \setof{cx \in V}{x \in X}$ has separation radius $cr$.
 \end{definition}
 
-\begin{lemma}\label{SpherePacking.scale_finiteDensity}\lean{SpherePacking.scale_finiteDensity}\uses{SpherePacking.finiteDensity, SpherePacking.scale}\leanok
+\begin{lemma}\label{SpherePacking.scale_finiteDensity}\lean{Metric.SpherePacking.scale_finiteDensity}\uses{SpherePacking.finiteDensity, SpherePacking.scale}\leanok
   Let $\Pa(X)$ be a sphere packing and $c$ a positive real number. Then, for all $R > 0$,
   \[
     \Delta_{\Pa(cX)}(cR) = \Delta_{\Pa(X)}(R).
@@ -22,7 +22,7 @@ Given that the problem involves the \emph{arrangement} of balls in space, it is 
   where the second equality follows from applying the fact that scaling a (measurable) set by a factor of $c$ scales its volume by a factor of $c^d$ to the fact that $\Pa(cX) \cap B_d(0, cR) = c \cdot (\Pa(X) \cap B_d(0, cR))$.
 \end{proof}
 
-\begin{lemma}\label{SpherePacking.scale_density}\lean{SpherePacking.scale_density}\uses{SpherePacking.scale}\leanok
+\begin{lemma}\label{SpherePacking.scale_density}\lean{Metric.SpherePacking.scale_density}\uses{SpherePacking.scale}\leanok
   Let $\Pa(X)$ be a sphere packing and $c$ a positive real number. Then, the density of the scaled packing $\Pa(cX)$ is equal to the density of the original packing $\Pa(X)$.
 \end{lemma}
 \begin{proof}\uses{SpherePacking.scale_finiteDensity}\leanok
@@ -41,7 +41,7 @@ Therefore, as expected, we do not need to worry about the separation radius when
 
 We can also use Lemma~\ref{SpherePacking.scale_density} to simplify the computation of the sphere packing constant by taking the supremum not over \emph{all} sphere packings but only over those with density $1$.
 
-\begin{lemma}\label{SpherePacking.constant_eq_constant_normalized}\lean{SpherePacking.constant_eq_constant_normalized}\uses{SpherePackingConstant, SpherePacking.density}\leanok
+\begin{lemma}\label{SpherePacking.constant_eq_constant_normalized}\lean{Metric.SpherePacking.constant_eq_constant_normalized}\uses{SpherePackingConstant, SpherePacking.density}\leanok
   \[
     \Delta_d = \sup\limits_{\substack{\Pa \subset \R^d \\ \text{sphere packing} \\ \text{sep.~rad.} = 1}} \Delta_{\Pa}
   \]

--- a/blueprint/src/subsections/sphere-packings.tex
+++ b/blueprint/src/subsections/sphere-packings.tex
@@ -2,15 +2,16 @@
 % results below are stated in greater generality than presented here: sphere
 % packings are defined over an arbitrary metric space (`Metric.SpherePacking`),
 % and periodic sphere packings over an arbitrary normed space over a normed
-% field (`Metric.PeriodicSpherePacking`). This blueprint, however, only contains
-% an exposition of the corresponding definitions and results in Euclidean
-% spaces, which in Lean are the abbreviations `EuclideanSpace.SpherePacking` and
-% `EuclideanSpace.PeriodicSpherePacking`. Accordingly, the `\lean{...}` links in
-% this section point to the Euclidean-space versions of the structures, while
-% operations and lemmas that are genuinely general resolve to their declarations
-% in the `Metric` namespace.
+% field (`Metric.PeriodicSpherePacking`). The Euclidean-space versions are the
+% abbreviations `EuclideanSpace.SpherePacking` and
+% `EuclideanSpace.PeriodicSpherePacking`. Where both a general (`Metric.*`) and a
+% Euclidean-space (`EuclideanSpace.*`) declaration match a blueprint statement,
+% the `\lean{...}` links point to both; operations and lemmas that exist only in
+% the general form resolve to their declarations in the `Metric` namespace. In
+% all cases, the informal exposition below describes only the Euclidean-space
+% versions.
 \begin{remark}
-  Whilst many of the definitions and results in this blueprint are stated, in the Lean formalisation, for general metric spaces (and, in the case of periodic packings, for normed spaces over normed fields), this blueprint only contains an exposition of the corresponding definitions and results in Euclidean spaces. The relevant Euclidean-space objects are \verb|EuclideanSpace.SpherePacking| and \verb|EuclideanSpace.PeriodicSpherePacking|, which are abbreviations for the general \verb|Metric.SpherePacking| and \verb|Metric.PeriodicSpherePacking|.
+  In the Lean formalisation, many of the definitions and results in this blueprint are stated for general metric spaces (and, in the case of periodic packings, for normed spaces over normed fields), as \verb|Metric.SpherePacking| and \verb|Metric.PeriodicSpherePacking|, with the Euclidean-space versions \verb|EuclideanSpace.SpherePacking| and \verb|EuclideanSpace.PeriodicSpherePacking| being abbreviations for the corresponding general declarations. Where both a general and a Euclidean-space declaration exist, we link to both; the remaining links point to the general declarations in the \verb|Metric| namespace, of which there is no separate Euclidean-space form. The informal exposition below, however, only describes the Euclidean-space versions.
 \end{remark}
 
 The Sphere Packing problem is a classic optimisation problem with widespread applications that go well beyond mathematics. The task is to determine the ``densest" possible arrangement of spheres in a given space. It remains unsolved in all but finitely many dimensions.
@@ -30,7 +31,7 @@ Arguably the most important definition in this subsection is that of \emph{packi
   \]
 \end{definition}
 
-\begin{remark}\label{SpherePacking}\lean{EuclideanSpace.SpherePacking}\leanok
+\begin{remark}\label{SpherePacking}\lean{Metric.SpherePacking,EuclideanSpace.SpherePacking}\leanok
   Note that a sphere packing is uniquely defined from a given set of centres (which, in order to be a valid set of centres, must admit a corresponding separation radius). Therefore, as a conscious choice during the formalisation process, we will define everything that depends on sphere packings in terms of \verb|SpherePacking|, a \verb|structure| that bundles all the identifying information of a packing, but not the actual balls themselves. For the purposes of this blueprint, however, we will refrain from making this distinction.
 \end{remark}
 

--- a/blueprint/src/subsections/sphere-packings.tex
+++ b/blueprint/src/subsections/sphere-packings.tex
@@ -1,3 +1,18 @@
+% NOTE ON GENERALITY: In the Lean formalisation, many of the definitions and
+% results below are stated in greater generality than presented here: sphere
+% packings are defined over an arbitrary metric space (`Metric.SpherePacking`),
+% and periodic sphere packings over an arbitrary normed space over a normed
+% field (`Metric.PeriodicSpherePacking`). This blueprint, however, only contains
+% an exposition of the corresponding definitions and results in Euclidean
+% spaces, which in Lean are the abbreviations `EuclideanSpace.SpherePacking` and
+% `EuclideanSpace.PeriodicSpherePacking`. Accordingly, the `\lean{...}` links in
+% this section point to the Euclidean-space versions of the structures, while
+% operations and lemmas that are genuinely general resolve to their declarations
+% in the `Metric` namespace.
+\begin{remark}
+  Whilst many of the definitions and results in this blueprint are stated, in the Lean formalisation, for general metric spaces (and, in the case of periodic packings, for normed spaces over normed fields), this blueprint only contains an exposition of the corresponding definitions and results in Euclidean spaces. The relevant Euclidean-space objects are \verb|EuclideanSpace.SpherePacking| and \verb|EuclideanSpace.PeriodicSpherePacking|, which are abbreviations for the general \verb|Metric.SpherePacking| and \verb|Metric.PeriodicSpherePacking|.
+\end{remark}
+
 The Sphere Packing problem is a classic optimisation problem with widespread applications that go well beyond mathematics. The task is to determine the ``densest" possible arrangement of spheres in a given space. It remains unsolved in all but finitely many dimensions.
 
 It was famously determined, in~\cite{Via2017}, that the optimal arrangement in $\mathbb{R}^8$ is given by the $E_8$ lattice. The result is strongly dependent on the Cohn-Elkies linear programming bound (Theorem 3.1 in~\cite{ElkiesCohn}), which, if a $\R^d \to \R$ function satisfying certain conditions exists, bounds the optimal density of sphere packings in $\R^d$ in terms of it. The proof in~\cite{Via2017} uses the theory of modular forms to construct a function that can be used to bound the density of all sphere packings in $\R^8$ above by the density of the $E_8$ lattice packing. This then allows us to conclude that no packing in $\R^8$ can be denser than the $E_8$ lattice packing.
@@ -8,20 +23,20 @@ This subsection gives an overview for the setup of the problem, both informally 
 
 Arguably the most important definition in this subsection is that of \emph{packing density}, which measures which portion of $d$-dimensional Euclidean space is covered by a given sphere packing. Taking the supremum over all packings gives what we refer to as the \emph{sphere packing constant}, which is the quantity we are interested in optimising.
 
-\begin{definition}\label{SpherePacking.balls}\lean{SpherePacking.balls}\leanok  % Do we want to replace the notation \mathcal{P} with \mathcal{P}_X or \mathcal{P}(X)?
+\begin{definition}\label{SpherePacking.balls}\lean{Metric.SpherePacking.balls}\leanok  % Do we want to replace the notation \mathcal{P} with \mathcal{P}_X or \mathcal{P}(X)?
   Given a set $X \subset \R^d$ and a real number $r > 0$ (known as the \emph{separation radius}) such that $\|x - y\| \geq r$ for all distinct $x, y \in X$, we define the \emph{sphere packing} $\Pa(X)$ with centres at $X$ to be the union of all open balls of radius $r$ centred at points in $X$:
   \[
     \Pa(X) := \bigcup_{x \in X} B_d(x, r)
   \]
 \end{definition}
 
-\begin{remark}\label{SpherePacking}\lean{SpherePacking}\leanok
+\begin{remark}\label{SpherePacking}\lean{EuclideanSpace.SpherePacking}\leanok
   Note that a sphere packing is uniquely defined from a given set of centres (which, in order to be a valid set of centres, must admit a corresponding separation radius). Therefore, as a conscious choice during the formalisation process, we will define everything that depends on sphere packings in terms of \verb|SpherePacking|, a \verb|structure| that bundles all the identifying information of a packing, but not the actual balls themselves. For the purposes of this blueprint, however, we will refrain from making this distinction.
 \end{remark}
 
 We now define a notion of density for bounded regions of space by considering the density inside balls of finite radius.
 
-\begin{definition}\label{SpherePacking.finiteDensity}\lean{SpherePacking.finiteDensity}\uses{SpherePacking, SpherePacking.balls}\leanok
+\begin{definition}\label{SpherePacking.finiteDensity}\lean{Metric.SpherePacking.finiteDensity}\uses{SpherePacking, SpherePacking.balls}\leanok
   The \emph{finite density} of a packing $\mathcal{P}$ is defined as
   \[
     \Delta_{\mathcal{P}}(R):=\frac{\mathrm{Vol}(\mathcal{P}\cap B_d(0,R))}{\mathrm{Vol}(B_d(0,R))},\quad R>0.
@@ -30,7 +45,7 @@ We now define a notion of density for bounded regions of space by considering th
 
 As intuitive as it seems to take the density of a packing to be the limit of the finite densities as the radius of the ball goes to infinity, it is not immediately clear that this limit exists. Therefore, we define the density of a sphere packing as a limit superior instead.
 
-\begin{definition}\label{SpherePacking.density}\lean{SpherePacking.density}\uses{SpherePacking, SpherePacking.finiteDensity}\leanok
+\begin{definition}\label{SpherePacking.density}\lean{Metric.SpherePacking.density}\uses{SpherePacking, SpherePacking.finiteDensity}\leanok
   We define the \emph{density} of a packing $\mathcal{P}$ as the limit superior
   \[
     \Delta_{\mathcal{P}}:=\limsup\limits_{R\to\infty}\Delta_{\mathcal{P}}(R).


### PR DESCRIPTION
This PR aims to prepare `SpherePacking.Basic.SpherePacking.lean` to be PRed to `mathlib`.

Let's use this thread to discuss any changes we want to implement before PRing to `mathlib`, such as generalising definitions. My understanding from our last packathon is that we want to stick to Euclidean Space because sphere packings can be poorly behaved in unusual metric spaces. I can include that as an implementation note if that's something we think would be useful.

See also [my Mathlib fork](https://github.com/thefundamentaltheor3m/mathlib4/commit/d4961fffcf3d1cc920e89a51b8007957c2889a0c#diff-72eb2a8fc0cf3b99a0853c0a6d6d8c0eca6f5f828c51220094c92603bab8bb5a).