### PR TITLE
[gauss] Cleaning Up Cohn-Elkies and Poisson Summation

### DIFF
--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -10,6 +10,7 @@ public import SpherePacking.E8.Packing
 public import SpherePacking.ForMathlib.Cusps
 public import SpherePacking.ForMathlib.DerivHelpers
 public import SpherePacking.ForMathlib.ExpPiIMulMulI
+public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.ModularFormsHelpers
 public import SpherePacking.Integration.Measure
 public import SpherePacking.MagicFunction.IntegralParametrisations

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -12,6 +12,7 @@ public import SpherePacking.ForMathlib.DerivHelpers
 public import SpherePacking.ForMathlib.ExpPiIMulMulI
 public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.ModularFormsHelpers
+public import SpherePacking.ForMathlib.UnitAddTorusQuotient
 public import SpherePacking.Integration.Measure
 public import SpherePacking.MagicFunction.IntegralParametrisations
 public import SpherePacking.MagicFunction.a.Eigenfunction

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -7,6 +7,7 @@ public import SpherePacking.CohnElkies.PoissonSummationGeneral
 public import SpherePacking.Contour.MobiusInv.WedgeSetContour
 public import SpherePacking.E8.Basic
 public import SpherePacking.E8.Packing
+public import SpherePacking.ForMathlib.CoordCube
 public import SpherePacking.ForMathlib.Cusps
 public import SpherePacking.ForMathlib.DerivHelpers
 public import SpherePacking.ForMathlib.DualLattice

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -9,6 +9,7 @@ public import SpherePacking.E8.Basic
 public import SpherePacking.E8.Packing
 public import SpherePacking.ForMathlib.Cusps
 public import SpherePacking.ForMathlib.DerivHelpers
+public import SpherePacking.ForMathlib.DualLattice
 public import SpherePacking.ForMathlib.ExpPiIMulMulI
 public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.ModularFormsHelpers

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -14,6 +14,7 @@ public import SpherePacking.ForMathlib.DualLattice
 public import SpherePacking.ForMathlib.ExpPiIMulMulI
 public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.ModularFormsHelpers
+public import SpherePacking.ForMathlib.SchwartzLatticeSummable
 public import SpherePacking.ForMathlib.UnitAddTorusQuotient
 public import SpherePacking.Integration.Measure
 public import SpherePacking.MagicFunction.IntegralParametrisations

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib.Algebra.Ring.IsFormallyReal
-public import Mathlib.Dynamics.Ergodic.Action.Regular
-public import Mathlib.Order.CompletePartialOrder
+public import Mathlib
+
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -761,51 +761,13 @@ namespace LPBoundAux
 
 variable (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ]
 
-/-- A Schwartz function has summable norms on any translate of a `ℤ`-lattice. -/
+/-- A Schwartz function has summable norms on any translate of a `ℤ`-lattice. The
+`EuclideanSpace`-specialised name kept for use throughout this file; the content is
+`SchwartzMap.summable_norm_comp_add`. -/
 public lemma summable_norm_comp_add_zlattice (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ))
     (a : EuclideanSpace ℝ (Fin d)) :
-    Summable (fun ℓ : Λ => ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖) := by
-  -- `k` is the decay order: two more than the rank, so the comparison series converges.
-  let k : ℕ := Module.finrank ℤ Λ + 2
-  obtain ⟨C, _hCpos, hC⟩ := f.decay k 0
-  -- `b = -a` is the shift, so that `a + ℓ = ℓ - b`.
-  set b : EuclideanSpace ℝ (Fin d) := -a
-  refine Summable.of_norm_bounded_eventually
-    (f := fun ℓ : Λ => ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖)
-    (g := fun ℓ : Λ => (C + 1) * ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖⁻¹ ^ k) ?_ ?_
-  · simpa [mul_assoc] using
-      (ZLattice.summable_norm_sub_inv_pow (L := Λ) (n := k) (by simp [k]) b).mul_left (C + 1)
-  · letI : DiscreteTopology Λ.toAddSubgroup := inferInstanceAs (DiscreteTopology Λ)
-    -- The bound fails only on the finite set where `‖ℓ - b‖ ≤ 1`.
-    have hfin : ({ℓ : Λ | ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ≤ (1 : ℝ)} : Set Λ).Finite := by
-      have hclosed : IsClosed (X := EuclideanSpace ℝ (Fin d))
-          (Λ : Set (EuclideanSpace ℝ (Fin d))) := by
-        simpa [Submodule.coe_toAddSubgroup] using
-          AddSubgroup.isClosed_of_discrete (H := Λ.toAddSubgroup)
-      simpa [Set.preimage, Metric.mem_closedBall, dist_eq_norm, and_true] using
-        (Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
-          Metric.isBounded_closedBall hclosed).preimage_embedding
-          (f := (⟨Subtype.val, Subtype.coe_injective⟩ : Λ ↪ EuclideanSpace ℝ (Fin d)))
-    refine hfin.subset fun ℓ hfail => ?_
-    by_contra hlarge
-    have hpos : 0 < ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k :=
-      pow_pos (lt_of_lt_of_le one_pos (lt_of_not_ge hlarge).le) _
-    -- Schwartz decay at order `k`, rewriting `‖a + ℓ‖` as `‖ℓ - b‖`.
-    have hab : ‖a + (ℓ : EuclideanSpace ℝ (Fin d))‖ = ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ := by
-      simp [b, sub_eq_add_neg, add_comm]
-    have hdec :
-        ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k *
-          ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖ ≤ C := by
-      simpa [hab, norm_iteratedFDeriv_zero] using hC (a + (ℓ : EuclideanSpace ℝ (Fin d)))
-    -- Rearrange the decay bound into the form `(C + 1) * ‖ℓ - b‖⁻¹ ^ k`.
-    have h1 : ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖ ≤
-        C / ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k := (le_div_iff₀' hpos).2 hdec
-    have h2 : C / ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k ≤
-        (C + 1) * ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖⁻¹ ^ k := by
-      simpa [div_eq_mul_inv, inv_pow] using
-        mul_le_mul_of_nonneg_right (by linarith : C ≤ C + 1)
-          (by positivity : 0 ≤ (‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k)⁻¹)
-    exact hfail (by simpa using h1.trans h2)
+    Summable (fun ℓ : Λ => ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖) :=
+  f.summable_norm_comp_add Λ a
 
 end LPBoundAux
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -8,6 +8,7 @@ public import Mathlib
 
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
+public import SpherePacking.ForMathlib.CoordCube
 
 /-!
 # Cohn-Elkies linear programming bound
@@ -94,53 +95,6 @@ public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin 
   lattice_discrete := inferInstance
   lattice_isZLattice := inferInstance
 
-/-- The half-open coordinate cube `[0, L)^d`. Used pervasively as the fundamental domain of
-`cubeLattice`; its membership API is `mem_coordCube`. -/
-@[expose] public def coordCube (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  {x | ∀ i : Fin d, x i ∈ Set.Ico (0 : ℝ) L}
-
-@[simp] public lemma mem_coordCube {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ coordCube d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
-
-/-- The closed inner cube `[r, L-r]^d`, the locus where a radius-`r` ball stays inside
-`coordCube L`. Membership API: `mem_coordCubeInner`. -/
-@[expose] public def coordCubeInner (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  {x | ∀ i : Fin d, x i ∈ Set.Icc r (L - r)}
-
-@[simp] public lemma mem_coordCubeInner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ coordCubeInner d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
-
-/-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is `coordCube d L` (`fundamentalDomain_cubeBasis_eq_coordCube`). -/
-@[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
-    Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
-  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
-
-/-- The cubic lattice `L • ℤ^d`, spanned by `cubeBasis d L hL`. Standalone so it can carry
-`ZLattice`/`DiscreteTopology` instances and act as the period lattice of the cube packing. -/
-@[expose] public noncomputable def cubeLattice (d : ℕ) (L : ℝ) (hL : 0 < L) :
-    Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
-  Submodule.span ℤ (Set.range (cubeBasis d L hL))
-
-instance instDiscreteTopology_cubeLattice (L : ℝ) (hL : 0 < L) :
-    DiscreteTopology (cubeLattice d L hL) :=
-  inferInstanceAs (DiscreteTopology (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
-
-instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
-    IsZLattice ℝ (cubeLattice d L hL) :=
-  inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
-
-/-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
-public lemma fundamentalDomain_cubeBasis_eq_coordCube (L : ℝ) (hL : 0 < L) :
-    fundamentalDomain (cubeBasis d L hL) = coordCube d L := by
-  ext x
-  simp only [ZSpan.mem_fundamentalDomain, coordCube, cubeBasis, Module.Basis.repr_isUnitSMul,
-    Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
-    OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
-    Set.mem_Ico]
-  exact forall_congr' fun i =>
-    and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
-
 /-- A ball of radius `r` centred in the inner cube `[r, L-r]^d` is contained in `[0, L)^d`. -/
 lemma ball_subset_coordCube_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
     (hx : x ∈ coordCubeInner d L r) : ball x r ⊆ coordCube d L := fun y hy i => by
@@ -165,48 +119,6 @@ public lemma periodizedCenters_inter_eq_of_subset {Λ : Submodule ℤ (Euclidean
   have hg : g = 0 := (huniq g hxD).trans (huniq 0 (by simpa using hF_sub hfF)).symm
   simpa [hg] using hfF
 
-namespace PeriodicConstant
-
-private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet s) :
-    volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s :=
-  (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
-
-/-- Every point has a unique `cubeLattice` translate lying in the cube `coordCube d L`. -/
-public lemma coordCube_unique_covers (L : ℝ) (hL : 0 < L) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ coordCube d L := fun x => by
-  simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
-    exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
-
-/-- The cube `coordCube d L` is a bounded set. -/
-public lemma isBounded_coordCube (L : ℝ) (hL : 0 < L) : IsBounded (coordCube d L) := by
-  simpa [fundamentalDomain_cubeBasis_eq_coordCube L hL] using
-    fundamentalDomain_isBounded (cubeBasis d L hL)
-
-/-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
-public lemma volume_coordCube (L : ℝ) : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
-  have hcube : coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-      (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
-    ext x; simp [mem_coordCube, Set.mem_pi]
-  rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
-    volume_pi, Measure.pi_pi]
-  simp [Real.volume_Ico, sub_zero]
-
-/-- `coordCubeInner d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
-public lemma coordCubeInner_eq_preimage_ofLp (L r : ℝ) :
-    coordCubeInner d L r =
-      (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-        (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
-  ext x; simp [mem_coordCubeInner, Pi.le_def, forall_and]
-
-/-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
-public lemma volume_coordCubeInner (L r : ℝ) :
-    volume (coordCubeInner d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
-  rw [coordCubeInner_eq_preimage_ofLp, volume_preimage_ofLp _
-    (.pi Set.countable_univ fun _ _ ↦ measurableSet_Icc), volume_pi, Measure.pi_pi]
-  simp [Real.volume_Icc, show L - r - r = L - 2 * r by ring]
-
-end PeriodicConstant
-
 namespace PeriodicConstantApprox
 
 public lemma coordCube_unique_covers_vadd (L : ℝ) (hL : 0 < L) (v : cubeLattice d L hL) :
@@ -215,7 +127,7 @@ public lemma coordCube_unique_covers_vadd (L : ℝ) (hL : 0 < L) (v : cubeLattic
       a +ᵥ x ∈ v +ᵥ coordCube d L ↔ (a - v) +ᵥ x ∈ coordCube d L := by
     simp [Set.mem_vadd_set_iff_neg_vadd_mem, Submodule.vadd_def, vadd_eq_add, sub_eq_add_neg,
       add_assoc, add_comm]
-  obtain ⟨g, hg, hguniq⟩ := PeriodicConstant.coordCube_unique_covers (d := d) L hL x
+  obtain ⟨g, hg, hguniq⟩ := coordCube_unique_covers (d := d) L hL x
   exact ⟨g + v, (hvadd _).2 (by simpa),
     fun _ ha => sub_eq_iff_eq_add.1 (hguniq _ <| (hvadd _).1 ha)⟩
 
@@ -230,14 +142,6 @@ public lemma ball_subset_vadd_coordCube_of_mem_vadd_inner {L r : ℝ} (hL : 0 < 
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
   simpa [mem_ball, dist_eq_norm, sub_sub] using hz
 
-public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :
-    Set.Finite {g : cubeLattice d L hL | (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 R} := by
-  refine (Set.Finite.preimage_embedding (f := ⟨fun g : cubeLattice d L hL =>
-    (g : EuclideanSpace ℝ (Fin d)), Subtype.val_injective⟩) (by
-      simpa [cubeLattice] using ZSpan.setFinite_inter (b := cubeBasis d L hL)
-        (s := ball (0 : EuclideanSpace ℝ (Fin d)) R) Metric.isBounded_ball)).subset fun g hg => ?_
-  exact ⟨hg, g.property⟩
-
 section CoordCubeCover
 
 variable (L : ℝ) (hL : 0 < L)
@@ -245,11 +149,11 @@ variable (L : ℝ) (hL : 0 < L)
 /-- The unique lattice vector translating `x` into `coordCube d L` (see `coordCubeCover_spec`).
 The cell-assignment map underlying the pigeonhole argument; named to pair with its spec lemma. -/
 noncomputable def coordCubeCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
-  Classical.choose (PeriodicConstant.coordCube_unique_covers L hL x)
+  Classical.choose (coordCube_unique_covers L hL x)
 
 lemma coordCubeCover_spec (x : EuclideanSpace ℝ (Fin d)) :
     coordCubeCover L hL x +ᵥ x ∈ coordCube d L :=
-  (Classical.choose_spec (PeriodicConstant.coordCube_unique_covers L hL x)).1
+  (Classical.choose_spec (coordCube_unique_covers L hL x)).1
 
 lemma neg_coordCubeCover_mem_ball {C R : ℝ}
     (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
@@ -272,11 +176,11 @@ end CoordCubeCover
 
 lemma card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball {L : ℝ} (hL : 0 < L)
     {R C : ℝ} (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
-    ((PeriodicConstantApprox.finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
+    ((finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
         ℝ≥0∞) * volume (coordCube d L) ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
   -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells.
-  set htSet := PeriodicConstantApprox.finite_lattice_in_ball (d := d) L hL (R + C)
+  set htSet := finite_lattice_in_ball (d := d) L hL (R + C)
   have hvadd : ∀ g : ↥(cubeLattice d L hL),
       volume (g +ᵥ coordCube d L) = volume (coordCube d L) :=
     fun g => measure_vadd volume g _
@@ -287,7 +191,7 @@ lemma card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball {L : ℝ} 
         simp_rw [hvadd, Finset.sum_const, nsmul_eq_mul]
     _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ coordCube d L) := (measure_biUnion_finset
         (fun _ _ _ _ hgh => disjoint_vadd_of_unique_covers (d := d)
-          (PeriodicConstant.coordCube_unique_covers L hL) hgh)
+          (coordCube_unique_covers L hL) hgh)
         (fun g _ => hms.const_vadd g)).symm
     _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := volume.mono <| by
         rintro y hy
@@ -385,12 +289,12 @@ lemma volume_cubeShell_eq_pow (L : ℝ) :
         WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg] at hx ⊢
       exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
   have hmeas : MeasurableSet (coordCubeInner d L 1) := by
-    simpa [PeriodicConstant.coordCubeInner_eq_preimage_ofLp] using
+    simpa [coordCubeInner_eq_preimage_ofLp] using
       (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
         (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
-  simpa [measure_vadd, constVec, PeriodicConstant.volume_coordCubeInner] using
+  simpa [measure_vadd, constVec, volume_coordCubeInner] using
     measure_diff (μ := volume) hsub hmeas.nullMeasurableSet
-      (by simp [PeriodicConstant.volume_coordCubeInner])
+      (by simp [volume_coordCubeInner])
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
@@ -434,7 +338,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   -- `D` is bounded, being a translate of the cube.
   have hD_bounded : IsBounded D := by
     simpa [D, Submodule.vadd_def, vadd_eq_add] using
-      (PeriodicConstant.isBounded_coordCube L hL).vadd (g : EuclideanSpace ℝ (Fin d))
+      (isBounded_coordCube L hL).vadd (g : EuclideanSpace ℝ (Fin d))
   have hnumReps : P.numReps = F.card := by
     exact_mod_cast show (P.numReps : ENat) = (F.card : ENat) by
       simpa [hPcD, Fset, Set.encard_coe_eq_coe_finsetCard] using
@@ -469,7 +373,7 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
   filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
   have hL2' : 0 ≤ L - 2 := by linarith
   have hvol : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
-    simpa using PeriodicConstant.volume_coordCube L
+    simpa using volume_coordCube L
   rw [volume_cubeShell_eq_pow L, hvol,
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L + 1), ← ENNReal.ofReal_pow hL2',
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L), ← ENNReal.ofReal_sub _ (pow_nonneg hL2' d)]
@@ -486,7 +390,7 @@ private lemma exists_L_and_C_for_cubeShellErr_lt {b c : ℝ≥0∞} (hbc : b < c
     (tendsto_volume_cubeShell_div_volume_coordCube_zero.eventually
       (Iio_mem_nhds (tsub_pos_of_lt hbc)))).exists
   obtain ⟨C, hC⟩ : ∃ C : ℝ, coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
-    simpa using (PeriodicConstant.isBounded_coordCube L hLpos).subset_ball 0
+    simpa using (isBounded_coordCube L hLpos).subset_ball 0
   have hCpos : 0 < C := by
     simpa [Metric.mem_ball, dist_eq_norm] using
       hC (by simp [coordCube, hLpos] : (0 : EuclideanSpace ℝ (Fin d)) ∈ coordCube d L)
@@ -583,10 +487,10 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
   set volBall := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
   have hvolCube_ne0 : volCube ≠ 0 := by
-    simpa [volCube, PeriodicConstant.volume_coordCube L] using
+    simpa [volCube, volume_coordCube L] using
       pow_ne_zero d (ENNReal.ofReal_pos.mpr hL).ne'
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (PeriodicConstant.isBounded_coordCube L hL).measure_lt_top.ne
+    (isBounded_coordCube L hL).measure_lt_top.ne
   -- Cancelling a common factor of `volCube` from the numerator and an outer division.
   have hcancel : ∀ a c : ℝ≥0∞, a * volCube / c / volCube = a / c := fun a c => by
     simp only [div_eq_mul_inv,
@@ -629,7 +533,7 @@ private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
   set volCube : ℝ≥0∞ := volume (coordCube d L)
   set volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (PeriodicConstant.isBounded_coordCube L hL).measure_lt_top.ne
+    (isBounded_coordCube L hL).measure_lt_top.ne
   -- Split `sg` by the inner cube: `F` (kept representatives) and `sb` (boundary, bounded by shell).
   let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ coordCubeInner d L (1 / 2 : ℝ)
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -119,17 +119,20 @@ public lemma periodizedCenters_inter_eq_of_subset {Λ : Submodule ℤ (Euclidean
   have hg : g = 0 := (huniq g hxD).trans (huniq 0 (by simpa using hF_sub hfF)).symm
   simpa [hg] using hfF
 
-namespace PeriodicConstantApprox
-
-public lemma cubeIco_unique_covers_vadd (L : ℝ) (hL : 0 < L) (v : cubeLattice d L hL) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ v +ᵥ cubeIco d L := fun x => by
-  have hvadd (a : cubeLattice d L hL) :
-      a +ᵥ x ∈ v +ᵥ cubeIco d L ↔ (a - v) +ᵥ x ∈ cubeIco d L := by
+/-- A translate `v +ᵥ D` of a fundamental domain is again a fundamental domain: if every point has a
+unique lattice translate landing in `D`, the same holds for `v +ᵥ D`. Fully lattice-generic — no
+cube, basis, or `EuclideanSpace` structure is used. -/
+public lemma vadd_unique_covers {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))}
+    {D : Set (EuclideanSpace ℝ (Fin d))} (hD : ∀ x, ∃! g : Λ, g +ᵥ x ∈ D) (v : Λ) :
+    ∀ x, ∃! g : Λ, g +ᵥ x ∈ v +ᵥ D := fun x => by
+  have hvadd (a : Λ) : a +ᵥ x ∈ v +ᵥ D ↔ (a - v) +ᵥ x ∈ D := by
     simp [Set.mem_vadd_set_iff_neg_vadd_mem, Submodule.vadd_def, vadd_eq_add, sub_eq_add_neg,
       add_assoc, add_comm]
-  obtain ⟨g, hg, hguniq⟩ := cubeIco_unique_covers (d := d) L hL x
+  obtain ⟨g, hg, hguniq⟩ := hD x
   exact ⟨g + v, (hvadd _).2 (by simpa),
     fun _ ha => sub_eq_iff_eq_add.1 (hguniq _ <| (hvadd _).1 ha)⟩
+
+namespace PeriodicConstantApprox
 
 public lemma ball_subset_vadd_cubeIco_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
     {v : cubeLattice d L hL} {x : EuclideanSpace ℝ (Fin d)}
@@ -318,7 +321,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   -- Assemble the periodic packing `P` from the cube cell `D` and the representatives `Fset`.
   let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ cubeIco d L
   let Fset : Set (EuclideanSpace ℝ (Fin d)) := (F : Set (EuclideanSpace ℝ (Fin d)))
-  have hD_unique := PeriodicConstantApprox.cubeIco_unique_covers_vadd L hL g
+  have hD_unique := vadd_unique_covers (cubeIco_unique_covers L hL) g
   let P : PeriodicSpherePacking d :=
     periodize_to_periodicSpherePacking (d := d) S (Λ := cubeLattice d L hL) D Fset
       (hD_unique_covers := hD_unique) (hF_centers := by assumption)

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -15,7 +15,7 @@ public import SpherePacking.ForMathlib.CoordCube
 
 Cohn-Elkies upper bound on `SpherePackingConstant d` via `LinearProgrammingBound`. Also contains
 the periodizing constructions and boundary-control machinery (merged from `BoundaryControl`):
-`periodizedCenters`, `periodize_to_periodicSpherePacking`, `coordCube`/`coordCubeInner`, the cube
+`periodizedCenters`, `periodize_to_periodicSpherePacking`, `cubeIco`/`cubeIcc`, the cube
 lattice `cubeLattice`, and the main result `periodic_constant_eq_constant`.
 -/
 
@@ -96,8 +96,8 @@ public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin 
   lattice_isZLattice := inferInstance
 
 /-- A ball of radius `r` centred in the inner cube `[r, L-r]^d` is contained in `[0, L)^d`. -/
-lemma ball_subset_coordCube_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ coordCubeInner d L r) : ball x r ⊆ coordCube d L := fun y hy i => by
+lemma ball_subset_cubeIco_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
+    (hx : x ∈ cubeIcc d L r) : ball x r ⊆ cubeIco d L := fun y hy i => by
   have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using abs_coord_le_norm (y - x) i
   have h₂ : ‖y - x‖ < r := by simpa [dist_eq_norm] using hy
   obtain ⟨hlo, hhi⟩ := abs_lt.mp (h₁.trans_lt h₂)
@@ -121,22 +121,22 @@ public lemma periodizedCenters_inter_eq_of_subset {Λ : Submodule ℤ (Euclidean
 
 namespace PeriodicConstantApprox
 
-public lemma coordCube_unique_covers_vadd (L : ℝ) (hL : 0 < L) (v : cubeLattice d L hL) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ v +ᵥ coordCube d L := fun x => by
+public lemma cubeIco_unique_covers_vadd (L : ℝ) (hL : 0 < L) (v : cubeLattice d L hL) :
+    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ v +ᵥ cubeIco d L := fun x => by
   have hvadd (a : cubeLattice d L hL) :
-      a +ᵥ x ∈ v +ᵥ coordCube d L ↔ (a - v) +ᵥ x ∈ coordCube d L := by
+      a +ᵥ x ∈ v +ᵥ cubeIco d L ↔ (a - v) +ᵥ x ∈ cubeIco d L := by
     simp [Set.mem_vadd_set_iff_neg_vadd_mem, Submodule.vadd_def, vadd_eq_add, sub_eq_add_neg,
       add_assoc, add_comm]
-  obtain ⟨g, hg, hguniq⟩ := coordCube_unique_covers (d := d) L hL x
+  obtain ⟨g, hg, hguniq⟩ := cubeIco_unique_covers (d := d) L hL x
   exact ⟨g + v, (hvadd _).2 (by simpa),
     fun _ ha => sub_eq_iff_eq_add.1 (hguniq _ <| (hvadd _).1 ha)⟩
 
-public lemma ball_subset_vadd_coordCube_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
+public lemma ball_subset_vadd_cubeIco_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
     {v : cubeLattice d L hL} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ v +ᵥ coordCubeInner d L r) :
-    ball x r ⊆ v +ᵥ coordCube d L := by
+    (hx : x ∈ v +ᵥ cubeIcc d L r) :
+    ball x r ⊆ v +ᵥ cubeIco d L := by
   obtain ⟨y, hy, rfl⟩ := hx
-  have hball : ball y r ⊆ coordCube d L := ball_subset_coordCube_of_mem_inner hy
+  have hball : ball y r ⊆ cubeIco d L := ball_subset_cubeIco_of_mem_inner hy
   intro z hz
   refine ⟨z - v, hball ?_, by simp [vadd_eq_add]⟩
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
@@ -146,52 +146,52 @@ section CoordCubeCover
 
 variable (L : ℝ) (hL : 0 < L)
 
-/-- The unique lattice vector translating `x` into `coordCube d L` (see `coordCubeCover_spec`).
+/-- The unique lattice vector translating `x` into `cubeIco d L` (see `cubeIcoCover_spec`).
 The cell-assignment map underlying the pigeonhole argument; named to pair with its spec lemma. -/
-noncomputable def coordCubeCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
-  Classical.choose (coordCube_unique_covers L hL x)
+noncomputable def cubeIcoCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
+  Classical.choose (cubeIco_unique_covers L hL x)
 
-lemma coordCubeCover_spec (x : EuclideanSpace ℝ (Fin d)) :
-    coordCubeCover L hL x +ᵥ x ∈ coordCube d L :=
-  (Classical.choose_spec (coordCube_unique_covers L hL x)).1
+lemma cubeIcoCover_spec (x : EuclideanSpace ℝ (Fin d)) :
+    cubeIcoCover L hL x +ᵥ x ∈ cubeIco d L :=
+  (Classical.choose_spec (cubeIco_unique_covers L hL x)).1
 
-lemma neg_coordCubeCover_mem_ball {C R : ℝ}
-    (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
+lemma neg_cubeIcoCover_mem_ball {C R : ℝ}
+    (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
     {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
-    ((-coordCubeCover L hL x : cubeLattice d L hL) :
+    ((-cubeIcoCover L hL x : cubeLattice d L hL) :
         EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
   -- `g` is the (coerced) covering translate; the goal is `‖-g‖ = ‖g‖ < R + C`.
-  set g := (coordCubeCover L hL x : EuclideanSpace ℝ (Fin d))
-  rw [mem_ball_zero_iff, show ((-coordCubeCover L hL x : cubeLattice d L hL) :
+  set g := (cubeIcoCover L hL x : EuclideanSpace ℝ (Fin d))
+  rw [mem_ball_zero_iff, show ((-cubeIcoCover L hL x : cubeLattice d L hL) :
     EuclideanSpace ℝ (Fin d)) = -g from rfl, norm_neg]
   have hx' : ‖x‖ < R := by simpa [mem_ball_zero_iff] using hx
   have hgx : ‖g + x‖ < C := by
     simpa [mem_ball_zero_iff] using hC (by
-      simpa [Submodule.vadd_def, vadd_eq_add] using coordCubeCover_spec L hL x)
+      simpa [Submodule.vadd_def, vadd_eq_add] using cubeIcoCover_spec L hL x)
   have htri : ‖g‖ ≤ ‖g + x‖ + ‖x‖ := by
     simpa [add_sub_cancel_right] using norm_sub_le (g + x) x
   linarith
 
 end CoordCubeCover
 
-lemma card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball {L : ℝ} (hL : 0 < L)
-    {R C : ℝ} (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
+lemma card_finite_lattice_in_ball_mul_volume_cubeIco_le_volume_ball {L : ℝ} (hL : 0 < L)
+    {R C : ℝ} (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
     ((finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
-        ℝ≥0∞) * volume (coordCube d L) ≤
+        ℝ≥0∞) * volume (cubeIco d L) ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
   -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells.
   set htSet := finite_lattice_in_ball (d := d) L hL (R + C)
   have hvadd : ∀ g : ↥(cubeLattice d L hL),
-      volume (g +ᵥ coordCube d L) = volume (coordCube d L) :=
+      volume (g +ᵥ cubeIco d L) = volume (cubeIco d L) :=
     fun g => measure_vadd volume g _
-  have hms : MeasurableSet (coordCube d L) :=
-    fundamentalDomain_cubeBasis_eq_coordCube L hL ▸ fundamentalDomain_measurableSet _
-  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (coordCube d L)
-      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ coordCube d L) := by
+  have hms : MeasurableSet (cubeIco d L) :=
+    fundamentalDomain_cubeBasis_eq_cubeIco L hL ▸ fundamentalDomain_measurableSet _
+  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (cubeIco d L)
+      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ cubeIco d L) := by
         simp_rw [hvadd, Finset.sum_const, nsmul_eq_mul]
-    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ coordCube d L) := (measure_biUnion_finset
+    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ cubeIco d L) := (measure_biUnion_finset
         (fun _ _ _ _ hgh => disjoint_vadd_of_unique_covers (d := d)
-          (coordCube_unique_covers L hL) hgh)
+          (cubeIco_unique_covers L hL) hgh)
         (fun g _ => hms.const_vadd g)).symm
     _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := volume.mono <| by
         rintro y hy
@@ -210,15 +210,15 @@ def constVec (d : ℕ) (c : ℝ) : EuclideanSpace ℝ (Fin d) := WithLp.toLp 2 (
 
 @[simp] lemma constVec_apply {c : ℝ} (i : Fin d) : constVec d c i = c := rfl
 
-lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
-    ((coordCube d L \ coordCubeInner d L (1 / 2)) +
+lemma cubeIco_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
+    ((cubeIco d L \ cubeIcc d L (1 / 2)) +
         ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2))
-      ⊆ ((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-        coordCubeInner d L 1 := by
+      ⊆ ((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+        cubeIcc d L 1 := by
   rintro z ⟨x, hx, y, hy, rfl⟩
   have hyi : ∀ i : Fin d, |y i| < (1 / 2 : ℝ) := fun i =>
     (abs_coord_le_norm y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
-  rw [Set.mem_diff, mem_coordCube] at hx
+  rw [Set.mem_diff, mem_cubeIco] at hx
   refine ⟨Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => ?_, fun hz_inner => ?_⟩
   · -- Each coordinate of `x + y`, shifted by `+ 1/2`, lands in `[0, L + 1]`.
     simp only [vadd_eq_add, neg_neg, constVec_apply, PiLp.add_apply, PiLp.neg_apply,
@@ -227,10 +227,10 @@ lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
     · linarith [(hx.1 i).1, abs_lt.mp (hyi i)]
     · linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)]
   · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (1 / 2 : ℝ) (L - 1 / 2) := by
-      simpa [mem_coordCubeInner] using not_forall.mp hx.2
+      simpa [mem_cubeIcc] using not_forall.mp hx.2
     rw [Set.mem_Icc, not_and_or] at hi
     have hz_i : (x i + y i) ∈ Set.Icc (1 : ℝ) (L - 1) := by
-      simpa [mem_coordCubeInner] using hz_inner i
+      simpa [mem_cubeIcc] using hz_inner i
     obtain hi | hi := hi <;> linarith [hz_i.1, hz_i.2, abs_lt.mp (hyi i)]
 
 variable (S : SpherePacking d)
@@ -240,10 +240,10 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
     {g : cubeLattice d L hL} {s : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_centers : ∀ x ∈ s, x ∈ S.centers)
     (hs_boundary : ∀ x ∈ s,
-      x ∈ (g +ᵥ coordCube d L) \ (g +ᵥ coordCubeInner d L (1 / 2))) :
+      x ∈ (g +ᵥ cubeIco d L) \ (g +ᵥ cubeIcc d L (1 / 2))) :
     (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) ≤
-      volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-        coordCubeInner d L 1) := by
+      volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+        cubeIcc d L 1) := by
   -- `r` abbreviates the common ball radius, matching the statement's `2⁻¹`.
   let r : ℝ := (2⁻¹ : ℝ)
   have hdisj : (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x => ball x r :=
@@ -251,19 +251,19 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       dsimp [r]; linarith [show (1 : ℝ) ≤ dist x y by
         simpa [hSsep] using S.centers_dist' x y (hs_centers x hx) (hs_centers y hy) hxy])
   have hsub : (⋃ x ∈ s, ball x r) ⊆
-      g +ᵥ (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-            coordCubeInner d L 1) := fun y hy => by
+      g +ᵥ (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+            cubeIcc d L 1) := fun y hy => by
     obtain ⟨x, hxS, hyBall⟩ : ∃ x ∈ s, y ∈ ball x r := by aesop
     have hxB := hs_boundary x hxS
     -- `x0`, `y0`: pull `x`, `y` back by `-g` to the base cube (referenced repeatedly below).
     set x0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ x
     set y0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ y
-    have hxB1' : x0 ∈ coordCube d L := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
-    have hxB2' : x0 ∉ coordCubeInner d L (1 / 2) :=
+    have hxB1' : x0 ∈ cubeIco d L := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
+    have hxB2' : x0 ∉ cubeIcc d L (1 / 2) :=
       fun h => hxB.2 (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)
-    have hy0 : y0 ∈ ((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-        coordCubeInner d L 1 := by
-      apply coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
+    have hy0 : y0 ∈ ((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+        cubeIcc d L 1 := by
+      apply cubeIco_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
       refine ⟨x0, ⟨hxB1', hxB2'⟩, y0 - x0, ?_, by simp [sub_eq_add_neg, add_left_comm]⟩
       have : ‖y - x‖ < r := by simpa [Metric.mem_ball, dist_eq_norm] using hyBall
       simpa [Metric.mem_ball, dist_eq_norm, x0, y0, r] using this
@@ -272,35 +272,35 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       = volume (⋃ x ∈ s, ball x r) := by
         simpa [Measure.addHaar_ball_center, mul_comm, mul_assoc] using
           (measure_biUnion_finset (μ := volume) hdisj (fun _ _ => measurableSet_ball)).symm
-    _ ≤ volume (g +ᵥ (((constVec d (-(1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-          coordCubeInner d L 1)) := volume.mono hsub
+    _ ≤ volume (g +ᵥ (((constVec d (-(1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+          cubeIcc d L 1)) := volume.mono hsub
     _ = _ := measure_vadd volume g _
 
 end BoundaryControl
 
 lemma volume_cubeShell_eq_pow (L : ℝ) :
-    volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-        coordCubeInner d L 1) =
+    volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+        cubeIcc d L 1) =
       (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
-  have hsub : coordCubeInner d L 1 ⊆
-      (constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0 := fun x hx =>
+  have hsub : cubeIcc d L 1 ⊆
+      (constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0 := fun x hx =>
     Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => by
-      simp only [mem_coordCubeInner, constVec, vadd_eq_add, one_div,
+      simp only [mem_cubeIcc, constVec, vadd_eq_add, one_div,
         WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg] at hx ⊢
       exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
-  have hmeas : MeasurableSet (coordCubeInner d L 1) := by
-    simpa [coordCubeInner_eq_preimage_ofLp] using
+  have hmeas : MeasurableSet (cubeIcc d L 1) := by
+    simpa [cubeIcc_eq_preimage_ofLp] using
       (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
         (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
-  simpa [measure_vadd, constVec, volume_coordCubeInner] using
+  simpa [measure_vadd, constVec, volume_cubeIcc] using
     measure_diff (μ := volume) hsub hmeas.nullMeasurableSet
-      (by simp [volume_coordCubeInner])
+      (by simp [volume_cubeIcc])
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
-      (volume (coordCube d L)).toNNReal := by
-  have hcov : ZLattice.covolume (cubeLattice d L hL) volume = (volume (coordCube d L)).toReal := by
-    simpa [Measure.real, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
+      (volume (cubeIco d L)).toNNReal := by
+  have hcov : ZLattice.covolume (cubeLattice d L hL) volume = (volume (cubeIco d L)).toReal := by
+    simpa [Measure.real, fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
       ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice d L hL) (μ := volume)
         (by simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
           IsAddFundamentalDomain (cubeLattice d L hL)
@@ -311,18 +311,18 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
     {L : ℝ} (hL : 0 < L) {g : cubeLattice d L hL}
     (F : Finset (EuclideanSpace ℝ (Fin d)))
     (hF_centers : ∀ x ∈ F, x ∈ S.centers)
-    (hF_inner : ∀ x ∈ F, x ∈ g +ᵥ coordCubeInner d L (2⁻¹ : ℝ)) :
+    (hF_inner : ∀ x ∈ F, x ∈ g +ᵥ cubeIcc d L (2⁻¹ : ℝ)) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ P.density =
         (F.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
           Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) := by
   -- Assemble the periodic packing `P` from the cube cell `D` and the representatives `Fset`.
-  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ coordCube d L
+  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ cubeIco d L
   let Fset : Set (EuclideanSpace ℝ (Fin d)) := (F : Set (EuclideanSpace ℝ (Fin d)))
-  have hD_unique := PeriodicConstantApprox.coordCube_unique_covers_vadd L hL g
+  have hD_unique := PeriodicConstantApprox.cubeIco_unique_covers_vadd L hL g
   let P : PeriodicSpherePacking d :=
     periodize_to_periodicSpherePacking (d := d) S (Λ := cubeLattice d L hL) D Fset
       (hD_unique_covers := hD_unique) (hF_centers := by assumption)
-      (hF_ball := fun x hx => ball_subset_vadd_coordCube_of_mem_vadd_inner hL <| by
+      (hF_ball := fun x hx => ball_subset_vadd_cubeIco_of_mem_vadd_inner hL <| by
         simpa [hSsep] using hF_inner x (by simpa [Fset] using hx))
   have hPsep : P.separation = 1 := by simpa [P, hSsep]
   -- The translated inner cube `Fset` sits inside the translated full cube `D`.
@@ -338,7 +338,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   -- `D` is bounded, being a translate of the cube.
   have hD_bounded : IsBounded D := by
     simpa [D, Submodule.vadd_def, vadd_eq_add] using
-      (isBounded_coordCube L hL).vadd (g : EuclideanSpace ℝ (Fin d))
+      (isBounded_cubeIco L hL).vadd (g : EuclideanSpace ℝ (Fin d))
   have hnumReps : P.numReps = F.card := by
     exact_mod_cast show (P.numReps : ENat) = (F.card : ENat) by
       simpa [hPcD, Fset, Set.encard_coe_eq_coe_finsetCard] using
@@ -346,14 +346,14 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
           hD_bounded hD_unique hd).symm
   exact ⟨P, hPsep, by simpa [hnumReps, hPsep] using P.density_eq' (d := d) hd⟩
 
-/-- The cube-shell error ratio `volume(shell) / volume(coordCube d L)` tends to `0` as `L → ∞`:
+/-- The cube-shell error ratio `volume(shell) / volume(cubeIco d L)` tends to `0` as `L → ∞`:
 the shell volume grows like `(L + 1) ^ d - (L - 2) ^ d` while the cube volume grows like `L ^ d`. -/
-lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
+lemma tendsto_volume_cubeShell_div_volume_cubeIco_zero :
     Tendsto
         (fun L : ℝ =>
-          volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-              coordCubeInner d L 1) /
-            volume (coordCube d L))
+          volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+              cubeIcc d L 1) /
+            volume (cubeIco d L))
         atTop (𝓝 (0 : ℝ≥0∞)) := by
   -- `f` is the real shell/cube volume ratio, whose `→ 0` limit we transfer to `ℝ≥0∞`.
   let f : ℝ → ℝ := fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)
@@ -372,28 +372,28 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
     simpa using (ENNReal.continuous_ofReal.tendsto (0 : ℝ)).comp hf).congr' ?_
   filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
   have hL2' : 0 ≤ L - 2 := by linarith
-  have hvol : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
-    simpa using volume_coordCube L
+  have hvol : volume (cubeIco d L) = (ENNReal.ofReal L) ^ d := by
+    simpa using volume_cubeIco L
   rw [volume_cubeShell_eq_pow L, hvol,
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L + 1), ← ENNReal.ofReal_pow hL2',
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L), ← ENNReal.ofReal_sub _ (pow_nonneg hL2' d)]
   simpa [f] using ENNReal.ofReal_div_of_pos (x := (L + 1)^d - (L - 2)^d) (pow_pos (by linarith) d)
 
-/-- Pick `L > 0` and `C > 0` with `coordCube d L ⊆ ball 0 C` and the cube-shell error
-`volume(shell) / volume(coordCube)` smaller than the headroom `c - b`. -/
+/-- Pick `L > 0` and `C > 0` with `cubeIco d L ⊆ ball 0 C` and the cube-shell error
+`volume(shell) / volume(cubeIco)` smaller than the headroom `c - b`. -/
 private lemma exists_L_and_C_for_cubeShellErr_lt {b c : ℝ≥0∞} (hbc : b < c) :
     ∃ L : ℝ, 0 < L ∧ ∃ C : ℝ, 0 < C ∧
-      coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
-      volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
-          coordCubeInner d L 1) / volume (coordCube d L) < c - b := by
+      cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
+      volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
+          cubeIcc d L 1) / volume (cubeIco d L) < c - b := by
   obtain ⟨L, hLpos, hLerr⟩ := ((eventually_gt_atTop (0 : ℝ)).and
-    (tendsto_volume_cubeShell_div_volume_coordCube_zero.eventually
+    (tendsto_volume_cubeShell_div_volume_cubeIco_zero.eventually
       (Iio_mem_nhds (tsub_pos_of_lt hbc)))).exists
-  obtain ⟨C, hC⟩ : ∃ C : ℝ, coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
-    simpa using (isBounded_coordCube L hLpos).subset_ball 0
+  obtain ⟨C, hC⟩ : ∃ C : ℝ, cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
+    simpa using (isBounded_cubeIco L hLpos).subset_ball 0
   have hCpos : 0 < C := by
     simpa [Metric.mem_ball, dist_eq_norm] using
-      hC (by simp [coordCube, hLpos] : (0 : EuclideanSpace ℝ (Fin d)) ∈ coordCube d L)
+      hC (by simp [cubeIco, hLpos] : (0 : EuclideanSpace ℝ (Fin d)) ∈ cubeIco d L)
   exact ⟨L, hLpos, C, hCpos, hC, hLerr⟩
 
 /-- Given `c < S.density` and headroom `δ < c`, find `R > 0` with `c < S.finiteDensity R` and the
@@ -420,17 +420,17 @@ private lemma exists_R_finiteDensity_gt_and_ratio_gt (hd : 0 < d)
   exact (hfreq.and_eventually ((eventually_gt_atTop (0 : ℝ)).and
     (hmul.eventually (Ioi_mem_nhds hδc)))).exists
 
-/-- Pigeonhole step: among the finitely many lattice translates of `coordCube d L` meeting
+/-- Pigeonhole step: among the finitely many lattice translates of `cubeIco d L` meeting
 `ball 0 (R₁ + C)`, some translate `g0` contains at least `s.card / t.card` of the centers in
 `s = S.centers ∩ ball 0 R₁`. The resulting cell `sg ⊆ s` satisfies the volume comparison
-`s.encard * volume(coordCube) ≤ sg.card * volume(ball (R₁ + 2 * C))`. -/
+`s.encard * volume(cubeIco) ≤ sg.card * volume(ball (R₁ + 2 * C))`. -/
 private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
-    (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
+    (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
     (S : SpherePacking d) {R₁ : ℝ} (hR₁ : 0 < R₁ + C) :
     ∃ g0 : cubeLattice d L hL, ∃ sg : Finset (EuclideanSpace ℝ (Fin d)),
-      (∀ x ∈ sg, x ∈ S.centers) ∧ (∀ x ∈ sg, x ∈ g0 +ᵥ coordCube d L) ∧
+      (∀ x ∈ sg, x ∈ S.centers) ∧ (∀ x ∈ sg, x ∈ g0 +ᵥ cubeIco d L) ∧
         ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) *
-            volume (coordCube d L) ≤
+            volume (cubeIco d L) ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) := by
   have hX : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).Finite :=
     SpherePacking.finite_centers_inter_ball S R₁
@@ -439,38 +439,38 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
   let s : Finset (EuclideanSpace ℝ (Fin d)) := hX.toFinset
   let htSet := finite_lattice_in_ball (d := d) L hL (R₁ + C)
   let t : Finset (cubeLattice d L hL) := htSet.toFinset
-  let f : EuclideanSpace ℝ (Fin d) → cubeLattice d L hL := fun x => -coordCubeCover L hL x
+  let f : EuclideanSpace ℝ (Fin d) → cubeLattice d L hL := fun x => -cubeIcoCover L hL x
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := fun _ hx =>
-    htSet.mem_toFinset.2 <| neg_coordCubeCover_mem_ball L hL hC (hX.mem_toFinset.1 hx).2
+    htSet.mem_toFinset.2 <| neg_cubeIcoCover_mem_ball L hL hC (hX.mem_toFinset.1 hx).2
   obtain ⟨g0, _, hg0max⟩ := Finset.exists_max_image t (fun g => (s.filter fun x => f x = g).card)
     ⟨0, htSet.mem_toFinset.2 (by simpa only [Set.mem_setOf_eq, Metric.mem_ball,
       ZeroMemClass.coe_zero, dist_self] using hR₁)⟩
   let sg : Finset (EuclideanSpace ℝ (Fin d)) := s.filter fun x => f x = g0
   refine ⟨g0, sg, fun x hx => (hX.mem_toFinset.1 (Finset.mem_filter.1 hx).1).1,
     fun x hx => ?_, ?_⟩
-  · have h : g0 = -coordCubeCover L hL x := (Finset.mem_filter.1 hx).2.symm
+  · have h : g0 = -cubeIcoCover L hL x := (Finset.mem_filter.1 hx).2.symm
     refine h ▸ Set.mem_vadd_set_iff_neg_vadd_mem.mpr ?_
-    simpa [neg_neg] using coordCubeCover_spec L hL x
+    simpa [neg_neg] using cubeIcoCover_spec L hL x
   · have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
       have hcard : s.card ≤ t.card * sg.card := by
         simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using
           Finset.sum_le_sum hg0max
       exact_mod_cast hcard
-    have ht_vol : ((t.card : ℝ≥0∞) * volume (coordCube d L)) ≤
+    have ht_vol : ((t.card : ℝ≥0∞) * volume (cubeIco d L)) ≤
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) :=
-      card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball hL hC
+      card_finite_lattice_in_ball_mul_volume_cubeIco_le_volume_ball hL hC
     have hs_enc : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) = s.card :=
       congrArg ((↑) : ENat → ℝ≥0∞) hX.encard_eq_coe_toFinset_card
-    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume (coordCube d L)
-        = (s.card : ℝ≥0∞) * volume (coordCube d L) := by rw [hs_enc]
-      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume (coordCube d L) :=
+    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume (cubeIco d L)
+        = (s.card : ℝ≥0∞) * volume (cubeIco d L) := by rw [hs_enc]
+      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume (cubeIco d L) :=
           mul_le_mul_left hs_le _
-      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume (coordCube d L)) := by ac_rfl
+      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume (cubeIco d L)) := by ac_rfl
       _ ≤ _ := mul_le_mul_right ht_vol _
 
 /-- From the pigeonhole volume comparison, a density-ratio lower bound, and a finite-density bound,
 derive that `δ < sg.card * volBall / volCube` where `volBall = volume(ball 0 (2⁻¹))` and
-`volCube = volume(coordCube d L)`. -/
+`volCube = volume(cubeIco d L)`. -/
 private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {L : ℝ} (hL : 0 < L) {R Cshift : ℝ}
     (hRC : 0 < R + Cshift) {c δ : ℝ≥0∞} (hcR : c < S.finiteDensity R)
@@ -478,19 +478,19 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))))
     {sg : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_mul : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) *
-        volume (coordCube d L) ≤
+        volume (cubeIco d L) ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) :
     δ < (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-      volume (coordCube d L) := by
+      volume (cubeIco d L) := by
   -- Abbreviations for the three volumes appearing in the inequality chase.
-  set volCube := volume (coordCube d L)
+  set volCube := volume (cubeIco d L)
   set volBall := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
   have hvolCube_ne0 : volCube ≠ 0 := by
-    simpa [volCube, volume_coordCube L] using
+    simpa [volCube, volume_cubeIco L] using
       pow_ne_zero d (ENNReal.ofReal_pos.mpr hL).ne'
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_coordCube L hL).measure_lt_top.ne
+    (isBounded_cubeIco L hL).measure_lt_top.ne
   -- Cancelling a common factor of `volCube` from the numerator and an outer division.
   have hcancel : ∀ a c : ℝ≥0∞, a * volCube / c / volCube = a / c := fun a c => by
     simp only [div_eq_mul_inv,
@@ -515,27 +515,27 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
   simp only [div_eq_mul_inv] at this ⊢
   convert this using 1 <;> ring
 
-/-- From a finset `sg` of centers in `g0 +ᵥ coordCube d L` satisfying `sg.card * volBall / volCube`
+/-- From a finset `sg` of centers in `g0 +ᵥ cubeIco d L` satisfying `sg.card * volBall / volCube`
 exceeding some bound `δ + shellVol / volCube`, construct a periodic packing `P` with separation `1`
 and density `> δ`. The inner-cube filtering bounds the boundary contribution by `shellVol`. -/
 private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {L : ℝ} (hL : 0 < L)
     {g0 : cubeLattice d L hL} {sg : Finset (EuclideanSpace ℝ (Fin d))} {δ : ℝ≥0∞}
-    (hsg_centers : ∀ x ∈ sg, x ∈ S.centers) (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ coordCube d L)
+    (hsg_centers : ∀ x ∈ sg, x ∈ S.centers) (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ cubeIco d L)
     (hsg_density : δ + volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ
-            coordCubeInner d (L + 1) 0) \ coordCubeInner d L 1) / volume (coordCube d L) <
+            cubeIcc d (L + 1) 0) \ cubeIcc d L 1) / volume (cubeIco d L) <
         (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-          volume (coordCube d L)) :
+          volume (cubeIco d L)) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ δ < P.density := by
   -- Abbreviations for the shell, cube, and unit-ball volumes used in the density bound.
   set shellVol : ℝ≥0∞ := volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ
-      coordCubeInner d (L + 1) 0) \ coordCubeInner d L 1)
-  set volCube : ℝ≥0∞ := volume (coordCube d L)
+      cubeIcc d (L + 1) 0) \ cubeIcc d L 1)
+  set volCube : ℝ≥0∞ := volume (cubeIco d L)
   set volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_coordCube L hL).measure_lt_top.ne
+    (isBounded_cubeIco L hL).measure_lt_top.ne
   -- Split `sg` by the inner cube: `F` (kept representatives) and `sb` (boundary, bounded by shell).
-  let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ coordCubeInner d L (1 / 2 : ℝ)
+  let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ cubeIcc d L (1 / 2 : ℝ)
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
   let sb : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∉ innerSet

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -145,37 +145,64 @@ public lemma ball_subset_vadd_cubeIco_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
   simpa [mem_ball, dist_eq_norm, sub_sub] using hz
 
-section CoordCubeCover
+section FundamentalDomainCover
+
+variable (b : Module.Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)))
+
+/-- The unique lattice vector translating `x` into `fundamentalDomain b`, for an arbitrary basis
+`b` (see `fundamentalDomainCover_spec`). The cell-assignment map underlying the pigeonhole argument;
+generic over the basis — no cube or coordinate structure is used. -/
+noncomputable def fundamentalDomainCover (x : EuclideanSpace ℝ (Fin d)) :
+    Submodule.span ℤ (Set.range b) :=
+  Classical.choose (ZSpan.exist_unique_vadd_mem_fundamentalDomain b x)
+
+lemma fundamentalDomainCover_spec (x : EuclideanSpace ℝ (Fin d)) :
+    fundamentalDomainCover b x +ᵥ x ∈ fundamentalDomain b :=
+  (Classical.choose_spec (ZSpan.exist_unique_vadd_mem_fundamentalDomain b x)).1
+
+lemma neg_fundamentalDomainCover_mem_ball {C R : ℝ}
+    (hC : fundamentalDomain b ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
+    {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
+    ((-fundamentalDomainCover b x : Submodule.span ℤ (Set.range b)) :
+        EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
+  -- `g` is the (coerced) covering translate; the goal is `‖-g‖ = ‖g‖ < R + C`.
+  set g := (fundamentalDomainCover b x : EuclideanSpace ℝ (Fin d))
+  rw [mem_ball_zero_iff, show ((-fundamentalDomainCover b x : Submodule.span ℤ (Set.range b)) :
+    EuclideanSpace ℝ (Fin d)) = -g from rfl, norm_neg]
+  have hx' : ‖x‖ < R := by simpa [mem_ball_zero_iff] using hx
+  have hgx : ‖g + x‖ < C := by
+    simpa [mem_ball_zero_iff] using hC (by
+      simpa [Submodule.vadd_def, vadd_eq_add] using fundamentalDomainCover_spec b x)
+  have htri : ‖g‖ ≤ ‖g + x‖ + ‖x‖ := by
+    simpa [add_sub_cancel_right] using norm_sub_le (g + x) x
+  linarith
+
+end FundamentalDomainCover
+
+section CubeCover
 
 variable (L : ℝ) (hL : 0 < L)
 
-/-- The unique lattice vector translating `x` into `cubeIco d L` (see `cubeIcoCover_spec`).
-The cell-assignment map underlying the pigeonhole argument; named to pair with its spec lemma. -/
+/-- The cube cell-assignment map: `fundamentalDomainCover` specialised to the scaled-cube basis.
+A thin wrapper so the pigeonhole argument reads in cube terms (`fundamentalDomain (cubeBasis …) =
+cubeIco`). -/
 noncomputable def cubeIcoCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
-  Classical.choose (cubeIco_unique_covers L hL x)
+  fundamentalDomainCover (cubeBasis d L hL) x
 
 lemma cubeIcoCover_spec (x : EuclideanSpace ℝ (Fin d)) :
-    cubeIcoCover L hL x +ᵥ x ∈ cubeIco d L :=
-  (Classical.choose_spec (cubeIco_unique_covers L hL x)).1
+    cubeIcoCover L hL x +ᵥ x ∈ cubeIco d L := by
+  rw [← fundamentalDomain_cubeBasis_eq_cubeIco L hL]
+  exact fundamentalDomainCover_spec (cubeBasis d L hL) x
 
 lemma neg_cubeIcoCover_mem_ball {C R : ℝ}
     (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
     {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
     ((-cubeIcoCover L hL x : cubeLattice d L hL) :
         EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
-  -- `g` is the (coerced) covering translate; the goal is `‖-g‖ = ‖g‖ < R + C`.
-  set g := (cubeIcoCover L hL x : EuclideanSpace ℝ (Fin d))
-  rw [mem_ball_zero_iff, show ((-cubeIcoCover L hL x : cubeLattice d L hL) :
-    EuclideanSpace ℝ (Fin d)) = -g from rfl, norm_neg]
-  have hx' : ‖x‖ < R := by simpa [mem_ball_zero_iff] using hx
-  have hgx : ‖g + x‖ < C := by
-    simpa [mem_ball_zero_iff] using hC (by
-      simpa [Submodule.vadd_def, vadd_eq_add] using cubeIcoCover_spec L hL x)
-  have htri : ‖g‖ ≤ ‖g + x‖ + ‖x‖ := by
-    simpa [add_sub_cancel_right] using norm_sub_le (g + x) x
-  linarith
+  refine neg_fundamentalDomainCover_mem_ball (cubeBasis d L hL) ?_ hx
+  rwa [fundamentalDomain_cubeBasis_eq_cubeIco]
 
-end CoordCubeCover
+end CubeCover
 
 lemma card_finite_lattice_in_ball_mul_volume_cubeIco_le_volume_ball {L : ℝ} (hL : 0 < L)
     {R C : ℝ} (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -925,7 +925,7 @@ private lemma lattice_translate_eq_zero (hD_unique_covers : ∀ x, ∃! g : P.la
   simpa using neg_eq_zero.mp ((hg0_unique (-ℓ) hyℓ).trans (hg0_unique 0 hy0).symm)
 
 /-- If `x + ℓ ≠ y` as centers in `P`, then `f` evaluated on the shifted difference is `≤ 0`. -/
-private lemma re_f_shifted_nonpos (hP : P.separation = 1)
+private lemma re_f_sub_add_lattice_nonpos (hP : P.separation = 1)
     (hCohnElkies₁ : ∀ x : EuclideanSpace ℝ (Fin d), ‖x‖ ≥ 1 → (f x).re ≤ 0)
     {x y : EuclideanSpace ℝ (Fin d)} (hx : x ∈ P.centers) (hy : y ∈ P.centers) (ℓ : P.lattice)
     (hxℓy : x + (ℓ : EuclideanSpace ℝ (Fin d)) ≠ y) :
@@ -957,7 +957,7 @@ private lemma lattice_sum_re_le_ite_diag (hP : P.separation = 1)
         (x : EuclideanSpace ℝ (Fin d)) :=
       fun h => hℓ (lattice_translate_eq_zero hD_unique_covers h)
     simpa [hℓ, sub_self, zero_add] using
-      re_f_shifted_nonpos hP hCohnElkies₁ x.property.1 x.property.1 ℓ hxℓ
+      re_f_sub_add_lattice_nonpos hP hCohnElkies₁ x.property.1 x.property.1 ℓ hxℓ
   simpa [hs.tsum_eq_add_tsum_ite (0 : P.lattice)] using add_le_add_left htail (f 0).re
 
 public lemma lattice_sum_re_le_ite (hP : P.separation = 1)
@@ -973,7 +973,7 @@ public lemma lattice_sum_re_le_ite (hP : P.separation = 1)
     simpa [sub_self, zero_add] using
       lattice_sum_re_le_ite_diag (P := P) hP hD_unique_covers hCohnElkies₁ x
   · rw [if_neg hxy]
-    refine tsum_nonpos fun ℓ => re_f_shifted_nonpos hP hCohnElkies₁
+    refine tsum_nonpos fun ℓ => re_f_sub_add_lattice_nonpos hP hCohnElkies₁
       x.property.1 y.property.1 ℓ (fun h => ?_)
     -- From `↑x + ↑ℓ = ↑y` we get `ℓ = 0`, hence `↑x = ↑y`, contradicting `x ≠ y`.
     have hℓ : ℓ = 0 := lattice_translate_eq_zero hD_unique_covers h
@@ -1104,7 +1104,7 @@ private lemma re_mul_conj_eq_norm_sq_step {d : ℕ}
 
 
 include d f hP hRealFourier hCohnElkies₁ hD_unique_covers in
-theorem calc_steps_part1 (hd : 0 < d) :
+theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
     ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥
       (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
@@ -1163,7 +1163,7 @@ theorem calc_steps_part1 (hd : 0 < d) :
         re_mul_conj_eq_norm_sq_step P f
 
 include d f hCohnElkies₂ in omit [Nonempty ↑P.centers] in
-theorem calc_steps_part2 (hd : 0 < d) :
+theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
     (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
           (𝓕 ⇑f m).re *
@@ -1275,7 +1275,7 @@ include d f hne_zero hReal hRealFourier hCohnElkies₁ hCohnElkies₂ P hP D hD_
   hD_unique_covers
 
 /-- Linear programming bound for a single periodic packing of separation `1`. -/
-public theorem LinearProgrammingBound' (hd : 0 < d) :
+public theorem LinearProgrammingBound_periodic (hd : 0 < d) :
     P.density ≤ (f 0).re.toNNReal / (𝓕 f 0).re.toNNReal *
       volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) := by
   haveI : Fact (0 < d) := ⟨hd⟩
@@ -1292,8 +1292,10 @@ public theorem LinearProgrammingBound' (hd : 0 < d) :
       (nonempty_quotient_iff _).2 ‹_›
     exact density_le_of_hCalc_of_ne_zero (P := P) hRealFourier hCohnElkies₂
       (ZLattice.covolume_pos P.lattice volume) h𝓕f hCalc
-  exact ge_trans (calc_steps_part1 (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
-    hD_unique_covers hd) (calc_steps_part2 (P := P) (D := D) (hCohnElkies₂ := hCohnElkies₂)
+  exact ge_trans
+    (numReps_mul_re_f_zero_ge (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
+      hD_unique_covers hd)
+    (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D) (hCohnElkies₂ := hCohnElkies₂)
       hD_isBounded hd)
 
 end Fundamental_Domain_Dependent
@@ -1309,7 +1311,7 @@ public theorem LinearProgrammingBound (hd : 0 < d) : SpherePackingConstant d ≤
   refine iSup_le fun P => iSup_le fun hP => ?_
   rcases isEmpty_or_nonempty ↑P.centers with _ | _
   · simp [P.density_of_centers_empty hd]
-  exact LinearProgrammingBound' hne_zero hReal hRealFourier hCohnElkies₁ hCohnElkies₂ hP
+  exact LinearProgrammingBound_periodic hne_zero hReal hRealFourier hCohnElkies₁ hCohnElkies₂ hP
     (ZSpan.fundamentalDomain_isBounded _) (PeriodicSpherePacking.fundamental_domain_unique_covers
       (S := P) (((ZLattice.module_free ℝ P.lattice).chooseBasis).reindex
         (PeriodicSpherePacking.basis_index_equiv P))) hd

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,34 +4,32 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
+public import Mathlib.Algebra.Module.Submodule.Basic
+public import Mathlib.Algebra.Module.ZLattice.Basic
+public import Mathlib.Algebra.Module.ZLattice.Covolume
+public import Mathlib.Algebra.Module.ZLattice.Summable
+public import Mathlib.Analysis.CStarAlgebra.Classes
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.Complex.Trigonometric
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import Mathlib.Analysis.RCLike.Inner
+public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
 public import Mathlib.Logic.Function.Basic
 public import Mathlib.Logic.Relator
 public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 public import Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus
 public import Mathlib.MeasureTheory.Integral.Bochner.Set
-public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Analysis.Complex.Trigonometric
-
-public import Mathlib.Algebra.Module.ZLattice.Basic
-public import Mathlib.Algebra.Module.ZLattice.Covolume
-public import Mathlib.Algebra.Module.ZLattice.Summable
-public import Mathlib.Algebra.Module.Submodule.Basic
-public import Mathlib.Analysis.CStarAlgebra.Classes
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
-public import Mathlib.Analysis.RCLike.Inner
-public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
+public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 public import Mathlib.Order.CompletePartialOrder
 public import Mathlib.Order.Filter.Cofinite
 public import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 public import Mathlib.Topology.Algebra.InfiniteSum.Real
-public import Mathlib.Topology.Metrizable.Basic
 public import Mathlib.Topology.Compactness.Lindelof
 public import Mathlib.Topology.EMetricSpace.Paracompact
+public import Mathlib.Topology.Metrizable.Basic
 public import Mathlib.Topology.Separation.CompletelyRegular
-
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
-public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 import Mathlib.Combinatorics.Pigeonhole
 
 /-!
@@ -51,22 +49,16 @@ open SpherePacking EuclideanSpace MeasureTheory Metric ZSpan Bornology Module Fi
 variable {d : ℕ}
 
 /-- Any coordinate of a vector is bounded in absolute value by the Euclidean norm. -/
-public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x i| ≤ ‖x‖ := by
-  rw [EuclideanSpace.norm_eq, ← Real.sqrt_sq_eq_abs]
-  exact Real.sqrt_le_sqrt (by
-    have hsq : (x.ofLp i) ^ 2 = ‖x.ofLp i‖ ^ 2 := by rw [Real.norm_eq_abs, sq_abs]
-    rw [hsq]
-    exact Finset.single_le_sum (f := fun j : Fin d => ‖x.ofLp j‖ ^ 2)
-      (fun _ _ => sq_nonneg _) (Finset.mem_univ i))
+public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x i| ≤ ‖x‖ :=
+  PiLp.norm_apply_le x i
 
 /-- If `ball x r ⊆ A` and `ball y r ⊆ B` with `A` and `B` disjoint, then `2 * r ≤ dist x y`. -/
 public lemma dist_le_of_disjoint_ball_subsets {x y : EuclideanSpace ℝ (Fin d)} {r : ℝ}
     {A B : Set (EuclideanSpace ℝ (Fin d))}
     (hx : ball x r ⊆ A) (hy : ball y r ⊆ B) (hAB : Disjoint A B) : 2 * r ≤ dist x y := by
-  by_contra hlt
-  refine Set.disjoint_left.1 hAB (hx (a := midpoint ℝ x y) ?_) (hy (a := midpoint ℝ x y) ?_) <;>
-    simpa [Metric.mem_ball, dist_comm] using
-      (by nlinarith [lt_of_not_ge hlt] : (1 / 2 : ℝ) * dist x y < r)
+  obtain hr | hr := le_or_gt r 0
+  · linarith [dist_nonneg (x := x) (y := y)]
+  · simpa [two_mul] using (disjoint_ball_ball_iff hr hr).1 (hAB.mono hx hy)
 
 /-- The union of all lattice translates of a set `F` of representatives. -/
 @[expose] public noncomputable def periodizedCenters (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d)))
@@ -83,17 +75,15 @@ public lemma periodizedCenters_lattice_action {Λ : Submodule ℤ (EuclideanSpac
     {F : Set (EuclideanSpace ℝ (Fin d))} {x y : EuclideanSpace ℝ (Fin d)}
     (hx : x ∈ Λ) (hy : y ∈ periodizedCenters (d := d) Λ F) :
     x + y ∈ periodizedCenters (d := d) Λ F := by
-  rcases mem_periodizedCenters_iff.1 hy with ⟨g, f, hf, rfl⟩
-  exact mem_periodizedCenters_iff.2
-    ⟨⟨x, hx⟩ + g, f, hf, by simp [Submodule.vadd_def, vadd_eq_add, add_assoc]⟩
+  obtain ⟨g, f, hf, rfl⟩ := mem_periodizedCenters_iff.1 hy
+  exact mem_periodizedCenters_iff.2 ⟨⟨x, hx⟩ + g, f, hf, (add_assoc x g f).symm⟩
 
 /-- Translating a ball by a lattice vector stays inside the translate of the ambient set. -/
 public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))}
     {D : Set (EuclideanSpace ℝ (Fin d))} {r : ℝ} {g : Λ} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : ball x r ⊆ D) : ball (g +ᵥ x) r ⊆ g +ᵥ D := fun y hy =>
-  ⟨(- (g : EuclideanSpace ℝ (Fin d))) +ᵥ y, hx <| by
-    simpa [Metric.mem_ball, dist_eq_norm, Submodule.vadd_def, vadd_eq_add, sub_eq_add_neg,
-      add_assoc, add_comm, add_left_comm] using hy, by simp [vadd_eq_add]⟩
+    (hx : ball x r ⊆ D) : ball (g +ᵥ x) r ⊆ g +ᵥ D := by
+  rw [Submodule.vadd_def, ← vadd_ball]
+  exact Set.vadd_set_mono hx
 
 /-- Construct a periodic sphere packing by translating a set of representatives `F ⊆ S.centers`
 along a lattice `Λ`. -/
@@ -135,8 +125,7 @@ along a lattice `Λ`. -/
 /-- A scaled basis used to realize `coordCube L` as a fundamental domain. -/
 @[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
     Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
-  ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).isUnitSMul
-    (fun _ : Fin d ↦ IsUnit.mk0 L (ne_of_gt hL))
+  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
 
 /-- The lattice generated by `cubeBasis L hL`. -/
 @[expose] public noncomputable def cubeLattice (d : ℕ) (L : ℝ) (hL : 0 < L) :
@@ -144,89 +133,87 @@ along a lattice `Λ`. -/
   Submodule.span ℤ (Set.range (cubeBasis d L hL))
 
 instance instDiscreteTopology_cubeLattice (L : ℝ) (hL : 0 < L) :
-    DiscreteTopology (cubeLattice d L hL) := by
-  change DiscreteTopology (Submodule.span ℤ (Set.range (cubeBasis d L hL)))
-  infer_instance
+    DiscreteTopology (cubeLattice d L hL) :=
+  inferInstanceAs (DiscreteTopology (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
 
 instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
-    IsZLattice ℝ (cubeLattice d L hL) := by dsimp [cubeLattice]; infer_instance
+    IsZLattice ℝ (cubeLattice d L hL) :=
+  inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
 
+/-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
 public lemma fundamentalDomain_cubeBasis_eq_coordCube (L : ℝ) (hL : 0 < L) :
     fundamentalDomain (cubeBasis d L hL) = coordCube d L := by
   ext x
   simp only [ZSpan.mem_fundamentalDomain, coordCube, cubeBasis, Module.Basis.repr_isUnitSMul,
-    Units.smul_def, Units.val_inv_eq_inv_val, Set.mem_setOf_eq, Set.mem_Ico]
-  refine ⟨fun hx i => ?_, fun hx i => ?_⟩ <;> specialize hx i
-  · exact ⟨by simpa [mul_inv_cancel₀ hL.ne'] using
-        (by simpa [mul_assoc] using mul_nonneg hL.le hx.1 : 0 ≤ (L * L⁻¹) * x.ofLp i),
-      by simpa [mul_inv_cancel₀ hL.ne'] using
-        (by simpa [mul_assoc] using mul_lt_mul_of_pos_left hx.2 hL :
-          (L * L⁻¹) * x.ofLp i < (L : ℝ) * 1)⟩
-  · exact ⟨mul_nonneg (inv_pos.mpr hL).le hx.1, by
-      simpa [mul_assoc, inv_mul_cancel₀ hL.ne'] using
-        mul_lt_mul_of_pos_left hx.2 (inv_pos.mpr hL)⟩
+    Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
+    OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
+    Set.mem_Ico]
+  exact forall_congr' fun i =>
+    and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
 
+/-- A ball of radius `r` centred in the inner cube `[r, L-r]^d` is contained in `[0, L)^d`. -/
 lemma ball_subset_coordCube_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
     (hx : x ∈ coordCubeInner d L r) : ball x r ⊆ coordCube d L := fun y hy i => by
-  have hsub := abs_lt.mp <| lt_of_le_of_lt (by simpa using abs_coord_le_norm (d := d) (y - x) i :
-    |y i - x i| ≤ ‖y - x‖)
-    (by simpa [Metric.mem_ball, dist_eq_norm, dist_comm] using hy : ‖y - x‖ < r)
-  refine ⟨?_, ?_⟩ <;> linarith [(hx i).1, (hx i).2, hsub.1, hsub.2]
+  have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using abs_coord_le_norm (y - x) i
+  have h₂ : ‖y - x‖ < r := by simpa [dist_eq_norm] using hy
+  obtain ⟨hlo, hhi⟩ := abs_lt.mp (h₁.trans_lt h₂)
+  obtain ⟨hxl, hxr⟩ := hx i
+  exact ⟨by linarith, by linarith⟩
 
+/-- If `F ⊆ D` and every point has a unique lattice translate landing in `D`, then intersecting
+the periodization of `F` with `D` recovers exactly `F`. -/
 public lemma periodizedCenters_inter_eq_of_subset {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))}
     {D F : Set (EuclideanSpace ℝ (Fin d))}
     (hF_sub : F ⊆ D) (hD_unique_covers : ∀ x, ∃! g : Λ, g +ᵥ x ∈ D) :
     periodizedCenters (d := d) Λ F ∩ D = F := by
   ext x
-  have zvadd : ∀ y : EuclideanSpace ℝ (Fin d), (0 : ↥Λ) +ᵥ y = y := fun y => zero_vadd _ _
-  refine ⟨?_, fun hxF => ⟨mem_periodizedCenters_iff.2 ⟨0, x, hxF, (zvadd x).symm⟩, hF_sub hxF⟩⟩
-  rintro ⟨⟨_, ⟨g, rfl⟩, ⟨f, hfF, rfl⟩⟩, hxD⟩
-  obtain ⟨_, _, hg0uniq⟩ := hD_unique_covers f
-  have hg0g : g = 0 := by
-    have h1 : (fun g ↦ g +ᵥ f ∈ D) g := hxD
-    have h2 : (fun g ↦ g +ᵥ f ∈ D) (0 : ↥Λ) := by
-      change (0 : ↥Λ) +ᵥ f ∈ D
-      rw [zvadd]; exact hF_sub hfF
-    exact (hg0uniq g h1).trans (hg0uniq 0 h2).symm
-  rw [hg0g]
-  change (0 : ↥Λ) +ᵥ f ∈ F
-  rw [zvadd]
-  exact hfF
+  refine ⟨?_, fun hxF ↦
+    ⟨mem_periodizedCenters_iff.2 ⟨0, x, hxF, (zero_vadd _ x).symm⟩, hF_sub hxF⟩⟩
+  rintro ⟨hxP, hxD⟩
+  obtain ⟨g, f, hfF, rfl⟩ := mem_periodizedCenters_iff.1 hxP
+  obtain ⟨g₀, -, huniq⟩ := hD_unique_covers f
+  have hg : g = 0 := (huniq g hxD).trans (huniq 0 (by simpa using hF_sub hfF)).symm
+  simpa [hg] using hfF
 
 namespace PeriodicConstant
 
 private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet s) :
-    volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s := by
-  simpa using (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
+    volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s :=
+  (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
 
+/-- Every point has a unique `cubeLattice` translate lying in the cube `coordCube d L`. -/
 public lemma coordCube_unique_covers (L : ℝ) (hL : 0 < L) :
     ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ coordCube d L := fun x => by
   simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
+/-- The cube `coordCube d L` is a bounded set. -/
 public lemma isBounded_coordCube (L : ℝ) (hL : 0 < L) : IsBounded (coordCube d L) := by
   simpa [fundamentalDomain_cubeBasis_eq_coordCube L hL] using
     fundamentalDomain_isBounded (cubeBasis d L hL)
 
+/-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
 public lemma volume_coordCube (L : ℝ) : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
-  rw [show coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-        (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) from
-      Set.ext fun x => by simp [coordCube, Set.mem_pi],
-    volume_preimage_ofLp _
-      (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico), volume_pi, Measure.pi_pi]
+  have hcube : coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
+      (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
+    ext x; simp [coordCube, Set.mem_pi]
+  rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
+    volume_pi, Measure.pi_pi]
   simp [Real.volume_Ico, sub_zero]
 
+/-- `coordCubeInner d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
 public lemma coordCubeInner_eq_preimage_ofLp (L r : ℝ) :
     coordCubeInner d L r =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
         (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
   ext x; simp [coordCubeInner, Pi.le_def, forall_and]
 
+/-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
 public lemma volume_coordCubeInner (L r : ℝ) :
     volume (coordCubeInner d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
   rw [coordCubeInner_eq_preimage_ofLp, volume_preimage_ofLp _
     (.pi Set.countable_univ fun _ _ ↦ measurableSet_Icc), volume_pi, Measure.pi_pi]
-  simp [Real.volume_Icc, sub_eq_add_neg, add_left_comm, add_comm, two_mul]
+  simp [Real.volume_Icc, show L - r - r = L - 2 * r by ring]
 
 end PeriodicConstant
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -29,9 +29,10 @@ variable {d : ℕ}
 public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x i| ≤ ‖x‖ :=
   PiLp.norm_apply_le x i
 
-/-- If `ball x r ⊆ A` and `ball y r ⊆ B` with `A` and `B` disjoint, then `2 * r ≤ dist x y`. -/
-public lemma dist_le_of_disjoint_ball_subsets {x y : EuclideanSpace ℝ (Fin d)} {r : ℝ}
-    {A B : Set (EuclideanSpace ℝ (Fin d))}
+/-- If `ball x r ⊆ A` and `ball y r ⊆ B` with `A` and `B` disjoint, then `2 * r ≤ dist x y`. Holds
+in any real normed space. -/
+public lemma dist_le_of_disjoint_ball_subsets {V : Type*} [SeminormedAddCommGroup V]
+    [NormedSpace ℝ V] {x y : V} {r : ℝ} {A B : Set V}
     (hx : ball x r ⊆ A) (hy : ball y r ⊆ B) (hAB : Disjoint A B) : 2 * r ≤ dist x y := by
   by_cases hr : 0 < r
   · simpa [two_mul] using (disjoint_ball_ball_iff hr hr).1 (hAB.mono hx hy)
@@ -729,20 +730,15 @@ section Integration
 
 open MeasureTheory Filter
 
-variable {E : Type*} [TopologicalSpace E] [AddGroup E] [IsTopologicalAddGroup E]
-  [MeasureSpace E] [BorelSpace E]
-variable [(volume : Measure E).IsAddLeftInvariant] [(volume : Measure E).Regular]
-  [NeZero (volume : Measure E)]
-
-instance : (volume : Measure E).IsOpenPosMeasure := isOpenPosMeasure_of_addLeftInvariant_of_regular
-
 /-- If `f` is continuous, integrable, and pointwise nonnegative, then `∫ f = 0` iff `f = 0`.
-This uses that an additive-invariant regular measure is positive on nonempty open sets. -/
-public theorem Continuous.integral_zero_iff_zero_of_nonneg {f : E → ℝ} (hf₁ : Continuous f)
-    (hf₂ : Integrable f) (hnn : ∀ x, 0 ≤ f x) : ∫ (v : E), f v = 0 ↔ f = 0 := by
+The only requirement on the measure is that it is positive on nonempty open sets
+(`IsOpenPosMeasure`); no group or invariance structure is needed. -/
+public theorem Continuous.integral_zero_iff_zero_of_nonneg {E : Type*} [TopologicalSpace E]
+    [MeasurableSpace E] {μ : Measure E} [μ.IsOpenPosMeasure] {f : E → ℝ} (hf₁ : Continuous f)
+    (hf₂ : Integrable f μ) (hnn : ∀ x, 0 ≤ f x) : ∫ (v : E), f v ∂μ = 0 ↔ f = 0 := by
   refine ⟨fun hintf => funext fun x => ?_, fun hf => by simp [hf]⟩
   by_contra hx
-  exact (MeasureTheory.Measure.measure_pos_of_mem_nhds volume
+  exact (MeasureTheory.Measure.measure_pos_of_mem_nhds μ
       ((isOpen_lt continuous_const hf₁).mem_nhds (lt_of_le_of_ne (hnn x) (Ne.symm hx)))).ne'
     (measure_mono_null (fun (y : E) (hy : 0 < f y) => hy.ne')
       ((integral_eq_zero_iff_of_nonneg hnn hf₂).1 hintf))

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib
-
+public import Mathlib.Algebra.Ring.IsFormallyReal
+public import Mathlib.Dynamics.Ergodic.Action.Regular
+public import Mathlib.Order.CompletePartialOrder
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,33 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib.Algebra.Module.Submodule.Basic
-public import Mathlib.Algebra.Module.ZLattice.Basic
-public import Mathlib.Algebra.Module.ZLattice.Covolume
-public import Mathlib.Algebra.Module.ZLattice.Summable
-public import Mathlib.Analysis.CStarAlgebra.Classes
-public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Analysis.Complex.Trigonometric
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
-public import Mathlib.Analysis.RCLike.Inner
-public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
-public import Mathlib.Logic.Function.Basic
-public import Mathlib.Logic.Relator
-public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
-public import Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus
-public import Mathlib.MeasureTheory.Integral.Bochner.Set
-public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
-public import Mathlib.Order.CompletePartialOrder
-public import Mathlib.Order.Filter.Cofinite
-public import Mathlib.Topology.Algebra.InfiniteSum.Constructions
-public import Mathlib.Topology.Algebra.InfiniteSum.Real
-public import Mathlib.Topology.Compactness.Lindelof
-public import Mathlib.Topology.EMetricSpace.Paracompact
-public import Mathlib.Topology.Metrizable.Basic
-public import Mathlib.Topology.Separation.CompletelyRegular
+public import Mathlib
+
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
-import Mathlib.Combinatorics.Pigeonhole
 
 /-!
 # Cohn-Elkies linear programming bound
@@ -56,11 +33,12 @@ public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x
 public lemma dist_le_of_disjoint_ball_subsets {x y : EuclideanSpace ℝ (Fin d)} {r : ℝ}
     {A B : Set (EuclideanSpace ℝ (Fin d))}
     (hx : ball x r ⊆ A) (hy : ball y r ⊆ B) (hAB : Disjoint A B) : 2 * r ≤ dist x y := by
-  obtain hr | hr := le_or_gt r 0
-  · linarith [dist_nonneg (x := x) (y := y)]
+  by_cases hr : 0 < r
   · simpa [two_mul] using (disjoint_ball_ball_iff hr hr).1 (hAB.mono hx hy)
+  · linarith [dist_nonneg (x := x) (y := y)]
 
-/-- The union of all lattice translates of a set `F` of representatives. -/
+/-- The union of all lattice translates `⋃ g : Λ, g +ᵥ F` of representatives `F`. Standalone as
+the centre set of `periodize_to_periodicSpherePacking`, with its own membership/closure API. -/
 @[expose] public noncomputable def periodizedCenters (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d)))
     (F : Set (EuclideanSpace ℝ (Fin d))) : Set (EuclideanSpace ℝ (Fin d)) := ⋃ g : Λ, g +ᵥ F
 
@@ -85,8 +63,8 @@ public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin 
   rw [Submodule.vadd_def, ← vadd_ball]
   exact Set.vadd_set_mono hx
 
-/-- Construct a periodic sphere packing by translating a set of representatives `F ⊆ S.centers`
-along a lattice `Λ`. -/
+/-- The periodic packing obtained by translating representatives `F ⊆ S.centers` along a lattice
+`Λ`. The core construction turning a finite cell into a `PeriodicSpherePacking`. -/
 @[expose] public noncomputable def periodize_to_periodicSpherePacking
     (S : SpherePacking d)
     (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ] [IsZLattice ℝ Λ]
@@ -97,37 +75,48 @@ along a lattice `Λ`. -/
   separation := S.separation
   separation_pos := S.separation_pos
   centers_dist := fun a b hab => by
-    change S.separation ≤ dist (a : EuclideanSpace ℝ (Fin d)) (b : EuclideanSpace ℝ (Fin d))
-    rcases mem_periodizedCenters_iff.1 a.property with ⟨ga, fa, hfa, ha⟩
-    rcases mem_periodizedCenters_iff.1 b.property with ⟨gb, fb, hfb, hb⟩
+    obtain ⟨ga, fa, hfa, ha⟩ := mem_periodizedCenters_iff.1 a.property
+    obtain ⟨gb, fb, hfb, hb⟩ := mem_periodizedCenters_iff.1 b.property
+    change S.separation ≤ dist (a : EuclideanSpace ℝ (Fin d)) b
+    rw [ha, hb]
     by_cases hgg : ga = gb
     · subst hgg
-      simpa [ha, hb] using (dist_vadd_cancel_left (ga : EuclideanSpace ℝ (Fin d)) fa fb).symm ▸
-        S.centers_dist' fa fb (hF_centers hfa) (hF_centers hfb)
-          (fun h => hab <| Subtype.ext <| by simp [ha, hb, h])
-    · simpa [ha, hb, two_mul, add_halves] using dist_le_of_disjoint_ball_subsets
+      simp only [Submodule.vadd_def, dist_vadd_cancel_left]
+      exact S.centers_dist' fa fb (hF_centers hfa) (hF_centers hfb)
+        fun h => hab <| Subtype.ext <| by rw [ha, hb, h]
+    · have hdist := dist_le_of_disjoint_ball_subsets
         (ball_vadd_subset_vadd (hF_ball fa hfa)) (ball_vadd_subset_vadd (hF_ball fb hfb))
         (disjoint_vadd_of_unique_covers (D := D) hD_unique_covers hgg)
+      linarith [add_halves S.separation]
   lattice := Λ
   lattice_action := fun _ _ ↦ periodizedCenters_lattice_action
   lattice_discrete := inferInstance
   lattice_isZLattice := inferInstance
 
-/-- The coordinate cube `[0,L)^d` as a set in `EuclideanSpace`. -/
+/-- The half-open coordinate cube `[0, L)^d`. Used pervasively as the fundamental domain of
+`cubeLattice`; its membership API is `mem_coordCube`. -/
 @[expose] public def coordCube (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
   {x | ∀ i : Fin d, x i ∈ Set.Ico (0 : ℝ) L}
 
-/-- The "inner cube" `[r, L-r]^d` (closed intervals) used to keep radius-`r` balls inside
-`coordCube L`. -/
+@[simp] public lemma mem_coordCube {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ coordCube d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
+
+/-- The closed inner cube `[r, L-r]^d`, the locus where a radius-`r` ball stays inside
+`coordCube L`. Membership API: `mem_coordCubeInner`. -/
 @[expose] public def coordCubeInner (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
   {x | ∀ i : Fin d, x i ∈ Set.Icc r (L - r)}
 
-/-- A scaled basis used to realize `coordCube L` as a fundamental domain. -/
+@[simp] public lemma mem_coordCubeInner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ coordCubeInner d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
+
+/-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
+its fundamental domain is `coordCube d L` (`fundamentalDomain_cubeBasis_eq_coordCube`). -/
 @[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
     Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
   (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
 
-/-- The lattice generated by `cubeBasis L hL`. -/
+/-- The cubic lattice `L • ℤ^d`, spanned by `cubeBasis d L hL`. Standalone so it can carry
+`ZLattice`/`DiscreteTopology` instances and act as the period lattice of the cube packing. -/
 @[expose] public noncomputable def cubeLattice (d : ℕ) (L : ℝ) (hL : 0 < L) :
     Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
   Submodule.span ℤ (Set.range (cubeBasis d L hL))
@@ -196,7 +185,7 @@ public lemma isBounded_coordCube (L : ℝ) (hL : 0 < L) : IsBounded (coordCube d
 public lemma volume_coordCube (L : ℝ) : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
   have hcube : coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
       (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
-    ext x; simp [coordCube, Set.mem_pi]
+    ext x; simp [mem_coordCube, Set.mem_pi]
   rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
     volume_pi, Measure.pi_pi]
   simp [Real.volume_Ico, sub_zero]
@@ -206,7 +195,7 @@ public lemma coordCubeInner_eq_preimage_ofLp (L r : ℝ) :
     coordCubeInner d L r =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
         (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
-  ext x; simp [coordCubeInner, Pi.le_def, forall_and]
+  ext x; simp [mem_coordCubeInner, Pi.le_def, forall_and]
 
 /-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
 public lemma volume_coordCubeInner (L r : ℝ) :
@@ -238,8 +227,7 @@ public lemma ball_subset_vadd_coordCube_of_mem_vadd_inner {L r : ℝ} (hL : 0 < 
   intro z hz
   refine ⟨z - v, hball ?_, by simp [vadd_eq_add]⟩
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
-  rw [mem_ball, dist_eq_norm, show z - ↑v - y = z - (↑v + y) by abel, ← dist_eq_norm]
-  exact hz
+  simpa [mem_ball, dist_eq_norm, sub_sub] using hz
 
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :
     Set.Finite {g : cubeLattice d L hL | (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 R} := by
@@ -253,6 +241,8 @@ section CoordCubeCover
 
 variable (L : ℝ) (hL : 0 < L)
 
+/-- The unique lattice vector translating `x` into `coordCube d L` (see `coordCubeCover_spec`).
+The cell-assignment map underlying the pigeonhole argument; named to pair with its spec lemma. -/
 noncomputable def coordCubeCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
   Classical.choose (PeriodicConstant.coordCube_unique_covers L hL x)
 
@@ -265,56 +255,55 @@ lemma neg_coordCubeCover_mem_ball {C R : ℝ}
     {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
     ((-coordCubeCover L hL x : cubeLattice d L hL) :
         EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
+  -- `g` is the (coerced) covering translate; the goal is `‖-g‖ = ‖g‖ < R + C`.
   set g := (coordCubeCover L hL x : EuclideanSpace ℝ (Fin d))
   rw [mem_ball_zero_iff, show ((-coordCubeCover L hL x : cubeLattice d L hL) :
     EuclideanSpace ℝ (Fin d)) = -g from rfl, norm_neg]
-  linarith [show ‖x‖ < R by simpa [mem_ball_zero_iff] using hx,
-    show ‖g + x‖ < C by simpa [mem_ball_zero_iff] using hC (by
-      simpa [Submodule.vadd_def, vadd_eq_add] using coordCubeCover_spec L hL x),
-    show ‖g‖ ≤ ‖g + x‖ + ‖x‖ by simpa [add_sub_cancel_right] using norm_sub_le (g + x) x]
+  have hx' : ‖x‖ < R := by simpa [mem_ball_zero_iff] using hx
+  have hgx : ‖g + x‖ < C := by
+    simpa [mem_ball_zero_iff] using hC (by
+      simpa [Submodule.vadd_def, vadd_eq_add] using coordCubeCover_spec L hL x)
+  have htri : ‖g‖ ≤ ‖g + x‖ + ‖x‖ := by
+    simpa [add_sub_cancel_right] using norm_sub_le (g + x) x
+  linarith
 
 end CoordCubeCover
 
 lemma card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball {L : ℝ} (hL : 0 < L)
     {R C : ℝ} (hC : coordCube d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
-    let htSet :=
-      PeriodicConstantApprox.finite_lattice_in_ball (d := d) L hL (R + C)
-    let t : Finset (cubeLattice d L hL) := htSet.toFinset
-    (t.card : ℝ≥0∞) * volume (coordCube d L) ≤
+    ((PeriodicConstantApprox.finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
+        ℝ≥0∞) * volume (coordCube d L) ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
-  intro htSet t
-  haveI hvi : VAddInvariantMeasure (↥(cubeLattice d L hL)) (EuclideanSpace ℝ (Fin d))
-      (MeasureTheory.volume) :=
-    inferInstanceAs (VAddInvariantMeasure (cubeLattice d L hL).toAddSubgroup _ _)
-  haveI hmcv : MeasurableConstVAdd (↥(cubeLattice d L hL)) (EuclideanSpace ℝ (Fin d)) :=
-    ⟨fun _ => measurable_const_vadd _⟩
+  -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells.
+  set htSet := PeriodicConstantApprox.finite_lattice_in_ball (d := d) L hL (R + C)
   have hvadd : ∀ g : ↥(cubeLattice d L hL),
       volume (g +ᵥ coordCube d L) = volume (coordCube d L) :=
-    fun g => @measure_vadd _ _ _ _ _ MeasureTheory.volume hvi g (coordCube d L)
-  have hms : MeasurableSet (coordCube d L) := by
-    rw [show coordCube d L = fundamentalDomain (cubeBasis d L hL) from
-      (fundamentalDomain_cubeBasis_eq_coordCube L hL).symm]
-    exact fundamentalDomain_measurableSet _
-  calc (↑t.card : ℝ≥0∞) * volume (coordCube d L)
-      = ∑ g ∈ t, volume (g +ᵥ coordCube d L) := by
-        simp_rw [hvadd, Finset.sum_const]
-        rw [nsmul_eq_mul]
-    _ = volume (⋃ g ∈ t, g +ᵥ coordCube d L) := (measure_biUnion_finset
+    fun g => measure_vadd volume g _
+  have hms : MeasurableSet (coordCube d L) :=
+    fundamentalDomain_cubeBasis_eq_coordCube L hL ▸ fundamentalDomain_measurableSet _
+  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (coordCube d L)
+      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ coordCube d L) := by
+        simp_rw [hvadd, Finset.sum_const, nsmul_eq_mul]
+    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ coordCube d L) := (measure_biUnion_finset
         (fun _ _ _ _ hgh => disjoint_vadd_of_unique_covers (d := d)
           (PeriodicConstant.coordCube_unique_covers L hL) hgh)
-        (fun g _ => @MeasurableSet.const_vadd _ _ _ _ _ hmcv _ hms g)).symm
+        (fun g _ => hms.const_vadd g)).symm
     _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := volume.mono <| by
         rintro y hy
         obtain ⟨g, hgT, x, hx, rfl⟩ := Set.mem_iUnion₂.1 hy
         have hg : (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) :=
-          htSet.mem_toFinset.1 (by simpa [t] using hgT)
+          htSet.mem_toFinset.1 hgT
         simp only [vadd_eq_add, mem_ball_zero_iff]
         linarith [norm_add_le (g : EuclideanSpace ℝ (Fin d)) x,
           mem_ball_zero_iff.mp (hC hx), mem_ball_zero_iff.mp hg]
 
 section BoundaryControl
 
+/-- The constant vector `(c, …, c)`. Used only to recentre the outer cube in the shell estimate;
+kept (with `constVec_apply`) to avoid repeating the `WithLp.toLp` spelling at its many sites. -/
 def constVec (d : ℕ) (c : ℝ) : EuclideanSpace ℝ (Fin d) := WithLp.toLp 2 (fun _ : Fin d => c)
+
+@[simp] lemma constVec_apply {c : ℝ} (i : Fin d) : constVec d c i = c := rfl
 
 lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
     ((coordCube d L \ coordCubeInner d L (1 / 2)) +
@@ -324,17 +313,19 @@ lemma coordCube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
   rintro z ⟨x, hx, y, hy, rfl⟩
   have hyi : ∀ i : Fin d, |y i| < (1 / 2 : ℝ) := fun i =>
     (abs_coord_le_norm y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
+  rw [Set.mem_diff, mem_coordCube] at hx
   refine ⟨Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => ?_, fun hz_inner => ?_⟩
-  · simp only [coordCubeInner, coordCube, constVec, vadd_eq_add] at hx ⊢
-    refine ⟨by simpa [add_assoc, add_left_comm, add_comm] using
-      (by linarith [(hx.1 i).1, abs_lt.mp (hyi i)] : (0:ℝ) ≤ x i + y i + (1/2:ℝ)),
-      by simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
-        (by linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)] : x i + y i + (1/2:ℝ) ≤ L + 1)⟩
+  · -- Each coordinate of `x + y`, shifted by `+ 1/2`, lands in `[0, L + 1]`.
+    simp only [vadd_eq_add, neg_neg, constVec_apply, PiLp.add_apply, PiLp.neg_apply,
+      Set.mem_Icc]
+    refine ⟨?_, ?_⟩  -- lower bound `0`, upper bound `L + 1`
+    · linarith [(hx.1 i).1, abs_lt.mp (hyi i)]
+    · linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)]
   · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (1 / 2 : ℝ) (L - 1 / 2) := by
-      simpa [coordCubeInner, Set.mem_setOf_eq] using not_forall.mp hx.2
+      simpa [mem_coordCubeInner] using not_forall.mp hx.2
     rw [Set.mem_Icc, not_and_or] at hi
     have hz_i : (x i + y i) ∈ Set.Icc (1 : ℝ) (L - 1) := by
-      simpa [coordCubeInner, Set.mem_setOf_eq] using hz_inner i
+      simpa [mem_coordCubeInner] using hz_inner i
     obtain hi | hi := hi <;> linarith [hz_i.1, hz_i.2, abs_lt.mp (hyi i)]
 
 variable (S : SpherePacking d)
@@ -348,7 +339,8 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
     (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) ≤
       volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
         coordCubeInner d L 1) := by
-  let r : ℝ := (1 / 2 : ℝ)
+  -- `r` abbreviates the common ball radius, matching the statement's `2⁻¹`.
+  let r : ℝ := (2⁻¹ : ℝ)
   have hdisj : (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x => ball x r :=
     fun x hx y hy hxy => ball_disjoint_ball (by
       dsimp [r]; linarith [show (1 : ℝ) ≤ dist x y by
@@ -356,16 +348,14 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
   have hsub : (⋃ x ∈ s, ball x r) ⊆
       g +ᵥ (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
             coordCubeInner d L 1) := fun y hy => by
-    obtain ⟨x, hxS, hyBall⟩ : ∃ x ∈ s, y ∈ ball x r := by simpa using hy
+    obtain ⟨x, hxS, hyBall⟩ : ∃ x ∈ s, y ∈ ball x r := by aesop
     have hxB := hs_boundary x hxS
+    -- `x0`, `y0`: pull `x`, `y` back by `-g` to the base cube (referenced repeatedly below).
     set x0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ x
     set y0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ y
-    have hvadd_eq : ∀ (v w : EuclideanSpace ℝ (Fin d)) (S : Set (EuclideanSpace ℝ (Fin d))),
-        v ∈ ((g : EuclideanSpace ℝ (Fin d)) +ᵥ S) ↔ -(g : EuclideanSpace ℝ (Fin d)) +ᵥ v ∈ S :=
-      fun v w S => Set.mem_vadd_set_iff_neg_vadd_mem
     have hxB1' : x0 ∈ coordCube d L := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
-    have hxB2' : x0 ∉ coordCubeInner d L (1/2) := fun h => hxB.2
-      (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)
+    have hxB2' : x0 ∉ coordCubeInner d L (1 / 2) :=
+      fun h => hxB.2 (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)
     have hy0 : y0 ∈ ((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
         coordCubeInner d L 1 := by
       apply coordCube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
@@ -375,16 +365,11 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
     exact Set.mem_vadd_set_iff_neg_vadd_mem.mpr hy0
   calc (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
       = volume (⋃ x ∈ s, ball x r) := by
-        rw [show (2⁻¹ : ℝ) = r by norm_num]
         simpa [Measure.addHaar_ball_center, mul_comm, mul_assoc] using
           (measure_biUnion_finset (μ := volume) hdisj (fun _ _ => measurableSet_ball)).symm
     _ ≤ volume (g +ᵥ (((constVec d (-(1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
           coordCubeInner d L 1)) := volume.mono hsub
-    _ = _ := by
-      haveI inst_vim : VAddInvariantMeasure (↥(cubeLattice d L hL)) (EuclideanSpace ℝ (Fin d))
-          (MeasureTheory.volume) :=
-        inferInstanceAs (VAddInvariantMeasure (cubeLattice d L hL).toAddSubgroup _ _)
-      exact @measure_vadd _ _ _ _ _ MeasureTheory.volume inst_vim g _
+    _ = _ := measure_vadd volume g _
 
 end BoundaryControl
 
@@ -392,27 +377,30 @@ lemma volume_cubeShell_eq_pow (L : ℝ) :
     volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0) \
         coordCubeInner d L 1) =
       (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
-  simpa [measure_vadd, constVec, PeriodicConstant.volume_coordCubeInner] using
-    measure_diff (μ := volume) (fun x hx => Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => by
-      simp only [coordCubeInner, Set.mem_setOf_eq, constVec, vadd_eq_add, one_div,
+  have hsub : coordCubeInner d L 1 ⊆
+      (constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0 := fun x hx =>
+    Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => by
+      simp only [mem_coordCubeInner, constVec, vadd_eq_add, one_div,
         WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg] at hx ⊢
-      exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩ :
-    coordCubeInner d L 1 ⊆ (constVec d (- (1 / 2 : ℝ))) +ᵥ coordCubeInner d (L + 1) 0)
-      (show MeasurableSet (coordCubeInner d L 1) by
-        simpa [PeriodicConstant.coordCubeInner_eq_preimage_ofLp] using
-          (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
-            (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable).nullMeasurableSet
+      exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
+  have hmeas : MeasurableSet (coordCubeInner d L 1) := by
+    simpa [PeriodicConstant.coordCubeInner_eq_preimage_ofLp] using
+      (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
+        (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
+  simpa [measure_vadd, constVec, PeriodicConstant.volume_coordCubeInner] using
+    measure_diff (μ := volume) hsub hmeas.nullMeasurableSet
       (by simp [PeriodicConstant.volume_coordCubeInner])
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
       (volume (coordCube d L)).toNNReal := by
-  simp [show ZLattice.covolume (cubeLattice d L hL) volume = (volume (coordCube d L)).toReal by
+  have hcov : ZLattice.covolume (cubeLattice d L hL) volume = (volume (coordCube d L)).toReal := by
     simpa [Measure.real, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
       ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice d L hL) (μ := volume)
         (by simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
           IsAddFundamentalDomain (cubeLattice d L hL)
-            (fundamentalDomain (cubeBasis d L hL)) volume)]
+            (fundamentalDomain (cubeBasis d L hL)) volume)
+  simp [hcov]
 
 lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.separation = 1)
     {L : ℝ} (hL : 0 < L) {g : cubeLattice d L hL}
@@ -422,6 +410,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ P.density =
         (F.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
           Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) := by
+  -- Assemble the periodic packing `P` from the cube cell `D` and the representatives `Fset`.
   let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ coordCube d L
   let Fset : Set (EuclideanSpace ℝ (Fin d)) := (F : Set (EuclideanSpace ℝ (Fin d)))
   have hD_unique := PeriodicConstantApprox.coordCube_unique_covers_vadd L hL g
@@ -431,22 +420,29 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
       (hF_ball := fun x hx => ball_subset_vadd_coordCube_of_mem_vadd_inner hL <| by
         simpa [hSsep] using hF_inner x (by simpa [Fset] using hx))
   have hPsep : P.separation = 1 := by simpa [P, hSsep]
+  -- The translated inner cube `Fset` sits inside the translated full cube `D`.
+  have hFsubD : Fset ⊆ D := fun x hx => by
+    rcases hF_inner x (by simpa [Fset] using hx) with ⟨a, ha, rfl⟩
+    exact ⟨a, fun i => ⟨(by norm_num : (0 : ℝ) < _).le.trans (ha i).1,
+      (ha i).2.trans_lt (sub_lt_self _ (by norm_num))⟩, rfl⟩
+  -- The periodized centers meet `D` in exactly `Fset` (`P.centers = periodizedCenters Λ Fset`).
+  have hPcD : P.centers ∩ D = Fset := by
+    simpa [P, periodize_to_periodicSpherePacking, Fset] using
+      periodizedCenters_inter_eq_of_subset (d := d) (Λ := cubeLattice d L hL) (D := D)
+        (F := Fset) hFsubD hD_unique
+  -- `D` is bounded, being a translate of the cube.
+  have hD_bounded : IsBounded D := by
+    simpa [D, Submodule.vadd_def, vadd_eq_add] using
+      (PeriodicConstant.isBounded_coordCube L hL).vadd (g : EuclideanSpace ℝ (Fin d))
   have hnumReps : P.numReps = F.card := by
     exact_mod_cast show (P.numReps : ENat) = (F.card : ENat) by
-      simpa [show P.centers ∩ D = Fset by
-        simpa [P, periodize_to_periodicSpherePacking, Fset] using
-          periodizedCenters_inter_eq_of_subset (d := d) (Λ := cubeLattice d L hL) (D := D)
-            (F := Fset) (fun x hx => by
-              rcases hF_inner x (by simpa [Fset] using hx) with ⟨a, ha, rfl⟩
-              exact ⟨a, fun i => ⟨(by norm_num : (0:ℝ) < _).le.trans (ha i).1,
-                (ha i).2.trans_lt (sub_lt_self _ (by norm_num))⟩, rfl⟩)
-            hD_unique, Fset, Set.encard_coe_eq_coe_finsetCard] using
+      simpa [hPcD, Fset, Set.encard_coe_eq_coe_finsetCard] using
         (P.encard_centers_inter_isFundamentalDomain (d := d) (D := D)
-          (by simpa [D, Submodule.vadd_def, vadd_eq_add] using
-            (PeriodicConstant.isBounded_coordCube L hL).vadd (g : EuclideanSpace ℝ (Fin d)) :
-            IsBounded D) hD_unique hd).symm
+          hD_bounded hD_unique hd).symm
   exact ⟨P, hPsep, by simpa [hnumReps, hPsep] using P.density_eq' (d := d) hd⟩
 
+/-- The cube-shell error ratio `volume(shell) / volume(coordCube d L)` tends to `0` as `L → ∞`:
+the shell volume grows like `(L + 1) ^ d - (L - 2) ^ d` while the cube volume grows like `L ^ d`. -/
 lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
     Tendsto
         (fun L : ℝ =>
@@ -454,6 +450,7 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
               coordCubeInner d L 1) /
             volume (coordCube d L))
         atTop (𝓝 (0 : ℝ≥0∞)) := by
+  -- `f` is the real shell/cube volume ratio, whose `→ 0` limit we transfer to `ℝ≥0∞`.
   let f : ℝ → ℝ := fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)
   have hf : Tendsto f atTop (𝓝 (0 : ℝ)) := by
     have h1 : Tendsto (fun L : ℝ => (1 + L⁻¹) ^ d) atTop (𝓝 (1 : ℝ)) := by
@@ -470,8 +467,9 @@ lemma tendsto_volume_cubeShell_div_volume_coordCube_zero :
     simpa using (ENNReal.continuous_ofReal.tendsto (0 : ℝ)).comp hf).congr' ?_
   filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
   have hL2' : 0 ≤ L - 2 := by linarith
-  rw [volume_cubeShell_eq_pow L, show volume (coordCube d L) = (ENNReal.ofReal L) ^ d by
-      simpa using PeriodicConstant.volume_coordCube L,
+  have hvol : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
+    simpa using PeriodicConstant.volume_coordCube L
+  rw [volume_cubeShell_eq_pow L, hvol,
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L + 1), ← ENNReal.ofReal_pow hL2',
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L), ← ENNReal.ofReal_sub _ (pow_nonneg hL2' d)]
   simpa [f] using ENNReal.ofReal_div_of_pos (x := (L + 1)^d - (L - 2)^d) (pow_pos (by linarith) d)
@@ -500,18 +498,22 @@ private lemma exists_R_finiteDensity_gt_and_ratio_gt (hd : 0 < d)
     ∃ R : ℝ, c < S.finiteDensity R ∧ 0 < R ∧
       δ < c * (volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) /
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) := by
+  -- `ratio R` is the ball-volume ratio `vol(ball R) / vol(ball (R + Cshift))`, tending to `1`.
   let ratio : ℝ → ℝ≥0∞ := fun R : ℝ =>
     volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) /
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
-  exact ((frequently_lt_of_lt_limsup (h := by simpa [SpherePacking.density] using hcS) :
-    ∃ᶠ R in (atTop : Filter ℝ), c < S.finiteDensity R).and_eventually
-    ((eventually_gt_atTop (0 : ℝ)).and
-      ((show Tendsto (fun R : ℝ => c * ratio R) atTop (𝓝 c) by
-        simpa [mul_one] using ENNReal.Tendsto.const_mul (a := c)
-          (by simpa [ratio, add_zero] using
-            volume_ball_ratio_tendsto_nhds_one'' (C := (0 : ℝ)) (C' := Cshift) hd :
-            Tendsto ratio atTop (𝓝 (1 : ℝ≥0∞)))).eventually
-        (Ioi_mem_nhds hδc)))).exists
+  -- `c < S.finiteDensity R` for arbitrarily large `R`, since `c < S.density = limsup`.
+  have hfreq : ∃ᶠ R in (atTop : Filter ℝ), c < S.finiteDensity R :=
+    frequently_lt_of_lt_limsup (h := by simpa [SpherePacking.density] using hcS)
+  -- The ball-volume ratio tends to `1`, so `c * ratio R → c`.
+  have hratio : Tendsto ratio atTop (𝓝 (1 : ℝ≥0∞)) := by
+    simpa [ratio, add_zero] using
+      volume_ball_ratio_tendsto_nhds_one'' (C := (0 : ℝ)) (C' := Cshift) hd
+  have hmul : Tendsto (fun R : ℝ => c * ratio R) atTop (𝓝 c) := by
+    simpa [mul_one] using ENNReal.Tendsto.const_mul (a := c) hratio (Or.inl one_ne_zero)
+  -- Eventually `c * ratio R > δ` (limit `c > δ`); combine with the frequent and positivity facts.
+  exact (hfreq.and_eventually ((eventually_gt_atTop (0 : ℝ)).and
+    (hmul.eventually (Ioi_mem_nhds hδc)))).exists
 
 /-- Pigeonhole step: among the finitely many lattice translates of `coordCube d L` meeting
 `ball 0 (R₁ + C)`, some translate `g0` contains at least `s.card / t.card` of the centers in
@@ -527,6 +529,8 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) := by
   have hX : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).Finite :=
     SpherePacking.finite_centers_inter_ball S R₁
+  -- Pigeonhole: `s` = centres in `ball 0 R₁`, `t` = lattice translates meeting `ball 0 (R₁+C)`,
+  -- `f` sends each centre to its covering translate; `sg` (below) is the fullest fibre.
   let s : Finset (EuclideanSpace ℝ (Fin d)) := hX.toFinset
   let htSet := finite_lattice_in_ball (d := d) L hL (R₁ + C)
   let t : Finset (cubeLattice d L hL) := htSet.toFinset
@@ -534,7 +538,8 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := fun _ hx =>
     htSet.mem_toFinset.2 <| neg_coordCubeCover_mem_ball L hL hC (hX.mem_toFinset.1 hx).2
   obtain ⟨g0, _, hg0max⟩ := Finset.exists_max_image t (fun g => (s.filter fun x => f x = g).card)
-    ⟨0, htSet.mem_toFinset.2 (by simp [Metric.mem_ball]; linarith)⟩
+    ⟨0, htSet.mem_toFinset.2 (by simpa only [Set.mem_setOf_eq, Metric.mem_ball,
+      ZeroMemClass.coe_zero, dist_self] using hR₁)⟩
   let sg : Finset (EuclideanSpace ℝ (Fin d)) := s.filter fun x => f x = g0
   refine ⟨g0, sg, fun x hx => (hX.mem_toFinset.1 (Finset.mem_filter.1 hx).1).1,
     fun x hx => ?_, ?_⟩
@@ -542,8 +547,10 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
     refine h ▸ Set.mem_vadd_set_iff_neg_vadd_mem.mpr ?_
     simpa [neg_neg] using coordCubeCover_spec L hL x
   · have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
-      exact_mod_cast by simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using
-        Finset.sum_le_sum hg0max
+      have hcard : s.card ≤ t.card * sg.card := by
+        simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using
+          Finset.sum_le_sum hg0max
+      exact_mod_cast hcard
     have ht_vol : ((t.card : ℝ≥0∞) * volume (coordCube d L)) ≤
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) :=
       card_finite_lattice_in_ball_mul_volume_coordCube_le_volume_ball hL hC
@@ -570,6 +577,7 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) :
     δ < (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
       volume (coordCube d L) := by
+  -- Abbreviations for the three volumes appearing in the inequality chase.
   set volCube := volume (coordCube d L)
   set volBall := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
@@ -578,26 +586,29 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
       pow_ne_zero d (ENNReal.ofReal_pos.mpr hL).ne'
   have hvolCube_ne_top : volCube ≠ ∞ :=
     (PeriodicConstant.isBounded_coordCube L hL).measure_lt_top.ne
+  -- Cancelling a common factor of `volCube` from the numerator and an outer division.
+  have hcancel : ∀ a c : ℝ≥0∞, a * volCube / c / volCube = a / c := fun a c => by
+    simp only [div_eq_mul_inv,
+      show a * volCube * c⁻¹ * volCube⁻¹ = a * c⁻¹ * (volCube * volCube⁻¹) by ring,
+      ENNReal.mul_inv_cancel hvolCube_ne0 hvolCube_ne_top, mul_one]
+  -- The numerator inequality, from the finite-density bound on `S`.
+  have hnum : c * volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) <
+      ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) * volBall :=
+    ENNReal.mul_lt_of_lt_div <| hcR.trans_le <| by
+      simpa [hSsep, volBall, add_assoc, add_left_comm, add_comm] using S.finiteDensity_le hd R
   have hc_ratio : c * (volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) / V) <
-      ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) * volBall / V :=
-      by
+      ((S.centers ∩ ball 0 (R + 2⁻¹)).encard : ℝ≥0∞) * volBall / V := by
     simpa [div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using
-      ENNReal.div_lt_div_right
-        ((Metric.measure_ball_pos volume _ hRC).ne.symm : V ≠ 0)
-        (MeasureTheory.measure_ball_lt_top (μ := volume)).ne
-        (ENNReal.mul_lt_of_lt_div <| hcR.trans_le <| by
-          simpa [hSsep, volBall, add_assoc, add_left_comm, add_comm] using S.finiteDensity_le hd R :
-        c * volume (ball (0 : EuclideanSpace ℝ (Fin d)) R) <
-        ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) * volBall)
+      ENNReal.div_lt_div_right ((Metric.measure_ball_pos volume _ hRC).ne.symm : V ≠ 0)
+        (MeasureTheory.measure_ball_lt_top (μ := volume)).ne hnum
   refine (hRratio.trans hc_ratio).trans_le ?_
-  have := mul_le_mul_left (show ((S.centers ∩ ball 0 (R + 2⁻¹)).encard : ℝ≥0∞) / V ≤
-      (sg.card : ℝ≥0∞) / volCube by
+  have hratio_le : ((S.centers ∩ ball 0 (R + 2⁻¹)).encard : ℝ≥0∞) / V ≤
+      (sg.card : ℝ≥0∞) / volCube := by
     have h := ENNReal.div_le_div_right (ENNReal.div_le_of_le_mul hs_mul) volCube
-    rwa [show ∀ a c : ℝ≥0∞, ((a * volCube) / c) / volCube = a / c from fun a c => by
-      simp only [div_eq_mul_inv,
-        show a * volCube * c⁻¹ * volCube⁻¹ = a * c⁻¹ * (volCube * volCube⁻¹) by ring,
-        ENNReal.mul_inv_cancel hvolCube_ne0 hvolCube_ne_top, mul_one]] at h) volBall
-  simp only [div_eq_mul_inv] at this ⊢; convert this using 1 <;> ring
+    rwa [hcancel] at h
+  have := mul_le_mul_left hratio_le volBall
+  simp only [div_eq_mul_inv] at this ⊢
+  convert this using 1 <;> ring
 
 /-- From a finset `sg` of centers in `g0 +ᵥ coordCube d L` satisfying `sg.card * volBall / volCube`
 exceeding some bound `δ + shellVol / volCube`, construct a periodic packing `P` with separation `1`
@@ -611,12 +622,14 @@ private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
         (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
           volume (coordCube d L)) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ δ < P.density := by
+  -- Abbreviations for the shell, cube, and unit-ball volumes used in the density bound.
   set shellVol : ℝ≥0∞ := volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ
       coordCubeInner d (L + 1) 0) \ coordCubeInner d L 1)
   set volCube : ℝ≥0∞ := volume (coordCube d L)
   set volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   have hvolCube_ne_top : volCube ≠ ∞ :=
     (PeriodicConstant.isBounded_coordCube L hL).measure_lt_top.ne
+  -- Split `sg` by the inner cube: `F` (kept representatives) and `sb` (boundary, bounded by shell).
   let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ coordCubeInner d L (1 / 2 : ℝ)
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
@@ -630,16 +643,20 @@ private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
   obtain ⟨P, hPsep, hPdens⟩ := periodize_cube_density_eq hd S hSsep hL F
     (fun x hx => hsg_centers x (Finset.mem_filter.1 hx).1)
     (fun x hx => by simpa [innerSet] using (Finset.mem_filter.1 hx).2)
+  have hcov_eq : (Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) : ℝ≥0∞) =
+      volCube := by
+    rw [show Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) = volCube.toNNReal by
+        simpa [volCube] using toNNReal_covolume_cubeLattice (d := d) L hL,
+      ENNReal.coe_toNNReal hvolCube_ne_top]
   have hPdens' : P.density = (F.card : ℝ≥0∞) * volBall / volCube := by
-    simpa [volBall, show (Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) : ℝ≥0∞) =
-        volCube by rw [show Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
-          volCube.toNNReal by simpa [volCube] using toNNReal_covolume_cubeLattice (d := d) L hL,
-        ENNReal.coe_toNNReal hvolCube_ne_top]] using hPdens
+    simpa [volBall, hcov_eq] using hPdens
   refine ⟨P, hPsep, (lt_tsub_iff_right.mpr hsg_density).trans_le (tsub_le_iff_right.2 ?_)⟩
+  have hcard : (sg.card : ℝ≥0∞) = (F.card : ℝ≥0∞) + (sb.card : ℝ≥0∞) := by
+    exact_mod_cast
+      (Finset.card_filter_add_card_filter_not (s := sg) (p := fun x => x ∈ innerSet)).symm
   have hsplit : (sg.card : ℝ≥0∞) * volBall =
       (F.card : ℝ≥0∞) * volBall + (sb.card : ℝ≥0∞) * volBall := by
-    rw [show (sg.card : ℝ≥0∞) = (F.card : ℝ≥0∞) + (sb.card : ℝ≥0∞) by exact_mod_cast
-      (Finset.card_filter_add_card_filter_not (s := sg) (p := fun x => x ∈ innerSet)).symm, add_mul]
+    rw [hcard, add_mul]
   simpa [hPdens', div_eq_mul_inv, mul_add, add_mul, mul_assoc, shellVol] using
     ENNReal.div_le_div_right (hsplit ▸ add_le_add_right hsb_vol _ :
       (sg.card : ℝ≥0∞) * volBall ≤ (F.card : ℝ≥0∞) * volBall + shellVol) volCube
@@ -673,10 +690,9 @@ public theorem periodic_constant_eq_constant (hd : 0 < d) :
     PeriodicSpherePackingConstant d = SpherePackingConstant d := by
   rw [periodic_constant_eq_periodic_constant_normalized,
     SpherePacking.constant_eq_constant_normalized]
-  refine le_antisymm (iSup₂_le fun P hPsep =>
-    (le_iSup (fun _ : (P.toSpherePacking).separation = 1 ↦ (P.toSpherePacking).density) hPsep).trans
-      <| le_iSup (fun S : SpherePacking d ↦ ⨆ (_ : S.separation = 1), S.density)
-        P.toSpherePacking) (iSup₂_le fun S hSsep => le_of_forall_lt fun a ha => ?_)
+  refine le_antisymm
+    (iSup₂_le fun P hPsep => le_iSup₂_of_le P.toSpherePacking hPsep le_rfl)
+    (iSup₂_le fun S hSsep => le_of_forall_lt fun a ha => ?_)
   obtain ⟨b, hab, hbS⟩ := exists_between ha
   obtain ⟨P, hPsep, hbP⟩ :=
     SpherePacking.exists_periodicSpherePacking_sep_one_density_gt_of_lt_density hd S hSsep hbS
@@ -706,7 +722,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E
 
 /-- Fourier inversion for Schwartz functions. -/
 @[simp]
-public theorem fourierInversion : 𝓕⁻ (𝓕 ⇑f) = f := by rw [← fourier_coe, ← fourierInv_coe]; simp
+public theorem fourierInversion : 𝓕⁻ (𝓕 ⇑f) = f := by simp [← fourier_coe, ← fourierInv_coe]
 
 end SchwartzMap
 section Integration
@@ -749,8 +765,10 @@ variable (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ]
 public lemma summable_norm_comp_add_zlattice (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ))
     (a : EuclideanSpace ℝ (Fin d)) :
     Summable (fun ℓ : Λ => ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖) := by
+  -- `k` is the decay order: two more than the rank, so the comparison series converges.
   let k : ℕ := Module.finrank ℤ Λ + 2
   obtain ⟨C, _hCpos, hC⟩ := f.decay k 0
+  -- `b = -a` is the shift, so that `a + ℓ = ℓ - b`.
   set b : EuclideanSpace ℝ (Fin d) := -a
   refine Summable.of_norm_bounded_eventually
     (f := fun ℓ : Λ => ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖)
@@ -758,29 +776,36 @@ public lemma summable_norm_comp_add_zlattice (f : 𝓢(EuclideanSpace ℝ (Fin d
   · simpa [mul_assoc] using
       (ZLattice.summable_norm_sub_inv_pow (L := Λ) (n := k) (by simp [k]) b).mul_left (C + 1)
   · letI : DiscreteTopology Λ.toAddSubgroup := inferInstanceAs (DiscreteTopology Λ)
-    refine (show ({ℓ : Λ | ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ≤ (1 : ℝ)} : Set Λ).Finite by
+    -- The bound fails only on the finite set where `‖ℓ - b‖ ≤ 1`.
+    have hfin : ({ℓ : Λ | ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ≤ (1 : ℝ)} : Set Λ).Finite := by
+      have hclosed : IsClosed (X := EuclideanSpace ℝ (Fin d))
+          (Λ : Set (EuclideanSpace ℝ (Fin d))) := by
+        simpa [Submodule.coe_toAddSubgroup] using
+          AddSubgroup.isClosed_of_discrete (H := Λ.toAddSubgroup)
       simpa [Set.preimage, Metric.mem_closedBall, dist_eq_norm, and_true] using
         (Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
-          Metric.isBounded_closedBall (by simpa [Submodule.coe_toAddSubgroup] using
-            AddSubgroup.isClosed_of_discrete (H := Λ.toAddSubgroup) :
-            IsClosed (X := EuclideanSpace ℝ (Fin d))
-              (Λ : Set (EuclideanSpace ℝ (Fin d))))).preimage_embedding
-          (f := (⟨Subtype.val, Subtype.coe_injective⟩ : Λ ↪ EuclideanSpace ℝ (Fin d)))).subset
-            fun ℓ hfail => ?_
+          Metric.isBounded_closedBall hclosed).preimage_embedding
+          (f := (⟨Subtype.val, Subtype.coe_injective⟩ : Λ ↪ EuclideanSpace ℝ (Fin d)))
+    refine hfin.subset fun ℓ hfail => ?_
     by_contra hlarge
     have hpos : 0 < ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k :=
       pow_pos (lt_of_lt_of_le one_pos (lt_of_not_ge hlarge).le) _
+    -- Schwartz decay at order `k`, rewriting `‖a + ℓ‖` as `‖ℓ - b‖`.
+    have hab : ‖a + (ℓ : EuclideanSpace ℝ (Fin d))‖ = ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ := by
+      simp [b, sub_eq_add_neg, add_comm]
     have hdec :
         ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k *
           ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖ ≤ C := by
-      simpa [show ‖a + (ℓ : EuclideanSpace ℝ (Fin d))‖ =
-          ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ by simp [b, sub_eq_add_neg, add_comm],
-        norm_iteratedFDeriv_zero] using hC (a + (ℓ : EuclideanSpace ℝ (Fin d)))
-    refine hfail (by simpa [div_eq_mul_inv, inv_pow] using
-      ((le_div_iff₀' hpos).2 hdec).trans (by
-        simpa [div_eq_mul_inv, mul_assoc] using
-          mul_le_mul_of_nonneg_right (by linarith : C ≤ C + 1)
-            (by positivity : 0 ≤ (‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k)⁻¹)))
+      simpa [hab, norm_iteratedFDeriv_zero] using hC (a + (ℓ : EuclideanSpace ℝ (Fin d)))
+    -- Rearrange the decay bound into the form `(C + 1) * ‖ℓ - b‖⁻¹ ^ k`.
+    have h1 : ‖f (a + (ℓ : EuclideanSpace ℝ (Fin d)))‖ ≤
+        C / ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k := (le_div_iff₀' hpos).2 hdec
+    have h2 : C / ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k ≤
+        (C + 1) * ‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖⁻¹ ^ k := by
+      simpa [div_eq_mul_inv, inv_pow] using
+        mul_le_mul_of_nonneg_right (by linarith : C ≤ C + 1)
+          (by positivity : 0 ≤ (‖(ℓ : EuclideanSpace ℝ (Fin d)) - b‖ ^ k)⁻¹)
+    exact hfail (by simpa using h1.trans h2)
 
 end LPBoundAux
 
@@ -808,23 +833,25 @@ public instance (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopol
     [IsZLattice ℝ Λ] :
     DiscreteTopology
       (LinearMap.BilinForm.dualSubmodule (B := innerₗ (EuclideanSpace ℝ (Fin d))) Λ) := by
+  -- `bZ` is an integral basis of `Λ`; its inner-product dual basis spans the dual submodule.
   let bZ : Basis (Module.Free.ChooseBasisIndex ℤ Λ) ℤ Λ := Module.Free.chooseBasis ℤ Λ
   have hB : LinearMap.BilinForm.Nondegenerate (innerₗ (EuclideanSpace ℝ (Fin d)) :
       LinearMap.BilinForm ℝ (EuclideanSpace ℝ (Fin d))) := by
     constructor <;> intro x hx <;>
       exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))
-  exact (show LinearMap.BilinForm.dualSubmodule (B := innerₗ (EuclideanSpace ℝ (Fin d))) Λ =
+  have hspan : LinearMap.BilinForm.dualSubmodule (B := innerₗ (EuclideanSpace ℝ (Fin d))) Λ =
       Submodule.span ℤ (Set.range
         (LinearMap.BilinForm.dualBasis (B := innerₗ (EuclideanSpace ℝ (Fin d)))
-          hB (bZ.ofZLatticeBasis ℝ Λ))) by
+          hB (bZ.ofZLatticeBasis ℝ Λ))) := by
     simpa [bZ.ofZLatticeBasis_span (K := ℝ) (L := Λ)] using
       LinearMap.BilinForm.dualSubmodule_span_of_basis (B := innerₗ (EuclideanSpace ℝ (Fin d)))
-        (R := ℤ) (S := ℝ) (M := EuclideanSpace ℝ (Fin d)) hB (bZ.ofZLatticeBasis ℝ Λ)) ▸
-    inferInstance
+        (R := ℤ) (S := ℝ) (M := EuclideanSpace ℝ (Fin d)) hB (bZ.ofZLatticeBasis ℝ Λ)
+  exact hspan ▸ inferInstance
 
 noncomputable section
 
-/-- Equivalence `((P.centers ∩ D) × P.lattice) ≃ P.centers` from a unique-covering assumption. -/
+/-- The equivalence `(P.centers ∩ D) × P.lattice ≃ P.centers` from a unique-covering hypothesis,
+realising the orbit decomposition of the centres; API: `centersInterProdEquiv_sub`. -/
 @[expose] public def centersInterProdEquiv (P : PeriodicSpherePacking d) [Nonempty P.centers]
     {D : Set (EuclideanSpace ℝ (Fin d))}
     (hD_unique_covers : ∀ x, ∃! g : P.lattice, g +ᵥ x ∈ D) :
@@ -834,6 +861,8 @@ noncomputable section
     fun x =>
       let ⟨g, hg, hguniq⟩ := hD_unique_covers (x : EuclideanSpace ℝ (Fin d))
       ⟨g, ⟨P.lattice_action g.property x.property, hg⟩, fun g' hg' => hguniq g' hg'.2⟩
+  -- `toCenter`/`toPair` are the two directions of the equivalence; `cover x` is `x`'s covering
+  -- translate and `repr x` its representative in `P.centers ∩ D`.
   let cover : P.centers → P.lattice := fun x => Classical.choose (hcover x)
   let repr : P.centers → ↑(P.centers ∩ D) := fun x =>
     ⟨cover x +ᵥ (x : EuclideanSpace ℝ (Fin d)), (Classical.choose_spec (hcover x)).1⟩
@@ -846,13 +875,12 @@ noncomputable section
       ((Classical.choose_spec (hcover (toCenter p))).2 (-p.2)
         (by
           simp only [toCenter]
-          rw [show -p.2 +ᵥ (p.2 +ᵥ (p.1 : EuclideanSpace ℝ (Fin d))) =
-            (p.1 : EuclideanSpace ℝ (Fin d)) from neg_vadd_vadd p.2 _]
+          rw [neg_vadd_vadd]
           exact p.1.property)).symm
     refine Prod.ext (Subtype.ext ?_) ?_
     · simp only [toPair, repr, toCenter, hcov]
       exact neg_vadd_vadd _ _
-    · simp [toPair, hcov]
+    · simp only [toPair, hcov, neg_neg]
   · exact fun x => Subtype.ext (by
       simp only [toPair, repr, toCenter]
       exact neg_vadd_vadd _ _)
@@ -886,7 +914,7 @@ private lemma summable_prod_schwartz_re (f : 𝓢(EuclideanSpace ℝ (Fin d), �
         (p.2 : EuclideanSpace ℝ (Fin d)))‖) ?_ ?_
   · refine (summable_prod_of_nonneg fun _ => norm_nonneg _).2
       ⟨fun x => by simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
-        (SpherePacking.CohnElkies.LPBoundAux.summable_norm_comp_add_zlattice (Λ := P.lattice) f
+        (LPBoundAux.summable_norm_comp_add_zlattice (Λ := P.lattice) f
           ((x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)))), Summable.of_finite⟩
   · rintro ⟨x, ℓ⟩
     simpa [centersInterProdEquiv_sub P hD_unique_covers x y ℓ, Real.norm_eq_abs] using
@@ -908,11 +936,10 @@ private lemma tsum_lattice_tsum_centersInter_swap (f : 𝓢(EuclideanSpace ℝ (
           EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)))).re := by
   letI : Fintype ↑(P.centers ∩ D) := Fintype.ofFinite _
   simpa [tsum_fintype] using
-    (Summable.tsum_finsetSum (s := (Finset.univ : Finset ↑(P.centers ∩ D))) (fun y _ =>
+    (Summable.tsum_finsetSum (s := Finset.univ) (fun y _ =>
       (summable_congr fun b => congrArg Complex.re (congrArg (⇑f)
           (centersInterProdEquiv_sub P hD_unique_covers x y b))).mpr
-        (SpherePacking.CohnElkies.LPBoundSummability.summable_lattice_translate_re
-          (Λ := P.lattice) (f := f)
+        (LPBoundSummability.summable_lattice_translate_re (Λ := P.lattice) (f := f)
           ((x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d))))))
 
 /-- Reindex the `x : P.centers` sum as a `x₀ : P.centers ∩ D` sum over lattice translates,
@@ -929,15 +956,19 @@ public lemma tsum_centers_eq_tsum_centersInter_centersInter_lattice
         (f ((x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)) +
           (ℓ : EuclideanSpace ℝ (Fin d)))).re := by
   haveI : Finite (↑(P.centers ∩ D)) := finite_centers_inter_of_isBounded P D hD_isBounded hd
+  -- `e` is the orbit-decomposition equivalence used to reindex the centre sum.
   let e : (↑(P.centers ∩ D) × P.lattice) ≃ P.centers :=
     centersInterProdEquiv (P := P) (D := D) hD_unique_covers
   have he_sub := centersInterProdEquiv_sub P hD_unique_covers
-  rw [show (∑' x : P.centers, ∑' y : ↑(P.centers ∩ D), (f (x - (y : EuclideanSpace ℝ (Fin d)))).re)
+  -- Reindex the `x : P.centers` sum along the equiv `e` as a sum over `(x₀, ℓ)`.
+  have hreindex :
+      (∑' x : P.centers, ∑' y : ↑(P.centers ∩ D), (f (x - (y : EuclideanSpace ℝ (Fin d)))).re)
         = ∑' (x : ↑(P.centers ∩ D)) (ℓ : P.lattice), ∑' y : ↑(P.centers ∩ D),
-            (f ((e (x, ℓ) : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)))).re from by
-      rw [← (summable_prod_schwartz_re f P hD_unique_covers).tsum_prod]
-      simpa [e] using (e.tsum_eq (f := fun x : P.centers =>
-        ∑' y : ↑(P.centers ∩ D), (f (x - (y : EuclideanSpace ℝ (Fin d)))).re)).symm]
+            (f ((e (x, ℓ) : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)))).re := by
+    rw [← (summable_prod_schwartz_re f P hD_unique_covers).tsum_prod]
+    simpa [e] using (e.tsum_eq (f := fun x : P.centers =>
+      ∑' y : ↑(P.centers ∩ D), (f (x - (y : EuclideanSpace ℝ (Fin d)))).re)).symm
+  rw [hreindex]
   refine tsum_congr fun x => ?_
   rw [tsum_lattice_tsum_centersInter_swap f P hD_unique_covers x]
   exact tsum_congr₂ fun b c => congrArg Complex.re (congrArg (⇑f) (he_sub x b c))
@@ -954,17 +985,18 @@ private lemma tsum_finset_finset_const_mul_swap {ι κ μ : Type*} [Finite ι] [
       = c * ∑' m : μ, a m * (∑' x : ι, ∑' y : κ, e x y m) := by
   letI : Fintype ι := Fintype.ofFinite ι
   letI : Fintype κ := Fintype.ofFinite κ
+  -- Commute the finite `y`-sum past the `m`-sum for each fixed `x`.
+  have hswap_y : ∀ x : ι, (∑ y : κ, ∑' m : μ, c * (a m * e x y m))
+      = ∑' m : μ, ∑ y : κ, c * (a m * e x y m) := fun x =>
+    (Summable.tsum_finsetSum fun y _ => by simpa [mul_assoc] using hSummable x y).symm
+  -- Commute the finite `x`-sum past the `m`-sum.
+  have hswap_x : (∑ x : ι, ∑' m : μ, ∑ y : κ, c * (a m * e x y m))
+      = ∑' m : μ, ∑ x : ι, ∑ y : κ, c * (a m * e x y m) :=
+    (Summable.tsum_finsetSum fun x _ =>
+      summable_sum fun y _ => by simpa [mul_assoc] using hSummable x y).symm
   simp only [tsum_fintype]
-  simp_rw [← tsum_mul_left]
-  simp_rw [show ∀ x : ι, (∑ y : κ, ∑' m : μ, c * (a m * e x y m))
-        = ∑' m : μ, ∑ y : κ, c * (a m * e x y m) from fun x =>
-    (Summable.tsum_finsetSum (fun y _ => by
-      simpa [mul_assoc] using hSummable x y)).symm]
-  rw [show (∑ x : ι, ∑' m : μ, ∑ y : κ, c * (a m * e x y m))
-        = ∑' m : μ, ∑ x : ι, ∑ y : κ, c * (a m * e x y m) from
-    (Summable.tsum_finsetSum (fun x _ =>
-      summable_sum (f := fun (y : κ) (m : μ) => c * (a m * e x y m)) fun y _ => by
-        simpa [mul_assoc] using hSummable x y)).symm]
+  simp_rw [← tsum_mul_left, hswap_y]
+  rw [hswap_x]
   exact tsum_congr fun m => by simp_rw [← Finset.mul_sum]
 
 /-- Summability on the dual lattice of `c * (𝓕 f m).re * exp(2πi⟪x - y, m⟫)`. -/
@@ -1014,17 +1046,18 @@ public lemma calc_steps_swap_sums {d : ℕ} (f : 𝓢(EuclideanSpace ℝ (Fin d)
                     ⟪(x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)),
                       (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]))).re := by
   have : Finite (↑(P.centers ∩ D)) := finite_centers_inter_of_isBounded P D hD_isBounded hd
-  letI : Fintype (↑(P.centers ∩ D)) := Fintype.ofFinite (↑(P.centers ∩ D))
   refine congrArg Complex.re ?_
+  -- Package the covolume scalar `c`, Fourier coefficients `a`, and exponentials `e` for
+  -- `tsum_finset_finset_const_mul_swap`.
   let c : ℂ := (1 / ZLattice.covolume P.lattice volume : ℂ)
   let a : SchwartzMap.dualLattice (d := d) P.lattice → ℂ := fun m => ((𝓕 f m).re : ℂ)
   let e : ↑(P.centers ∩ D) → ↑(P.centers ∩ D) →
       SchwartzMap.dualLattice (d := d) P.lattice → ℂ := fun x y m =>
     exp (2 * π * I * ⟪(x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)),
       (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])
-  have hFourierReal : ∀ m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m) = a m := fun m => by
-    simpa [a] using (hRealFourier (m : EuclideanSpace ℝ (Fin d))).symm
-  simpa (config := { zeta := false }) [c, e, hFourierReal] using
+  have hFourierReal : ∀ m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m) = a m :=
+    fun m => by simpa [a] using (hRealFourier (m : EuclideanSpace ℝ (Fin d))).symm
+  simpa [c, e, hFourierReal] using
     tsum_finset_finset_const_mul_swap c a e fun x y =>
       summable_const_mul_re_fourier_mul_exp f P c x y
 
@@ -1040,12 +1073,13 @@ private lemma lattice_translate_eq_zero (hD_unique_covers : ∀ x, ∃! g : P.la
   have hy0 : (0 : P.lattice) +ᵥ (y : EuclideanSpace ℝ (Fin d)) ∈ D := by
     simpa [Submodule.vadd_def] using y.property.2
   have hyℓ : (-ℓ : P.lattice) +ᵥ (y : EuclideanSpace ℝ (Fin d)) ∈ D := by
+    -- `(-ℓ) +ᵥ y = -ℓ + y = x`, and `x ∈ D` by `x.property.2`.
     have hEq : ((-ℓ : P.lattice) : EuclideanSpace ℝ (Fin d)) + (y : EuclideanSpace ℝ (Fin d)) =
         (x : EuclideanSpace ℝ (Fin d)) := by
       simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc] using
         (eq_sub_of_add_eq hxy).symm
-    simpa [Submodule.vadd_def] using (hEq ▸ x.property.2 :
-      ((-ℓ : P.lattice) : EuclideanSpace ℝ (Fin d)) + _ ∈ D)
+    simp only [Submodule.vadd_def, vadd_eq_add, hEq]
+    exact x.property.2
   simpa using neg_eq_zero.mp ((hg0_unique (-ℓ) hyℓ).trans (hg0_unique 0 hy0).symm)
 
 /-- If `x + ℓ ≠ y` as centers in `P`, then `f` evaluated on the shifted difference is `≤ 0`. -/
@@ -1056,11 +1090,9 @@ private lemma re_f_shifted_nonpos (hP : P.separation = 1)
     (f (x - y + (ℓ : EuclideanSpace ℝ (Fin d)))).re ≤ 0 := by
   have hxℓ : x + (ℓ : EuclideanSpace ℝ (Fin d)) ∈ P.centers := by
     simpa [add_comm] using P.lattice_action ℓ.property hx
-  have hdist : (1 : ℝ) ≤ dist (x + (ℓ : EuclideanSpace ℝ (Fin d))) y := by
-    simpa [hP] using P.centers_dist' _ _ hxℓ hy hxℓy
   have hnorm : (1 : ℝ) ≤ ‖x + (ℓ : EuclideanSpace ℝ (Fin d)) - y‖ := by
-    simpa [dist_eq_norm] using hdist
-  have hle := hCohnElkies₁ _ (by simpa [ge_iff_le] using hnorm)
+    simpa [hP, dist_eq_norm] using P.centers_dist' _ _ hxℓ hy hxℓy
+  have hle := hCohnElkies₁ _ hnorm
   simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using hle
 
 /-- Diagonal case `x = y` of `lattice_sum_re_le_ite`: the lattice sum at the origin equals
@@ -1101,7 +1133,9 @@ public lemma lattice_sum_re_le_ite (hP : P.separation = 1)
   · rw [if_neg hxy]
     refine tsum_nonpos fun ℓ => re_f_shifted_nonpos hP hCohnElkies₁
       x.property.1 y.property.1 ℓ (fun h => ?_)
-    exact hxy (Subtype.ext (by simpa [lattice_translate_eq_zero hD_unique_covers h] using h))
+    -- From `↑x + ↑ℓ = ↑y` we get `ℓ = 0`, hence `↑x = ↑y`, contradicting `x ≠ y`.
+    have hℓ : ℓ = 0 := lattice_translate_eq_zero hD_unique_covers h
+    exact hxy (Subtype.ext (by simpa [hℓ] using h))
 
 end SpherePacking.CohnElkies
 
@@ -1114,26 +1148,33 @@ variable (hCohnElkies₂ : ∀ x : EuclideanSpace ℝ (Fin d), (𝓕 f x).re ≥
 
 local notation "conj" => starRingEnd ℂ
 
-theorem hIntegrable : MeasureTheory.Integrable (𝓕 ⇑f) :=
+/-- The Fourier transform of a Schwartz function is integrable. -/
+theorem integrable_fourier : MeasureTheory.Integrable (𝓕 ⇑f) :=
   (FourierTransform.fourierCLE ℂ (SchwartzMap (EuclideanSpace ℝ (Fin d)) ℂ) f).integrable
 
 include hReal hRealFourier hCohnElkies₂ hne_zero in
 theorem f_zero_pos : 0 < (f 0).re := by
-  refine lt_of_le_of_ne (show 0 ≤ (f 0).re by
+  -- `f 0` is the integral of `𝓕 f`, which is nonnegative by `hCohnElkies₂`.
+  have hnonneg : 0 ≤ (f 0).re := by
     rw [← f.fourierInversion, fourierInv_eq]
     simp only [inner_zero_right, AddChar.map_zero_eq_one, one_smul, ← RCLike.re_eq_complex_re]
     rw [show RCLike.re (∫ (v : EuclideanSpace ℝ (Fin d)), 𝓕 (⇑f) v) =
         ∫ v : EuclideanSpace ℝ (Fin d), RCLike.re ((𝓕 f) v) from
-      (integral_re hIntegrable).symm]
-    exact integral_nonneg fun v ↦ by simpa using hCohnElkies₂ v) fun hf0re => hne_zero <|
+      (integral_re integrable_fourier).symm]
+    exact integral_nonneg fun v ↦ by simpa using hCohnElkies₂ v
+  -- If `(f 0).re = 0`, then `∫ 𝓕 f = 0`, hence `𝓕 f = 0`, hence `f = 0`, contradicting `hne_zero`.
+  refine lt_of_le_of_ne hnonneg fun hf0re => hne_zero <|
     (ContinuousLinearEquiv.map_eq_zero_iff (FourierTransform.fourierCLE ℂ _)).1 ?_
-  have hfun := (Continuous.integral_zero_iff_zero_of_nonneg
-    (Complex.continuous_re.comp (𝓕 f).continuous) hIntegrable.re hCohnElkies₂).1 (by
+  have hintegral_zero : ∫ v : EuclideanSpace ℝ (Fin d), (re ∘ 𝓕 ⇑f) v = 0 := by
     rw [show (∫ v : EuclideanSpace ℝ (Fin d), (re ∘ 𝓕 ⇑f) v) =
         (∫ v : EuclideanSpace ℝ (Fin d), 𝓕 (⇑f) v).re by
-      simpa using integral_re (f := fun v : EuclideanSpace ℝ (Fin d) => 𝓕 (⇑f) v) hIntegrable]
+      simpa using integral_re (f := fun v : EuclideanSpace ℝ (Fin d) => 𝓕 (⇑f) v)
+        integrable_fourier]
     simpa [fourierInv_eq, show f 0 = 0 by simpa [hf0re.symm] using (hReal 0).symm] using
-      congrArg Complex.re (congrArg (· 0) f.fourierInversion))
+      congrArg Complex.re (congrArg (· 0) f.fourierInversion)
+  have hfun := (Continuous.integral_zero_iff_zero_of_nonneg
+    (Complex.continuous_re.comp (𝓕 f).continuous) integrable_fourier.re hCohnElkies₂).1
+    hintegral_zero
   ext x; simpa [show (𝓕 f x).re = 0 by simpa using congrFun hfun x] using (hRealFourier x).symm
 
 section Fundamental_Domain_Dependent
@@ -1152,7 +1193,7 @@ private lemma summable_fourier_mul_norm_exp_sq (hd : 0 < d) :
   refine Summable.of_norm_bounded (g := fun m => ‖(𝓕 ⇑f) (m : EuclideanSpace ℝ (Fin d))‖ *
     ((Fintype.card (↑(P.centers ∩ D)) : ℝ) ^ 2)) ?_ fun m => ?_
   · simpa [SchwartzMap.fourier_coe] using
-      (SpherePacking.CohnElkies.LPBoundAux.summable_norm_comp_add_zlattice
+      (CohnElkies.LPBoundAux.summable_norm_comp_add_zlattice
         (Λ := SchwartzMap.dualLattice (d := d) P.lattice) (f := 𝓕 f)
         (a := (0 : EuclideanSpace ℝ (Fin d)))).mul_right _
   simp only [norm_mul, Real.norm_of_nonneg (sq_nonneg _)]; gcongr
@@ -1167,8 +1208,7 @@ private lemma numReps_mul_f_zero_ge_double_tsum (hd : 0 < d) :
     ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥
       ∑' (x : P.centers) (y : ↑(P.centers ∩ D)), (f (x - ↑y)).re := by
   letI : Fintype ↑(P.centers ∩ D) := P.instFintypeNumReps' hd hD_isBounded
-  classical
-  simp_rw [SpherePacking.CohnElkies.tsum_centers_eq_tsum_centersInter_centersInter_lattice
+  simp_rw [CohnElkies.tsum_centers_eq_tsum_centersInter_centersInter_lattice
     (f := f) (P := P) (D := D) hD_isBounded hD_unique_covers hd, tsum_fintype]
   exact (Finset.sum_le_sum fun x _ => Finset.sum_le_sum fun i _ =>
     CohnElkies.lattice_sum_re_le_ite hP hD_unique_covers hCohnElkies₁ x i).trans
@@ -1186,20 +1226,17 @@ private lemma re_tsum_triple_centers_inter_lattice (hd : 0 < d) :
   exact tsum_congr fun x => by
     rw [re_tsum Summable.of_finite]; exact tsum_congr fun y => by
       simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
-        (re_tsum (SpherePacking.CohnElkies.LPBoundSummability.summable_lattice_translate
+        (re_tsum (CohnElkies.LPBoundSummability.summable_lattice_translate
           (Λ := P.lattice) (f := f) (a := (↑x - ↑y : EuclideanSpace ℝ (Fin d))))).symm
 
 /-- `exp(-(2πi⟪x, m⟫)) = conj (exp(2πi⟪x, m⟫))`. -/
 private lemma exp_neg_two_pi_I_inner_eq_conj {d : ℕ} (x m : EuclideanSpace ℝ (Fin d)) :
     Complex.exp (-(2 * (Real.pi : ℂ) * Complex.I * (⟪x, m⟫_[ℝ] : ℂ)))
       = conj (Complex.exp (2 * (Real.pi : ℂ) * Complex.I * (⟪x, m⟫_[ℝ] : ℂ))) := by
-  calc Complex.exp (-(2 * (Real.pi : ℂ) * Complex.I * (⟪x, m⟫_[ℝ] : ℂ)))
-      = Circle.exp (-2 * Real.pi * ⟪x, m⟫_[ℝ]) := by
-        rw [Circle.coe_exp]; push_cast; ring_nf
-    _ = conj (Circle.exp (2 * Real.pi * ⟪x, m⟫_[ℝ])) := by
-        rw [mul_assoc, neg_mul, ← mul_assoc, ← Circle.coe_inv_eq_conj, Circle.exp_neg]
-    _ = conj (Complex.exp (2 * (Real.pi : ℂ) * Complex.I * (⟪x, m⟫_[ℝ] : ℂ))) := by
-        rw [Circle.coe_exp]; apply congrArg conj; push_cast; ring_nf
+  rw [← Complex.exp_conj]
+  congr 1
+  simp only [map_mul, map_ofNat, Complex.conj_I, Complex.conj_ofReal]
+  ring
 
 /-- Reduce `((c * ∑' m, a m * (z * conj z)).re : ℂ) = ↑((c * ∑' m, a m * ‖z‖^2).re)`,
 the final normSq-identity step in the LP-bound calculation. -/
@@ -1236,7 +1273,8 @@ theorem calc_steps_part1 (hd : 0 < d) :
   calc ↑(P.numReps' hd hD_isBounded) * (f 0).re
   _ ≥ ∑' (x : P.centers) (y : ↑(P.centers ∩ D)), (f (x - ↑y)).re :=
         numReps_mul_f_zero_ge_double_tsum hCohnElkies₁ hP hD_isBounded hD_unique_covers hd
-  _ = ∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)) (ℓ : P.lattice), (f (↑x - ↑y + ↑ℓ)).re :=
+  _ = ∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)) (ℓ : P.lattice),
+      (f (↑x - ↑y + ↑ℓ)).re :=
         CohnElkies.tsum_centers_eq_tsum_centersInter_centersInter_lattice f P
           hD_isBounded hD_unique_covers hd
   _ = (∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)) (ℓ : P.lattice),
@@ -1250,7 +1288,7 @@ theorem calc_steps_part1 (hd : 0 < d) :
       ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
       (𝓕 f m).re * (∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)),
       exp (2 * π * I * ⟪↑x - ↑y, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]))).re := by
-        simpa using SpherePacking.CohnElkies.calc_steps_swap_sums (f := f)
+        simpa using CohnElkies.calc_steps_swap_sums (f := f)
           (hRealFourier := hRealFourier) (P := P) (D := D) hD_isBounded hd
   _ = ((1 / ZLattice.covolume P.lattice volume) *
       ∑' m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m).re * (
@@ -1340,9 +1378,9 @@ private lemma density_le_of_𝓕_zero (h𝓕f : 𝓕 f 0 = 0) :
         volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) := by
   have vol_ne_zero : volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) ≠ 0 :=
     (Metric.measure_ball_pos (μ := volume) _ one_half_pos).ne'
+  have hf0_pos : 0 < (f 0).re := f_zero_pos hne_zero hReal hRealFourier hCohnElkies₂
   rw [h𝓕f, zero_re, toNNReal_zero, ENNReal.coe_zero,
-    ENNReal.div_zero (ENNReal.coe_ne_zero.mpr (toNNReal_pos.mpr
-      (f_zero_pos hne_zero hReal hRealFourier hCohnElkies₂)).ne'),
+    ENNReal.div_zero (ENNReal.coe_ne_zero.mpr (toNNReal_pos.mpr hf0_pos).ne'),
     ENNReal.top_mul vol_ne_zero]
   exact le_top
 
@@ -1366,6 +1404,18 @@ private lemma density_le_of_hCalc_of_ne_zero
     rw [ne_eq, Real.toNNReal_eq_zero, not_le]
     exact lt_of_le_of_ne (hCohnElkies₂ 0) fun heq => h𝓕f <|
       Complex.ext heq.symm (by simpa [eq_comm] using congrArg Complex.im (hRealFourier 0))
+  -- Pull the casts of the two products out of the `ENNReal` arithmetic into `Real.toNNReal`.
+  have hcast_num : (P.numReps : ENNReal) * ↑(f 0).re.toNNReal =
+      ↑(P.numReps * (f 0).re).toNNReal := by
+    simp [Real.toNNReal_mul (Nat.cast_nonneg _)]
+  have hcast_sq : (P.numReps : ENNReal) ^ 2 * ((𝓕 f 0).re.toNNReal : ENNReal) /
+      ((ZLattice.covolume P.lattice volume).toNNReal : ENNReal) =
+      ↑((P.numReps : ℝ) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume).toNNReal := by
+    simp only [div_eq_mul_inv, ← ENNReal.coe_inv (Real.toNNReal_pos.mpr hcov_pos).ne',
+      Real.toNNReal_of_nonneg (mul_nonneg (mul_nonneg (sq_nonneg _) (hCohnElkies₂ 0))
+        (inv_nonneg.mpr hcov_pos.le))]
+    norm_cast
+    rw [Real.toNNReal_of_nonneg (hCohnElkies₂ 0), Real.toNNReal_of_nonneg hcov_pos.le]; rfl
   rw [ENat.toENNReal_coe, mul_div_assoc, div_eq_mul_inv (volume _), mul_comm (volume _),
     ← mul_assoc, ENNReal.mul_le_mul_iff_left vol_ne_zero measure_ball_lt_top.ne,
     ← ENNReal.mul_le_mul_iff_left hfouaux₁ ENNReal.coe_ne_top,
@@ -1375,17 +1425,7 @@ private lemma density_le_of_hCalc_of_ne_zero
       (by simpa [ENat.toENNReal_coe] using Fintype.card_ne_zero :
         ENat.toENNReal (P.numReps : ENat) ≠ 0)
       (Ne.symm (ne_of_beq_false rfl) : ENat.toENNReal (P.numReps : ENat) ≠ ⊤),
-    ENat.toENNReal_coe, ← mul_assoc, ← pow_two, ← mul_div_assoc,
-    show (P.numReps : ENNReal) * ↑(f 0).re.toNNReal = (P.numReps * (f 0).re).toNNReal by
-      simp [Real.toNNReal_mul (Nat.cast_nonneg _)],
-    show (P.numReps : ENNReal) ^ 2 * ((𝓕 f 0).re.toNNReal : ENNReal) /
-        ((ZLattice.covolume P.lattice volume).toNNReal : ENNReal) =
-        ((P.numReps) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume).toNNReal by
-      simp only [div_eq_mul_inv, ← ENNReal.coe_inv (Real.toNNReal_pos.mpr hcov_pos).ne',
-        Real.toNNReal_of_nonneg (mul_nonneg (mul_nonneg (sq_nonneg _) (hCohnElkies₂ 0))
-          (inv_nonneg.mpr hcov_pos.le))]
-      norm_cast
-      rw [Real.toNNReal_of_nonneg (hCohnElkies₂ 0), Real.toNNReal_of_nonneg hcov_pos.le]; rfl,
+    ENat.toENNReal_coe, ← mul_assoc, ← pow_two, ← mul_div_assoc, hcast_num, hcast_sq,
     ENNReal.coe_le_coe]
   exact Real.toNNReal_le_toNNReal hCalc
 
@@ -1400,8 +1440,9 @@ public theorem LinearProgrammingBound' (hd : 0 < d) :
   rw [P.density_eq' hd]
   suffices hCalc : (P.numReps' hd hD_isBounded) * (f 0).re ≥
     (P.numReps' hd hD_isBounded)^2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume by
-    rw [hP]; rw [ge_iff_le] at hCalc
-    rcases eq_or_ne (𝓕 f 0) 0 with h𝓕f | h𝓕f
+    rw [hP]
+    rw [ge_iff_le] at hCalc
+    by_cases h𝓕f : 𝓕 f 0 = 0
     · exact density_le_of_𝓕_zero (P := P) hne_zero hReal hRealFourier hCohnElkies₂ h𝓕f
     rw [← PeriodicSpherePacking.numReps_eq_numReps' (S := P) Fact.out hD_isBounded
       hD_unique_covers] at hCalc

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib
+public import Mathlib.Dynamics.Ergodic.Action.Regular
+public import Mathlib.Order.CompletePartialOrder
 
 public import SpherePacking.Basic.PeriodicPacking
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
 public import SpherePacking.ForMathlib.CoordCube
+public import SpherePacking.ForMathlib.DualLattice
 
 /-!
 # Cohn-Elkies linear programming bound

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -790,26 +790,6 @@ public theorem summable_lattice_translate_re :
 
 end LPBoundSummability
 
-/-- A discrete `ℤ`-lattice has a discrete dual submodule (for the Euclidean inner product). -/
-public instance (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ]
-    [IsZLattice ℝ Λ] :
-    DiscreteTopology
-      (LinearMap.BilinForm.dualSubmodule (B := innerₗ (EuclideanSpace ℝ (Fin d))) Λ) := by
-  -- `bZ` is an integral basis of `Λ`; its inner-product dual basis spans the dual submodule.
-  let bZ : Basis (Module.Free.ChooseBasisIndex ℤ Λ) ℤ Λ := Module.Free.chooseBasis ℤ Λ
-  have hB : LinearMap.BilinForm.Nondegenerate (innerₗ (EuclideanSpace ℝ (Fin d)) :
-      LinearMap.BilinForm ℝ (EuclideanSpace ℝ (Fin d))) := by
-    constructor <;> intro x hx <;>
-      exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))
-  have hspan : LinearMap.BilinForm.dualSubmodule (B := innerₗ (EuclideanSpace ℝ (Fin d))) Λ =
-      Submodule.span ℤ (Set.range
-        (LinearMap.BilinForm.dualBasis (B := innerₗ (EuclideanSpace ℝ (Fin d)))
-          hB (bZ.ofZLatticeBasis ℝ Λ))) := by
-    simpa [bZ.ofZLatticeBasis_span (K := ℝ) (L := Λ)] using
-      LinearMap.BilinForm.dualSubmodule_span_of_basis (B := innerₗ (EuclideanSpace ℝ (Fin d)))
-        (R := ℤ) (S := ℝ) (M := EuclideanSpace ℝ (Fin d)) hB (bZ.ofZLatticeBasis ℝ Λ)
-  exact hspan ▸ inferInstance
-
 noncomputable section
 
 /-- The equivalence `(P.centers ∩ D) × P.lattice ≃ P.centers` from a unique-covering hypothesis,

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -290,10 +290,13 @@ lemma volume_cubeShell_eq_pow (L : ℝ) :
   have hsub : {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc 1 (L - 1)} ⊆
       {x | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} :=
     fun x hx i => ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
-  simpa [volume_cube_Icc, show L + 2⁻¹ - -(2⁻¹ : ℝ) = L + 1 by ring,
-    show L - 1 - 1 = L - 2 by ring] using
-    measure_diff (μ := volume) hsub (measurableSet_cube measurableSet_Icc).nullMeasurableSet
-      (by simp [volume_cube_Icc])
+  have hfin : volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc 1 (L - 1)} ≠ ∞ := by
+    rw [volume_cube_Icc]
+    exact ENNReal.pow_ne_top ENNReal.ofReal_ne_top
+  rw [measure_diff (μ := volume) hsub
+      (measurableSet_cube measurableSet_Icc).nullMeasurableSet hfin,
+    volume_cube_Icc, volume_cube_Icc,
+    show L + 2⁻¹ - -(2⁻¹ : ℝ) = L + 1 by ring, show L - 1 - 1 = L - 2 by ring]
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
@@ -458,11 +461,16 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
   refine ⟨g0, sg, fun x hx => (hX.mem_toFinset.1 (Finset.mem_filter.1 hx).1).1,
     fun x hx => ?_, ?_⟩
   · -- `x` lies in the `g0`-translate of the cube: the witness is the covering translate of `x`,
-    -- since `g0` is its negation on the fibre.
+    -- whose negation is `g0` on the fibre; the identity is checked in the ambient space.
     refine ⟨_, fundamentalDomain_cubeBasis L hL ▸
       fundamentalDomainCover_spec (cubeBasis d L hL) x, ?_⟩
-    rw [show g0 = -fundamentalDomainCover (cubeBasis d L hL) x from
-      (Finset.mem_filter.1 hx).2.symm, vadd_vadd, neg_add_cancel, zero_vadd]
+    have hg0 : (g0 : EuclideanSpace ℝ (Fin d)) =
+        -(fundamentalDomainCover (cubeBasis d L hL) x : EuclideanSpace ℝ (Fin d)) := by
+      rw [← (Finset.mem_filter.1 hx).2]
+      exact map_neg (cubeLattice d L hL).subtype _
+    show (g0 : EuclideanSpace ℝ (Fin d)) +ᵥ
+        ((fundamentalDomainCover (cubeBasis d L hL) x : EuclideanSpace ℝ (Fin d)) +ᵥ x) = x
+    rw [hg0, vadd_vadd, neg_add_cancel, zero_vadd]
   · have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
       have hcard : s.card ≤ t.card * sg.card := by
         simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -692,11 +692,12 @@ end LPPrereqs
 locally here and in `PoissonSummationGeneral.lean`): it elaborates literally to
 `LinearMap.BilinForm.dualSubmodule`, so the discreteness instance
 `instDiscreteTopology_dualSubmodule_innerₗ` from `ForMathlib/DualLattice.lean` applies directly.
-Declared at file level so it scopes over the remaining sections (cf. `conj` below); the dimension
-`d` in the expansion resolves at each use site, hence the disabled precheck. -/
+Declared at file level so it scopes over the remaining sections (cf. `conj` below); the ambient
+space is a hole, pinned by unification with `L`'s type at each use site (notation hygiene forbids
+capturing a use-site `d`). -/
 set_option quotPrecheck false in
 local notation:max "dualLattice " L:max =>
-  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
+  LinearMap.BilinForm.dualSubmodule (innerₗ _) L
 
 namespace SpherePacking.CohnElkies
 variable {d : ℕ}

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
+-- The two imports below are `#min_imports` artifacts: they carry instances that the elaboration
+-- of this file's statements depends on (cf. the `CStarMatrix` note in
+-- `SpherePacking/UpperBound.lean`). Do not remove without a full build.
 public import Mathlib.Dynamics.Ergodic.Action.Regular
 public import Mathlib.Order.CompletePartialOrder
 
@@ -15,7 +18,8 @@ public import SpherePacking.ForMathlib.DualLattice
 /-!
 # Cohn-Elkies linear programming bound
 
-Cohn-Elkies upper bound on `SpherePackingConstant d` via `LinearProgrammingBound`. Also contains
+Cohn-Elkies upper bound on `SpherePackingConstant d` via
+`SpherePacking.CohnElkies.LinearProgrammingBound`. Also contains
 the periodizing constructions and boundary-control machinery (merged from `BoundaryControl`):
 `periodizedCenters`, `periodize_to_periodicSpherePacking`, the inline coordinate cubes
 `{x | ∀ i, x i ∈ Set.Ico 0 L}`/`{x | ∀ i, x i ∈ Set.Icc r (L - r)}`, the cube lattice
@@ -38,10 +42,6 @@ local notation:max "cubeBasis " d:max L:max hL:max =>
     fun _ : Fin d ↦ IsUnit.mk0 L (LT.lt.ne' hL)
 local notation:max "cubeLattice " d:max L:max hL:max =>
   Submodule.span ℤ (Set.range (cubeBasis d L hL))
-
-/-- Any coordinate of a vector is bounded in absolute value by the Euclidean norm. -/
-public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x i| ≤ ‖x‖ :=
-  PiLp.norm_apply_le x i
 
 /-- If `ball x r ⊆ A` and `ball y r ⊆ B` with `A` and `B` disjoint, then `2 * r ≤ dist x y`. Holds
 in any real normed space. -/
@@ -113,7 +113,7 @@ lemma ball_subset_cube_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
     (hx : ∀ i, x i ∈ Set.Icc r (L - r)) :
     ball x r ⊆ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} :=
   fun y hy i => by
-  have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using abs_coord_le_norm (y - x) i
+  have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using PiLp.norm_apply_le (y - x) i
   have h₂ : ‖y - x‖ < r := by simpa [dist_eq_norm] using hy
   obtain ⟨hlo, hhi⟩ := abs_lt.mp (h₁.trans_lt h₂)
   obtain ⟨hxl, hxr⟩ := hx i
@@ -138,8 +138,9 @@ public lemma periodizedCenters_inter_eq_of_subset {Λ : Submodule ℤ (Euclidean
 unique lattice translate landing in `D`, the same holds for `v +ᵥ D`. Fully lattice-generic — no
 cube, basis, or `EuclideanSpace` structure is used. -/
 public lemma vadd_unique_covers {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))}
-    {D : Set (EuclideanSpace ℝ (Fin d))} (hD : ∀ x, ∃! g : Λ, g +ᵥ x ∈ D) (v : Λ) :
-    ∀ x, ∃! g : Λ, g +ᵥ x ∈ v +ᵥ D := fun x => by
+    {D : Set (EuclideanSpace ℝ (Fin d))} (hD : ∀ x, ∃! g : Λ, g +ᵥ x ∈ D) (v : Λ)
+    (x : EuclideanSpace ℝ (Fin d)) :
+    ∃! g : Λ, g +ᵥ x ∈ v +ᵥ D := by
   have hvadd (a : Λ) : a +ᵥ x ∈ v +ᵥ D ↔ (a - v) +ᵥ x ∈ D := by
     simp [Set.mem_vadd_set_iff_neg_vadd_mem, Submodule.vadd_def, vadd_eq_add, sub_eq_add_neg,
       add_assoc, add_comm]
@@ -233,7 +234,7 @@ lemma cube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
         {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)} := by
   rintro z ⟨x, hx, y, hy, rfl⟩
   have hyi : ∀ i : Fin d, |y i| < (2⁻¹ : ℝ) := fun i =>
-    (abs_coord_le_norm y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
+    (PiLp.norm_apply_le y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
   rw [Set.mem_diff] at hx
   refine ⟨fun i => ?_, fun hz_inner => ?_⟩
   · -- Each coordinate of `x + y` lands in `[-1/2, L + 1/2]`.
@@ -672,15 +673,10 @@ open MeasureTheory Filter
 /-- If `f` is continuous, integrable, and pointwise nonnegative, then `∫ f = 0` iff `f = 0`.
 The only requirement on the measure is that it is positive on nonempty open sets
 (`IsOpenPosMeasure`); no group or invariance structure is needed. -/
-public theorem Continuous.integral_zero_iff_zero_of_nonneg {E : Type*} [TopologicalSpace E]
+public theorem Continuous.integral_eq_zero_iff_of_nonneg {E : Type*} [TopologicalSpace E]
     [MeasurableSpace E] {μ : Measure E} [μ.IsOpenPosMeasure] {f : E → ℝ} (hf₁ : Continuous f)
     (hf₂ : Integrable f μ) (hnn : ∀ x, 0 ≤ f x) : ∫ (v : E), f v ∂μ = 0 ↔ f = 0 := by
-  refine ⟨fun hintf => funext fun x => ?_, fun hf => by simp [hf]⟩
-  by_contra hx
-  exact (MeasureTheory.Measure.measure_pos_of_mem_nhds μ
-      ((isOpen_lt continuous_const hf₁).mem_nhds (lt_of_le_of_ne (hnn x) (Ne.symm hx)))).ne'
-    (measure_mono_null (fun (y : E) (hy : 0 < f y) => hy.ne')
-      ((integral_eq_zero_iff_of_nonneg hnn hf₂).1 hintf))
+  rw [MeasureTheory.integral_eq_zero_iff_of_nonneg hnn hf₂, hf₁.ae_eq_iff_eq μ continuous_zero]
 
 end Integration
 
@@ -690,8 +686,8 @@ end LPPrereqs
 
 /- The dual `ℤ`-lattice for the Euclidean inner product is *notation*, not a definition (declared
 locally here and in `PoissonSummationGeneral.lean`): it elaborates literally to
-`LinearMap.BilinForm.dualSubmodule`, so the discreteness instance
-`instDiscreteTopology_dualSubmodule_innerₗ` from `ForMathlib/DualLattice.lean` applies directly.
+`LinearMap.BilinForm.dualSubmodule`, so the discreteness instance from
+`ForMathlib/DualLattice.lean` applies directly.
 Declared at file level so it scopes over the remaining sections (cf. `conj` below); the ambient
 space is a hole, pinned by unification with `L`'s type at each use site (notation hygiene forbids
 capturing a use-site `d`). -/
@@ -1024,9 +1020,6 @@ public lemma lattice_sum_re_le_ite (hP : P.separation = 1)
     have hℓ : ℓ = 0 := lattice_translate_eq_zero hD_unique_covers h
     exact hxy (Subtype.ext (by simpa [hℓ] using h))
 
-end SpherePacking.CohnElkies
-
-variable {d : ℕ}
 variable {f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ)} (hne_zero : f ≠ 0)
 variable (hReal : ∀ x : EuclideanSpace ℝ (Fin d), ↑(f x).re = (f x))
 variable (hRealFourier : ∀ x : EuclideanSpace ℝ (Fin d), ↑(𝓕 f x).re = (𝓕 f x))
@@ -1059,7 +1052,7 @@ theorem f_zero_pos : 0 < (f 0).re := by
         integrable_fourier]
     simpa [fourierInv_eq, show f 0 = 0 by simpa [hf0re.symm] using (hReal 0).symm] using
       congrArg Complex.re (congrArg (· 0) f.fourierInversion)
-  have hfun := (Continuous.integral_zero_iff_zero_of_nonneg
+  have hfun := (Continuous.integral_eq_zero_iff_of_nonneg
     (Complex.continuous_re.comp (𝓕 f).continuous) integrable_fourier.re hCohnElkies₂).1
     hintegral_zero
   ext x; simpa [show (𝓕 f x).re = 0 by simpa using congrFun hfun x] using (hRealFourier x).symm
@@ -1147,16 +1140,15 @@ private lemma re_mul_conj_eq_norm_sq_step {d : ℕ}
   congr 1; push_cast; congr! 3 with m
   rw [mul_assoc, mul_conj, Complex.normSq_eq_norm_sq]; norm_cast
 
-
 include d f hP hRealFourier hCohnElkies₁ hD_unique_covers in
-theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
-    ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥
-      (1 / ZLattice.covolume P.lattice volume) *
+theorem le_numReps_mul_re_f_zero (hd : 0 < d) :
+    (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
-                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
+                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
+      ≤ ↑(P.numReps' hd hD_isBounded) * (f 0).re := by
   calc ↑(P.numReps' hd hD_isBounded) * (f 0).re
   _ ≥ ∑' (x : P.centers) (y : ↑(P.centers ∩ D)), (f (x - ↑y)).re :=
         numReps_mul_f_zero_ge_double_tsum hCohnElkies₁ hP hD_isBounded hD_unique_covers hd
@@ -1209,14 +1201,13 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
 
 include d f hCohnElkies₂ in omit [Nonempty ↑P.centers] in
 theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
-    (1 / ZLattice.covolume P.lattice volume) *
+    ↑(P.numReps' hd hD_isBounded) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume ≤
+      (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
-                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
-      ≥
-      ↑(P.numReps' hd hD_isBounded) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume := by
+                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
   calc (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
@@ -1257,7 +1248,7 @@ theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
 
 omit [Nonempty ↑P.centers] in include hne_zero hReal hRealFourier hCohnElkies₂ in
 /-- Degenerate case of the LP bound when `𝓕 f 0 = 0`: the right-hand side is `∞`. -/
-private lemma density_le_of_𝓕_zero (h𝓕f : 𝓕 f 0 = 0) :
+private lemma density_le_of_fourier_zero (h𝓕f : 𝓕 f 0 = 0) :
     ENat.toENNReal (P.numReps : ENat) *
         volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) /
         (ZLattice.covolume P.lattice volume).toNNReal ≤
@@ -1311,7 +1302,7 @@ private lemma density_le_of_hCalc_of_ne_zero
     ← ENNReal.div_eq_inv_mul, ← ENNReal.mul_le_mul_iff_right
       (by simpa [ENat.toENNReal_coe] using Fintype.card_ne_zero :
         ENat.toENNReal (P.numReps : ENat) ≠ 0)
-      (Ne.symm (ne_of_beq_false rfl) : ENat.toENNReal (P.numReps : ENat) ≠ ⊤),
+      (by simp : ENat.toENNReal (P.numReps : ENat) ≠ ⊤),
     ENat.toENNReal_coe, ← mul_assoc, ← pow_two, ← mul_div_assoc, hcast_num, hcast_sq,
     ENNReal.coe_le_coe]
   exact Real.toNNReal_le_toNNReal hCalc
@@ -1325,23 +1316,21 @@ public theorem LinearProgrammingBound_periodic (hd : 0 < d) :
       volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) := by
   haveI : Fact (0 < d) := ⟨hd⟩
   rw [P.density_eq' hd]
-  suffices hCalc : (P.numReps' hd hD_isBounded) * (f 0).re ≥
-    (P.numReps' hd hD_isBounded)^2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume by
+  suffices hCalc : (P.numReps' hd hD_isBounded)^2 * (𝓕 f 0).re /
+      ZLattice.covolume P.lattice volume ≤ (P.numReps' hd hD_isBounded) * (f 0).re by
     rw [hP]
-    rw [ge_iff_le] at hCalc
     by_cases h𝓕f : 𝓕 f 0 = 0
-    · exact density_le_of_𝓕_zero (P := P) hne_zero hReal hRealFourier hCohnElkies₂ h𝓕f
+    · exact density_le_of_fourier_zero (P := P) hne_zero hReal hRealFourier hCohnElkies₂ h𝓕f
     rw [← PeriodicSpherePacking.numReps_eq_numReps' (S := P) Fact.out hD_isBounded
       hD_unique_covers] at hCalc
     haveI : Nonempty (Quotient (AddAction.orbitRel ↥P.lattice ↑P.centers)) :=
       (nonempty_quotient_iff _).2 ‹_›
     exact density_le_of_hCalc_of_ne_zero (P := P) hRealFourier hCohnElkies₂
       (ZLattice.covolume_pos P.lattice volume) h𝓕f hCalc
-  exact ge_trans
-    (numReps_mul_re_f_zero_ge (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
+  exact (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D)
+      (hCohnElkies₂ := hCohnElkies₂) hD_isBounded hd).trans
+    (le_numReps_mul_re_f_zero (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
       hD_unique_covers hd)
-    (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D) (hCohnElkies₂ := hCohnElkies₂)
-      hD_isBounded hd)
 
 end Fundamental_Domain_Dependent
 
@@ -1349,7 +1338,7 @@ include d f hne_zero hReal hRealFourier hCohnElkies₁ hCohnElkies₂
 
 /-- The Cohn-Elkies linear programming upper bound on `SpherePackingConstant d`. -/
 public theorem LinearProgrammingBound (hd : 0 < d) : SpherePackingConstant d ≤
-    (f 0).re.toNNReal / (𝓕 ⇑f 0).re.toNNReal *
+    (f 0).re.toNNReal / (𝓕 f 0).re.toNNReal *
       volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) := by
   rw [← periodic_constant_eq_constant hd,
     periodic_constant_eq_periodic_constant_normalized (d := d)]
@@ -1360,3 +1349,5 @@ public theorem LinearProgrammingBound (hd : 0 < d) : SpherePackingConstant d ≤
     (ZSpan.fundamentalDomain_isBounded _) (PeriodicSpherePacking.fundamental_domain_unique_covers
       (S := P) (((ZLattice.module_free ℝ P.lattice).chooseBasis).reindex
         (PeriodicSpherePacking.basis_index_equiv P))) hd
+
+end SpherePacking.CohnElkies

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -1149,6 +1149,7 @@ theorem le_numReps_mul_re_f_zero (hd : 0 < d) :
               exp (2 * π * I *
                 ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
       ≤ ↑(P.numReps' hd hD_isBounded) * (f 0).re := by
+  rw [← ge_iff_le]
   calc ↑(P.numReps' hd hD_isBounded) * (f 0).re
   _ ≥ ∑' (x : P.centers) (y : ↑(P.centers ∩ D)), (f (x - ↑y)).re :=
         numReps_mul_f_zero_ge_double_tsum hCohnElkies₁ hP hD_isBounded hD_unique_covers hd
@@ -1208,6 +1209,7 @@ theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
                 ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
+  rw [← ge_iff_le]
   calc (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -1329,8 +1329,9 @@ public theorem LinearProgrammingBound_periodic (hd : 0 < d) :
       (nonempty_quotient_iff _).2 ‹_›
     exact density_le_of_hCalc_of_ne_zero (P := P) hRealFourier hCohnElkies₂
       (ZLattice.covolume_pos P.lattice volume) h𝓕f hCalc
-  exact (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D)
-      (hCohnElkies₂ := hCohnElkies₂) hD_isBounded hd).trans
+  exact le_trans
+    (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D)
+      (hCohnElkies₂ := hCohnElkies₂) hD_isBounded hd)
     (le_numReps_mul_re_f_zero (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
       hD_unique_covers hd)
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -34,7 +34,8 @@ definitions (declared locally here and in `ForMathlib/CoordCube.lean`, following
 pattern for cross-file notation, cf. `ℝ⁸`): they elaborate literally to `Basis.isUnitSMul` and
 `Submodule.span`, so Mathlib's `ZSpan`/`ZLattice` lemmas and instances apply directly. -/
 local notation:max "cubeBasis " d:max L:max hL:max =>
-  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
+  Module.Basis.isUnitSMul (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ))
+    fun _ : Fin d ↦ IsUnit.mk0 L (LT.lt.ne' hL)
 local notation:max "cubeLattice " d:max L:max hL:max =>
   Submodule.span ℤ (Set.range (cubeBasis d L hL))
 

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -648,6 +648,13 @@ section LPPrereqs
 variable {d : ℕ} [Fact (0 < d)]
 variable (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ] [IsZLattice ℝ Λ]
 
+/- The dual `ℤ`-lattice for the Euclidean inner product is *notation*, not a definition (declared
+locally here and in `PoissonSummationGeneral.lean`): it elaborates literally to
+`LinearMap.BilinForm.dualSubmodule`, so the discreteness instance
+`instDiscreteTopology_dualSubmodule_innerₗ` from `ForMathlib/DualLattice.lean` applies directly. -/
+local notation:max "dualLattice " L:max =>
+  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
+
 /-- Convenience: `Fin d` is nonempty when `0 < d`. -/
 public instance instNonemptyFin : Nonempty (Fin d) := ⟨0, Fact.out⟩
 
@@ -880,13 +887,13 @@ private lemma tsum_finset_finset_const_mul_swap {ι κ μ : Type*} [Finite ι] [
 private lemma summable_const_mul_re_fourier_mul_exp {d : ℕ}
     (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ)) (P : PeriodicSpherePacking d) (c : ℂ)
     (x y : EuclideanSpace ℝ (Fin d)) :
-    Summable fun m : SchwartzMap.dualLattice (d := d) P.lattice =>
+    Summable fun m : dualLattice P.lattice =>
       c * (((𝓕 f m).re : ℂ)) *
         exp (2 * π * I * ⟪x - y, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]) := by
-  have hFNorm : Summable fun m : SchwartzMap.dualLattice (d := d) P.lattice =>
+  have hFNorm : Summable fun m : dualLattice P.lattice =>
       ‖(𝓕 f) (m : EuclideanSpace ℝ (Fin d))‖ := by
     simpa using SpherePacking.CohnElkies.LPBoundAux.summable_norm_comp_add_zlattice
-      (Λ := SchwartzMap.dualLattice (d := d) P.lattice) (f := 𝓕 f)
+      (Λ := dualLattice P.lattice) (f := 𝓕 f)
       (a := (0 : EuclideanSpace ℝ (Fin d)))
   refine Summable.of_norm_bounded
     (g := fun m => ‖c‖ * ‖(𝓕 f) (m : EuclideanSpace ℝ (Fin d))‖)
@@ -908,14 +915,14 @@ public lemma calc_steps_swap_sums {d : ℕ} (f : 𝓢(EuclideanSpace ℝ (Fin d)
     (∑' x : ↑(P.centers ∩ D),
         ∑' y : ↑(P.centers ∩ D),
           (1 / ZLattice.covolume P.lattice volume) *
-            ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+            ∑' m : dualLattice P.lattice,
               (𝓕 f m) *
                 exp (2 * π * I *
                   ⟪(x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)),
                     (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])).re
       =
       ((1 / ZLattice.covolume P.lattice volume) *
-          ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+          ∑' m : dualLattice P.lattice,
             (𝓕 f m).re *
               (∑' x : ↑(P.centers ∩ D),
                 ∑' y : ↑(P.centers ∩ D),
@@ -927,12 +934,12 @@ public lemma calc_steps_swap_sums {d : ℕ} (f : 𝓢(EuclideanSpace ℝ (Fin d)
   -- Package the covolume scalar `c`, Fourier coefficients `a`, and exponentials `e` for
   -- `tsum_finset_finset_const_mul_swap`.
   let c : ℂ := (1 / ZLattice.covolume P.lattice volume : ℂ)
-  let a : SchwartzMap.dualLattice (d := d) P.lattice → ℂ := fun m => ((𝓕 f m).re : ℂ)
+  let a : dualLattice P.lattice → ℂ := fun m => ((𝓕 f m).re : ℂ)
   let e : ↑(P.centers ∩ D) → ↑(P.centers ∩ D) →
-      SchwartzMap.dualLattice (d := d) P.lattice → ℂ := fun x y m =>
+      dualLattice P.lattice → ℂ := fun x y m =>
     exp (2 * π * I * ⟪(x : EuclideanSpace ℝ (Fin d)) - (y : EuclideanSpace ℝ (Fin d)),
       (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])
-  have hFourierReal : ∀ m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m) = a m :=
+  have hFourierReal : ∀ m : dualLattice P.lattice, (𝓕 f m) = a m :=
     fun m => by simpa [a] using (hRealFourier (m : EuclideanSpace ℝ (Fin d))).symm
   simpa [c, e, hFourierReal] using
     tsum_finset_finset_const_mul_swap c a e fun x y =>
@@ -1062,7 +1069,7 @@ variable (hD_unique_covers : ∀ x, ∃! g : P.lattice, g +ᵥ x ∈ D)
 
 omit [Nonempty ↑P.centers] in include hD_isBounded in
 private lemma summable_fourier_mul_norm_exp_sq (hd : 0 < d) :
-    Summable (fun m : ↥(SchwartzMap.dualLattice (d := d) P.lattice) =>
+    Summable (fun m : ↥(dualLattice P.lattice) =>
       (𝓕 ⇑f m).re * (norm (∑' x : ↑(P.centers ∩ D),
         exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)) := by
   letI : Fintype (↑(P.centers ∩ D)) :=
@@ -1071,7 +1078,7 @@ private lemma summable_fourier_mul_norm_exp_sq (hd : 0 < d) :
     ((Fintype.card (↑(P.centers ∩ D)) : ℝ) ^ 2)) ?_ fun m => ?_
   · simpa [SchwartzMap.fourier_coe] using
       (CohnElkies.LPBoundAux.summable_norm_comp_add_zlattice
-        (Λ := SchwartzMap.dualLattice (d := d) P.lattice) (f := 𝓕 f)
+        (Λ := dualLattice P.lattice) (f := 𝓕 f)
         (a := (0 : EuclideanSpace ℝ (Fin d)))).mul_right _
   simp only [norm_mul, Real.norm_of_nonneg (sq_nonneg _)]; gcongr
   · simpa [Real.norm_eq_abs] using abs_re_le_norm _
@@ -1121,13 +1128,13 @@ private lemma re_mul_conj_eq_norm_sq_step {d : ℕ}
     (P : PeriodicSpherePacking d) {D : Set (EuclideanSpace ℝ (Fin d))}
     (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ)) :
     ((1 / ZLattice.covolume P.lattice volume) *
-        ∑' m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m).re *
+        ∑' m : dualLattice P.lattice, (𝓕 f m).re *
           (∑' x : ↑(P.centers ∩ D),
             exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) *
           conj (∑' x : ↑(P.centers ∩ D),
             exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]))).re =
       (1 / ZLattice.covolume P.lattice volume) *
-        ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+        ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re * (norm (∑' x : ↑(P.centers ∩ D),
             exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
   rw [← ofReal_re (1 / ZLattice.covolume P.lattice volume *
@@ -1142,7 +1149,7 @@ include d f hP hRealFourier hCohnElkies₁ hD_unique_covers in
 theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
     ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥
       (1 / ZLattice.covolume P.lattice volume) *
-        ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+        ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
@@ -1158,17 +1165,17 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
       f (↑x - ↑y + ↑ℓ)).re := re_tsum_triple_centers_inter_lattice hD_isBounded hd
   _ = (∑' x : ↑(P.centers ∩ D),
       ∑' y : ↑(P.centers ∩ D), (1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m) *
+      ∑' m : dualLattice P.lattice, (𝓕 f m) *
       exp (2 * π * I * ⟪↑x - ↑y, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])).re := by
         congr! 5 with x y; exact SchwartzMap.poissonSummation_lattice P.lattice f _
   _ = ((1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+      ∑' m : dualLattice P.lattice,
       (𝓕 f m).re * (∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)),
       exp (2 * π * I * ⟪↑x - ↑y, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]))).re := by
         simpa using CohnElkies.calc_steps_swap_sums (f := f)
           (hRealFourier := hRealFourier) (P := P) (D := D) hD_isBounded hd
   _ = ((1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m).re * (
+      ∑' m : dualLattice P.lattice, (𝓕 f m).re * (
       ∑' (x : ↑(P.centers ∩ D)) (y : ↑(P.centers ∩ D)),
       exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]) *
       exp (2 * π * I * ⟪-↑y, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ]))).re := by
@@ -1176,7 +1183,7 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
         simp [sub_eq_neg_add, RCLike.wInner_neg_left, ofReal_neg, mul_neg,
           mul_comm, RCLike.wInner_add_left, ofReal_add, mul_add, Complex.exp_add]
   _ = ((1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+      ∑' m : dualLattice P.lattice,
       (𝓕 f m).re * (∑' x : ↑(P.centers ∩ D),
       exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) *
       (∑' y : ↑(P.centers ∩ D),
@@ -1184,7 +1191,7 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
         simp_rw [mul_assoc, ← tsum_mul_right, ← tsum_mul_left]
         congr! 9 with m x y; simp only [RCLike.wInner_neg_left, ofReal_neg, mul_neg]
   _ = ((1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice, (𝓕 f m).re *
+      ∑' m : dualLattice P.lattice, (𝓕 f m).re *
       (∑' x : ↑(P.centers ∩ D),
       exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) *
       conj (∑' x : ↑(P.centers ∩ D),
@@ -1192,7 +1199,7 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
         simp_rw [conj_tsum]; congr! 7 with m x
         exact exp_neg_two_pi_I_inner_eq_conj _ _
   _ = (1 / ZLattice.covolume P.lattice volume) *
-      ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+      ∑' m : dualLattice P.lattice,
         (𝓕 ⇑f m).re * (norm (∑' x : ↑(P.centers ∩ D),
       exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) :=
         re_mul_conj_eq_norm_sq_step P f
@@ -1200,7 +1207,7 @@ theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
 include d f hCohnElkies₂ in omit [Nonempty ↑P.centers] in
 theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
     (1 / ZLattice.covolume P.lattice volume) *
-        ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+        ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
@@ -1208,14 +1215,14 @@ theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
       ≥
       ↑(P.numReps' hd hD_isBounded) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume := by
   calc (1 / ZLattice.covolume P.lattice volume) *
-        ∑' m : SchwartzMap.dualLattice (d := d) P.lattice,
+        ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
                 ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
     _ = (1 / ZLattice.covolume P.lattice volume) * (
-        (∑' (m : SchwartzMap.dualLattice (d := d) P.lattice),
-          if m = (0 : ↥(SchwartzMap.dualLattice (d := d) P.lattice)) then 0
+        (∑' (m : dualLattice P.lattice),
+          if m = (0 : ↥(dualLattice P.lattice)) then 0
           else (𝓕 ⇑f m).re * (norm (∑' x : ↑(P.centers ∩ D),
         exp (2 * π * I * ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)) +
         (𝓕 ⇑f (0 : EuclideanSpace ℝ (Fin d))).re *
@@ -1230,7 +1237,7 @@ theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
         rw [ge_iff_le, ← tsub_nonpos, mul_assoc, ← mul_sub (1 / _) _ _]
         simpa using mul_nonneg (one_div_nonneg.mpr (ZLattice.covolume_pos P.lattice volume).le)
           (tsum_nonneg fun m => by
-            by_cases hm : m = (0 : ↥(SchwartzMap.dualLattice (d := d) P.lattice))
+            by_cases hm : m = (0 : ↥(dualLattice P.lattice))
             · simp [hm]
             · simpa [hm] using mul_nonneg
                 (by simpa using hCohnElkies₂ (m : EuclideanSpace ℝ (Fin d)))

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -29,6 +29,15 @@ open SpherePacking EuclideanSpace MeasureTheory Metric ZSpan Bornology Module Fi
 
 variable {d : ℕ}
 
+/- The scaled standard basis and the cubic lattice `L • ℤ^d` it spans are *notation*, not
+definitions (declared locally here and in `ForMathlib/CoordCube.lean`, following this project's
+pattern for cross-file notation, cf. `ℝ⁸`): they elaborate literally to `Basis.isUnitSMul` and
+`Submodule.span`, so Mathlib's `ZSpan`/`ZLattice` lemmas and instances apply directly. -/
+local notation:max "cubeBasis " d:max L:max hL:max =>
+  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
+local notation:max "cubeLattice " d:max L:max hL:max =>
+  Submodule.span ℤ (Set.range (cubeBasis d L hL))
+
 /-- Any coordinate of a vector is bounded in absolute value by the Euclidean norm. -/
 public lemma abs_coord_le_norm (x : EuclideanSpace ℝ (Fin d)) (i : Fin d) : |x i| ≤ ‖x‖ :=
   PiLp.norm_apply_le x i
@@ -305,7 +314,7 @@ lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
       (volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}).toReal := by
     simpa [Measure.real, fundamentalDomain_cubeBasis L hL] using
       ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice d L hL) (μ := volume)
-        (by simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
+        (ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
           IsAddFundamentalDomain (cubeLattice d L hL)
             (fundamentalDomain (cubeBasis d L hL)) volume)
   simp [hcov]

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -17,8 +17,9 @@ public import SpherePacking.ForMathlib.DualLattice
 
 Cohn-Elkies upper bound on `SpherePackingConstant d` via `LinearProgrammingBound`. Also contains
 the periodizing constructions and boundary-control machinery (merged from `BoundaryControl`):
-`periodizedCenters`, `periodize_to_periodicSpherePacking`, `cubeIco`/`cubeIcc`, the cube
-lattice `cubeLattice`, and the main result `periodic_constant_eq_constant`.
+`periodizedCenters`, `periodize_to_periodicSpherePacking`, the coordinate boxes
+`cubeBox d (Set.Ico 0 L)`/`cubeBox d (Set.Icc r (L - r))`, the cube lattice `cubeLattice`, and the
+main result `periodic_constant_eq_constant`.
 -/
 
 section PeriodicPackingBoundaryControl
@@ -98,8 +99,9 @@ public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin 
   lattice_isZLattice := inferInstance
 
 /-- A ball of radius `r` centred in the inner cube `[r, L-r]^d` is contained in `[0, L)^d`. -/
-lemma ball_subset_cubeIco_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ cubeIcc d L r) : ball x r ⊆ cubeIco d L := fun y hy i => by
+lemma ball_subset_cubeBox_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
+    (hx : x ∈ cubeBox d (Set.Icc r (L - r))) : ball x r ⊆ cubeBox d (Set.Ico 0 L) :=
+  fun y hy i => by
   have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using abs_coord_le_norm (y - x) i
   have h₂ : ‖y - x‖ < r := by simpa [dist_eq_norm] using hy
   obtain ⟨hlo, hhi⟩ := abs_lt.mp (h₁.trans_lt h₂)
@@ -136,12 +138,12 @@ public lemma vadd_unique_covers {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))
 
 namespace PeriodicConstantApprox
 
-public lemma ball_subset_vadd_cubeIco_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
+public lemma ball_subset_vadd_cubeBox_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
     {v : cubeLattice d L hL} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ v +ᵥ cubeIcc d L r) :
-    ball x r ⊆ v +ᵥ cubeIco d L := by
+    (hx : x ∈ v +ᵥ cubeBox d (Set.Icc r (L - r))) :
+    ball x r ⊆ v +ᵥ cubeBox d (Set.Ico 0 L) := by
   obtain ⟨y, hy, rfl⟩ := hx
-  have hball : ball y r ⊆ cubeIco d L := ball_subset_cubeIco_of_mem_inner hy
+  have hball : ball y r ⊆ cubeBox d (Set.Ico 0 L) := ball_subset_cubeBox_of_mem_inner hy
   intro z hz
   refine ⟨z - v, hball ?_, by simp [vadd_eq_add]⟩
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
@@ -181,49 +183,23 @@ lemma neg_fundamentalDomainCover_mem_ball {C R : ℝ}
 
 end FundamentalDomainCover
 
-section CubeCover
-
-variable (L : ℝ) (hL : 0 < L)
-
-/-- The cube cell-assignment map: `fundamentalDomainCover` specialised to the scaled-cube basis.
-A thin wrapper so the pigeonhole argument reads in cube terms (`fundamentalDomain (cubeBasis …) =
-cubeIco`). -/
-noncomputable def cubeIcoCover (x : EuclideanSpace ℝ (Fin d)) : cubeLattice d L hL :=
-  fundamentalDomainCover (cubeBasis d L hL) x
-
-lemma cubeIcoCover_spec (x : EuclideanSpace ℝ (Fin d)) :
-    cubeIcoCover L hL x +ᵥ x ∈ cubeIco d L := by
-  rw [← fundamentalDomain_cubeBasis_eq_cubeIco L hL]
-  exact fundamentalDomainCover_spec (cubeBasis d L hL) x
-
-lemma neg_cubeIcoCover_mem_ball {C R : ℝ}
-    (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
-    {x : EuclideanSpace ℝ (Fin d)} (hx : x ∈ ball 0 R) :
-    ((-cubeIcoCover L hL x : cubeLattice d L hL) :
-        EuclideanSpace ℝ (Fin d)) ∈ ball 0 (R + C) := by
-  refine neg_fundamentalDomainCover_mem_ball (cubeBasis d L hL) ?_ hx
-  rwa [fundamentalDomain_cubeBasis_eq_cubeIco]
-
-end CubeCover
-
-lemma card_finite_lattice_in_ball_mul_volume_cubeIco_le_volume_ball {L : ℝ} (hL : 0 < L)
-    {R C : ℝ} (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
+lemma card_finite_lattice_in_ball_mul_volume_cubeBox_le_volume_ball {L : ℝ} (hL : 0 < L)
+    {R C : ℝ} (hC : cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
     ((finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
-        ℝ≥0∞) * volume (cubeIco d L) ≤
+        ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
   -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells.
   set htSet := finite_lattice_in_ball (d := d) L hL (R + C)
   have hvadd : ∀ g : ↥(cubeLattice d L hL),
-      volume (g +ᵥ cubeIco d L) = volume (cubeIco d L) :=
+      volume (g +ᵥ cubeBox d (Set.Ico 0 L)) = volume (cubeBox d (Set.Ico 0 L)) :=
     fun g => measure_vadd volume g _
-  have hms : MeasurableSet (cubeIco d L) :=
-    fundamentalDomain_cubeBasis_eq_cubeIco L hL ▸ fundamentalDomain_measurableSet _
-  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (cubeIco d L)
-      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ cubeIco d L) := by
+  have hms : MeasurableSet (cubeBox d (Set.Ico 0 L)) := measurableSet_cubeBox measurableSet_Ico
+  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))
+      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ cubeBox d (Set.Ico 0 L)) := by
         simp_rw [hvadd, Finset.sum_const, nsmul_eq_mul]
-    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ cubeIco d L) := (measure_biUnion_finset
+    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ cubeBox d (Set.Ico 0 L)) := (measure_biUnion_finset
         (fun _ _ _ _ hgh => disjoint_vadd_of_unique_covers (d := d)
-          (cubeIco_unique_covers L hL) hgh)
+          (cubeLattice_unique_covers L hL) hgh)
         (fun g _ => hms.const_vadd g)).symm
     _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := volume.mono <| by
         rintro y hy
@@ -242,15 +218,15 @@ def constVec (d : ℕ) (c : ℝ) : EuclideanSpace ℝ (Fin d) := WithLp.toLp 2 (
 
 @[simp] lemma constVec_apply {c : ℝ} (i : Fin d) : constVec d c i = c := rfl
 
-lemma cubeIco_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
-    ((cubeIco d L \ cubeIcc d L (1 / 2)) +
-        ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2))
-      ⊆ ((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-        cubeIcc d L 1 := by
+lemma cubeBox_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
+    ((cubeBox d (Set.Ico 0 L) \ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))) +
+        ball (0 : EuclideanSpace ℝ (Fin d)) 2⁻¹)
+      ⊆ ((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+        cubeBox d (Set.Icc 1 (L - 1)) := by
   rintro z ⟨x, hx, y, hy, rfl⟩
-  have hyi : ∀ i : Fin d, |y i| < (1 / 2 : ℝ) := fun i =>
+  have hyi : ∀ i : Fin d, |y i| < (2⁻¹ : ℝ) := fun i =>
     (abs_coord_le_norm y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
-  rw [Set.mem_diff, mem_cubeIco] at hx
+  rw [Set.mem_diff] at hx
   refine ⟨Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => ?_, fun hz_inner => ?_⟩
   · -- Each coordinate of `x + y`, shifted by `+ 1/2`, lands in `[0, L + 1]`.
     simp only [vadd_eq_add, neg_neg, constVec_apply, PiLp.add_apply, PiLp.neg_apply,
@@ -258,11 +234,11 @@ lemma cubeIco_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
     refine ⟨?_, ?_⟩  -- lower bound `0`, upper bound `L + 1`
     · linarith [(hx.1 i).1, abs_lt.mp (hyi i)]
     · linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)]
-  · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (1 / 2 : ℝ) (L - 1 / 2) := by
-      simpa [mem_cubeIcc] using not_forall.mp hx.2
+  · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (2⁻¹ : ℝ) (L - 2⁻¹) :=
+      not_forall.mp hx.2
     rw [Set.mem_Icc, not_and_or] at hi
     have hz_i : (x i + y i) ∈ Set.Icc (1 : ℝ) (L - 1) := by
-      simpa [mem_cubeIcc] using hz_inner i
+      simpa using hz_inner i
     obtain hi | hi := hi <;> linarith [hz_i.1, hz_i.2, abs_lt.mp (hyi i)]
 
 variable (S : SpherePacking d)
@@ -272,10 +248,10 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
     {g : cubeLattice d L hL} {s : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_centers : ∀ x ∈ s, x ∈ S.centers)
     (hs_boundary : ∀ x ∈ s,
-      x ∈ (g +ᵥ cubeIco d L) \ (g +ᵥ cubeIcc d L (1 / 2))) :
+      x ∈ (g +ᵥ cubeBox d (Set.Ico 0 L)) \ (g +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹)))) :
     (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) ≤
-      volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-        cubeIcc d L 1) := by
+      volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+        cubeBox d (Set.Icc 1 (L - 1))) := by
   -- `r` abbreviates the common ball radius, matching the statement's `2⁻¹`.
   let r : ℝ := (2⁻¹ : ℝ)
   have hdisj : (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x => ball x r :=
@@ -283,19 +259,19 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       dsimp [r]; linarith [show (1 : ℝ) ≤ dist x y by
         simpa [hSsep] using S.centers_dist' x y (hs_centers x hx) (hs_centers y hy) hxy])
   have hsub : (⋃ x ∈ s, ball x r) ⊆
-      g +ᵥ (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-            cubeIcc d L 1) := fun y hy => by
+      g +ᵥ (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+            cubeBox d (Set.Icc 1 (L - 1))) := fun y hy => by
     obtain ⟨x, hxS, hyBall⟩ : ∃ x ∈ s, y ∈ ball x r := by aesop
     have hxB := hs_boundary x hxS
     -- `x0`, `y0`: pull `x`, `y` back by `-g` to the base cube (referenced repeatedly below).
     set x0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ x
     set y0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ y
-    have hxB1' : x0 ∈ cubeIco d L := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
-    have hxB2' : x0 ∉ cubeIcc d L (1 / 2) :=
+    have hxB1' : x0 ∈ cubeBox d (Set.Ico 0 L) := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
+    have hxB2' : x0 ∉ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹)) :=
       fun h => hxB.2 (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)
-    have hy0 : y0 ∈ ((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-        cubeIcc d L 1 := by
-      apply cubeIco_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
+    have hy0 : y0 ∈ ((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+        cubeBox d (Set.Icc 1 (L - 1)) := by
+      apply cubeBox_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
       refine ⟨x0, ⟨hxB1', hxB2'⟩, y0 - x0, ?_, by simp [sub_eq_add_neg, add_left_comm]⟩
       have : ‖y - x‖ < r := by simpa [Metric.mem_ball, dist_eq_norm] using hyBall
       simpa [Metric.mem_ball, dist_eq_norm, x0, y0, r] using this
@@ -304,35 +280,40 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       = volume (⋃ x ∈ s, ball x r) := by
         simpa [Measure.addHaar_ball_center, mul_comm, mul_assoc] using
           (measure_biUnion_finset (μ := volume) hdisj (fun _ _ => measurableSet_ball)).symm
-    _ ≤ volume (g +ᵥ (((constVec d (-(1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-          cubeIcc d L 1)) := volume.mono hsub
+    _ ≤ volume (g +ᵥ (((constVec d (-(2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+          cubeBox d (Set.Icc 1 (L - 1)))) := volume.mono hsub
     _ = _ := measure_vadd volume g _
 
 end BoundaryControl
 
 lemma volume_cubeShell_eq_pow (L : ℝ) :
-    volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-        cubeIcc d L 1) =
+    volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+        cubeBox d (Set.Icc 1 (L - 1))) =
       (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
-  have hsub : cubeIcc d L 1 ⊆
-      (constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0 := fun x hx =>
+  have hsub : cubeBox d (Set.Icc 1 (L - 1)) ⊆
+      (constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1)) := fun x hx =>
     Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => by
-      simp only [mem_cubeIcc, constVec, vadd_eq_add, one_div,
-        WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg] at hx ⊢
-      exact ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
-  have hmeas : MeasurableSet (cubeIcc d L 1) := by
-    simpa [cubeIcc_eq_preimage_ofLp] using
-      (MeasurableSet.pi Set.countable_univ fun _ _ => measurableSet_Icc).preimage
-        (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
-  simpa [measure_vadd, constVec, volume_cubeIcc] using
+      have h1 := (hx i).1
+      have h2 := (hx i).2
+      simp only [constVec, vadd_eq_add,
+        WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg, Set.mem_Icc]
+      exact ⟨by linarith, by linarith⟩
+  have hmeas : MeasurableSet (cubeBox d (Set.Icc (1 : ℝ) (L - 1))) :=
+    measurableSet_cubeBox measurableSet_Icc
+  have hOuter : volume (cubeBox d (Set.Icc (0 : ℝ) (L + 1))) = ENNReal.ofReal (L + 1) ^ d := by
+    rw [volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, sub_zero]
+  have hInner : volume (cubeBox d (Set.Icc (1 : ℝ) (L - 1))) = ENNReal.ofReal (L - 2) ^ d := by
+    rw [volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, show L - 1 - 1 = L - 2 by ring]
+  simpa [measure_vadd, hOuter, hInner] using
     measure_diff (μ := volume) hsub hmeas.nullMeasurableSet
-      (by simp [volume_cubeIcc])
+      (by simp [hInner])
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
-      (volume (cubeIco d L)).toNNReal := by
-  have hcov : ZLattice.covolume (cubeLattice d L hL) volume = (volume (cubeIco d L)).toReal := by
-    simpa [Measure.real, fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
+      (volume (cubeBox d (Set.Ico 0 L))).toNNReal := by
+  have hcov : ZLattice.covolume (cubeLattice d L hL) volume =
+      (volume (cubeBox d (Set.Ico 0 L))).toReal := by
+    simpa [Measure.real, fundamentalDomain_cubeBasis L hL] using
       ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice d L hL) (μ := volume)
         (by simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
           IsAddFundamentalDomain (cubeLattice d L hL)
@@ -343,18 +324,18 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
     {L : ℝ} (hL : 0 < L) {g : cubeLattice d L hL}
     (F : Finset (EuclideanSpace ℝ (Fin d)))
     (hF_centers : ∀ x ∈ F, x ∈ S.centers)
-    (hF_inner : ∀ x ∈ F, x ∈ g +ᵥ cubeIcc d L (2⁻¹ : ℝ)) :
+    (hF_inner : ∀ x ∈ F, x ∈ g +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ P.density =
         (F.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
           Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) := by
   -- Assemble the periodic packing `P` from the cube cell `D` and the representatives `Fset`.
-  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ cubeIco d L
+  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ cubeBox d (Set.Ico 0 L)
   let Fset : Set (EuclideanSpace ℝ (Fin d)) := (F : Set (EuclideanSpace ℝ (Fin d)))
-  have hD_unique := vadd_unique_covers (cubeIco_unique_covers L hL) g
+  have hD_unique := vadd_unique_covers (cubeLattice_unique_covers L hL) g
   let P : PeriodicSpherePacking d :=
     periodize_to_periodicSpherePacking (d := d) S (Λ := cubeLattice d L hL) D Fset
       (hD_unique_covers := hD_unique) (hF_centers := by assumption)
-      (hF_ball := fun x hx => ball_subset_vadd_cubeIco_of_mem_vadd_inner hL <| by
+      (hF_ball := fun x hx => ball_subset_vadd_cubeBox_of_mem_vadd_inner hL <| by
         simpa [hSsep] using hF_inner x (by simpa [Fset] using hx))
   have hPsep : P.separation = 1 := by simpa [P, hSsep]
   -- The translated inner cube `Fset` sits inside the translated full cube `D`.
@@ -370,7 +351,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   -- `D` is bounded, being a translate of the cube.
   have hD_bounded : IsBounded D := by
     simpa [D, Submodule.vadd_def, vadd_eq_add] using
-      (isBounded_cubeIco L hL).vadd (g : EuclideanSpace ℝ (Fin d))
+      (isBounded_cubeBox_Ico L hL).vadd (g : EuclideanSpace ℝ (Fin d))
   have hnumReps : P.numReps = F.card := by
     exact_mod_cast show (P.numReps : ENat) = (F.card : ENat) by
       simpa [hPcD, Fset, Set.encard_coe_eq_coe_finsetCard] using
@@ -378,14 +359,14 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
           hD_bounded hD_unique hd).symm
   exact ⟨P, hPsep, by simpa [hnumReps, hPsep] using P.density_eq' (d := d) hd⟩
 
-/-- The cube-shell error ratio `volume(shell) / volume(cubeIco d L)` tends to `0` as `L → ∞`:
+/-- The cube-shell error ratio `volume(shell) / volume([0, L)^d)` tends to `0` as `L → ∞`:
 the shell volume grows like `(L + 1) ^ d - (L - 2) ^ d` while the cube volume grows like `L ^ d`. -/
-lemma tendsto_volume_cubeShell_div_volume_cubeIco_zero :
+lemma tendsto_volume_cubeShell_div_volume_cubeBox_zero :
     Tendsto
         (fun L : ℝ =>
-          volume (((constVec d (- (1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-              cubeIcc d L 1) /
-            volume (cubeIco d L))
+          volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+              cubeBox d (Set.Icc 1 (L - 1))) /
+            volume (cubeBox d (Set.Ico 0 L)))
         atTop (𝓝 (0 : ℝ≥0∞)) := by
   -- `f` is the real shell/cube volume ratio, whose `→ 0` limit we transfer to `ℝ≥0∞`.
   let f : ℝ → ℝ := fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)
@@ -404,28 +385,30 @@ lemma tendsto_volume_cubeShell_div_volume_cubeIco_zero :
     simpa using (ENNReal.continuous_ofReal.tendsto (0 : ℝ)).comp hf).congr' ?_
   filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
   have hL2' : 0 ≤ L - 2 := by linarith
-  have hvol : volume (cubeIco d L) = (ENNReal.ofReal L) ^ d := by
-    simpa using volume_cubeIco L
+  have hvol : volume (cubeBox d (Set.Ico (0 : ℝ) L)) = (ENNReal.ofReal L) ^ d := by
+    rw [volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
   rw [volume_cubeShell_eq_pow L, hvol,
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L + 1), ← ENNReal.ofReal_pow hL2',
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L), ← ENNReal.ofReal_sub _ (pow_nonneg hL2' d)]
   simpa [f] using ENNReal.ofReal_div_of_pos (x := (L + 1)^d - (L - 2)^d) (pow_pos (by linarith) d)
 
-/-- Pick `L > 0` and `C > 0` with `cubeIco d L ⊆ ball 0 C` and the cube-shell error
-`volume(shell) / volume(cubeIco)` smaller than the headroom `c - b`. -/
+/-- Pick `L > 0` and `C > 0` with `[0, L)^d ⊆ ball 0 C` and the cube-shell error
+`volume(shell) / volume(cube)` smaller than the headroom `c - b`. -/
 private lemma exists_L_and_C_for_cubeShellErr_lt {b c : ℝ≥0∞} (hbc : b < c) :
     ∃ L : ℝ, 0 < L ∧ ∃ C : ℝ, 0 < C ∧
-      cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
-      volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ cubeIcc d (L + 1) 0) \
-          cubeIcc d L 1) / volume (cubeIco d L) < c - b := by
+      cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
+      volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
+          cubeBox d (Set.Icc 1 (L - 1))) / volume (cubeBox d (Set.Ico 0 L)) < c - b := by
   obtain ⟨L, hLpos, hLerr⟩ := ((eventually_gt_atTop (0 : ℝ)).and
-    (tendsto_volume_cubeShell_div_volume_cubeIco_zero.eventually
+    (tendsto_volume_cubeShell_div_volume_cubeBox_zero.eventually
       (Iio_mem_nhds (tsub_pos_of_lt hbc)))).exists
-  obtain ⟨C, hC⟩ : ∃ C : ℝ, cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
-    simpa using (isBounded_cubeIco L hLpos).subset_ball 0
+  obtain ⟨C, hC⟩ : ∃ C : ℝ,
+      cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
+    simpa using (isBounded_cubeBox_Ico L hLpos).subset_ball 0
   have hCpos : 0 < C := by
     simpa [Metric.mem_ball, dist_eq_norm] using
-      hC (by simp [cubeIco, hLpos] : (0 : EuclideanSpace ℝ (Fin d)) ∈ cubeIco d L)
+      hC (fun i => ⟨le_rfl, hLpos⟩ :
+        (0 : EuclideanSpace ℝ (Fin d)) ∈ cubeBox d (Set.Ico 0 L))
   exact ⟨L, hLpos, C, hCpos, hC, hLerr⟩
 
 /-- Given `c < S.density` and headroom `δ < c`, find `R > 0` with `c < S.finiteDensity R` and the
@@ -452,57 +435,65 @@ private lemma exists_R_finiteDensity_gt_and_ratio_gt (hd : 0 < d)
   exact (hfreq.and_eventually ((eventually_gt_atTop (0 : ℝ)).and
     (hmul.eventually (Ioi_mem_nhds hδc)))).exists
 
-/-- Pigeonhole step: among the finitely many lattice translates of `cubeIco d L` meeting
+/-- Pigeonhole step: among the finitely many lattice translates of the cube `[0, L)^d` meeting
 `ball 0 (R₁ + C)`, some translate `g0` contains at least `s.card / t.card` of the centers in
 `s = S.centers ∩ ball 0 R₁`. The resulting cell `sg ⊆ s` satisfies the volume comparison
-`s.encard * volume(cubeIco) ≤ sg.card * volume(ball (R₁ + 2 * C))`. -/
+`s.encard * volume(cube) ≤ sg.card * volume(ball (R₁ + 2 * C))`. -/
 private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
-    (hC : cubeIco d L ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
+    (hC : cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
     (S : SpherePacking d) {R₁ : ℝ} (hR₁ : 0 < R₁ + C) :
     ∃ g0 : cubeLattice d L hL, ∃ sg : Finset (EuclideanSpace ℝ (Fin d)),
-      (∀ x ∈ sg, x ∈ S.centers) ∧ (∀ x ∈ sg, x ∈ g0 +ᵥ cubeIco d L) ∧
+      (∀ x ∈ sg, x ∈ S.centers) ∧ (∀ x ∈ sg, x ∈ g0 +ᵥ cubeBox d (Set.Ico 0 L)) ∧
         ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) *
-            volume (cubeIco d L) ≤
+            volume (cubeBox d (Set.Ico 0 L)) ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) := by
   have hX : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).Finite :=
     SpherePacking.finite_centers_inter_ball S R₁
+  have hC' : fundamentalDomain (cubeBasis d L hL) ⊆
+      ball (0 : EuclideanSpace ℝ (Fin d)) C := by
+    rw [fundamentalDomain_cubeBasis L hL]; exact hC
   -- Pigeonhole: `s` = centres in `ball 0 R₁`, `t` = lattice translates meeting `ball 0 (R₁+C)`,
   -- `f` sends each centre to its covering translate; `sg` (below) is the fullest fibre.
   let s : Finset (EuclideanSpace ℝ (Fin d)) := hX.toFinset
   let htSet := finite_lattice_in_ball (d := d) L hL (R₁ + C)
   let t : Finset (cubeLattice d L hL) := htSet.toFinset
-  let f : EuclideanSpace ℝ (Fin d) → cubeLattice d L hL := fun x => -cubeIcoCover L hL x
+  let f : EuclideanSpace ℝ (Fin d) → cubeLattice d L hL :=
+    fun x => -fundamentalDomainCover (cubeBasis d L hL) x
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := fun _ hx =>
-    htSet.mem_toFinset.2 <| neg_cubeIcoCover_mem_ball L hL hC (hX.mem_toFinset.1 hx).2
+    htSet.mem_toFinset.2 <|
+      neg_fundamentalDomainCover_mem_ball (cubeBasis d L hL) hC' (hX.mem_toFinset.1 hx).2
   obtain ⟨g0, _, hg0max⟩ := Finset.exists_max_image t (fun g => (s.filter fun x => f x = g).card)
     ⟨0, htSet.mem_toFinset.2 (by simpa only [Set.mem_setOf_eq, Metric.mem_ball,
       ZeroMemClass.coe_zero, dist_self] using hR₁)⟩
   let sg : Finset (EuclideanSpace ℝ (Fin d)) := s.filter fun x => f x = g0
   refine ⟨g0, sg, fun x hx => (hX.mem_toFinset.1 (Finset.mem_filter.1 hx).1).1,
     fun x hx => ?_, ?_⟩
-  · have h : g0 = -cubeIcoCover L hL x := (Finset.mem_filter.1 hx).2.symm
+  · have h : g0 = -fundamentalDomainCover (cubeBasis d L hL) x :=
+      (Finset.mem_filter.1 hx).2.symm
     refine h ▸ Set.mem_vadd_set_iff_neg_vadd_mem.mpr ?_
-    simpa [neg_neg] using cubeIcoCover_spec L hL x
+    have hspec := fundamentalDomainCover_spec (cubeBasis d L hL) x
+    rw [fundamentalDomain_cubeBasis L hL] at hspec
+    simpa [neg_neg] using hspec
   · have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
       have hcard : s.card ≤ t.card * sg.card := by
         simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using
           Finset.sum_le_sum hg0max
       exact_mod_cast hcard
-    have ht_vol : ((t.card : ℝ≥0∞) * volume (cubeIco d L)) ≤
+    have ht_vol : ((t.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))) ≤
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) :=
-      card_finite_lattice_in_ball_mul_volume_cubeIco_le_volume_ball hL hC
+      card_finite_lattice_in_ball_mul_volume_cubeBox_le_volume_ball hL hC
     have hs_enc : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) = s.card :=
       congrArg ((↑) : ENat → ℝ≥0∞) hX.encard_eq_coe_toFinset_card
-    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume (cubeIco d L)
-        = (s.card : ℝ≥0∞) * volume (cubeIco d L) := by rw [hs_enc]
-      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume (cubeIco d L) :=
+    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))
+        = (s.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) := by rw [hs_enc]
+      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) :=
           mul_le_mul_left hs_le _
-      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume (cubeIco d L)) := by ac_rfl
+      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))) := by ac_rfl
       _ ≤ _ := mul_le_mul_right ht_vol _
 
 /-- From the pigeonhole volume comparison, a density-ratio lower bound, and a finite-density bound,
 derive that `δ < sg.card * volBall / volCube` where `volBall = volume(ball 0 (2⁻¹))` and
-`volCube = volume(cubeIco d L)`. -/
+`volCube = volume([0, L)^d)`. -/
 private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {L : ℝ} (hL : 0 < L) {R Cshift : ℝ}
     (hRC : 0 < R + Cshift) {c δ : ℝ≥0∞} (hcR : c < S.finiteDensity R)
@@ -510,19 +501,21 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))))
     {sg : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_mul : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) *
-        volume (cubeIco d L) ≤
+        volume (cubeBox d (Set.Ico 0 L)) ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) :
     δ < (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-      volume (cubeIco d L) := by
+      volume (cubeBox d (Set.Ico 0 L)) := by
   -- Abbreviations for the three volumes appearing in the inequality chase.
-  set volCube := volume (cubeIco d L)
+  set volCube := volume (cubeBox d (Set.Ico 0 L))
   set volBall := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
   have hvolCube_ne0 : volCube ≠ 0 := by
-    simpa [volCube, volume_cubeIco L] using
+    have hvol : volume (cubeBox d (Set.Ico (0 : ℝ) L)) = (ENNReal.ofReal L) ^ d := by
+      rw [volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
+    simpa [volCube, hvol] using
       pow_ne_zero d (ENNReal.ofReal_pos.mpr hL).ne'
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_cubeIco L hL).measure_lt_top.ne
+    (isBounded_cubeBox_Ico L hL).measure_lt_top.ne
   -- Cancelling a common factor of `volCube` from the numerator and an outer division.
   have hcancel : ∀ a c : ℝ≥0∞, a * volCube / c / volCube = a / c := fun a c => by
     simp only [div_eq_mul_inv,
@@ -547,27 +540,30 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
   simp only [div_eq_mul_inv] at this ⊢
   convert this using 1 <;> ring
 
-/-- From a finset `sg` of centers in `g0 +ᵥ cubeIco d L` satisfying `sg.card * volBall / volCube`
-exceeding some bound `δ + shellVol / volCube`, construct a periodic packing `P` with separation `1`
-and density `> δ`. The inner-cube filtering bounds the boundary contribution by `shellVol`. -/
+/-- From a finset `sg` of centers in a lattice translate of the cube `[0, L)^d` satisfying
+`sg.card * volBall / volCube` exceeding some bound `δ + shellVol / volCube`, construct a periodic
+packing `P` with separation `1` and density `> δ`. The inner-cube filtering bounds the boundary
+contribution by `shellVol`. -/
 private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {L : ℝ} (hL : 0 < L)
     {g0 : cubeLattice d L hL} {sg : Finset (EuclideanSpace ℝ (Fin d))} {δ : ℝ≥0∞}
-    (hsg_centers : ∀ x ∈ sg, x ∈ S.centers) (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ cubeIco d L)
-    (hsg_density : δ + volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ
-            cubeIcc d (L + 1) 0) \ cubeIcc d L 1) / volume (cubeIco d L) <
+    (hsg_centers : ∀ x ∈ sg, x ∈ S.centers)
+    (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ cubeBox d (Set.Ico 0 L))
+    (hsg_density : δ + volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ
+            cubeBox d (Set.Icc 0 (L + 1))) \ cubeBox d (Set.Icc 1 (L - 1))) /
+          volume (cubeBox d (Set.Ico 0 L)) <
         (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-          volume (cubeIco d L)) :
+          volume (cubeBox d (Set.Ico 0 L))) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ δ < P.density := by
   -- Abbreviations for the shell, cube, and unit-ball volumes used in the density bound.
-  set shellVol : ℝ≥0∞ := volume (((constVec (d := d) (-(1 / 2 : ℝ))) +ᵥ
-      cubeIcc d (L + 1) 0) \ cubeIcc d L 1)
-  set volCube : ℝ≥0∞ := volume (cubeIco d L)
+  set shellVol : ℝ≥0∞ := volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ
+      cubeBox d (Set.Icc 0 (L + 1))) \ cubeBox d (Set.Icc 1 (L - 1)))
+  set volCube : ℝ≥0∞ := volume (cubeBox d (Set.Ico 0 L))
   set volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_cubeIco L hL).measure_lt_top.ne
+    (isBounded_cubeBox_Ico L hL).measure_lt_top.ne
   -- Split `sg` by the inner cube: `F` (kept representatives) and `sb` (boundary, bounded by shell).
-  let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ cubeIcc d L (1 / 2 : ℝ)
+  let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
   let sb : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∉ innerSet

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -18,8 +18,7 @@ public import SpherePacking.ForMathlib.DualLattice
 /-!
 # Cohn-Elkies linear programming bound
 
-Cohn-Elkies upper bound on `SpherePackingConstant d` via
-`SpherePacking.CohnElkies.LinearProgrammingBound`. Also contains
+Cohn-Elkies upper bound on `SpherePackingConstant d` via `LinearProgrammingBound`. Also contains
 the periodizing constructions and boundary-control machinery (merged from `BoundaryControl`):
 `periodizedCenters`, `periodize_to_periodicSpherePacking`, the inline coordinate cubes
 `{x | ∀ i, x i ∈ Set.Ico 0 L}`/`{x | ∀ i, x i ∈ Set.Icc r (L - r)}`, the cube lattice
@@ -1020,6 +1019,9 @@ public lemma lattice_sum_re_le_ite (hP : P.separation = 1)
     have hℓ : ℓ = 0 := lattice_translate_eq_zero hD_unique_covers h
     exact hxy (Subtype.ext (by simpa [hℓ] using h))
 
+end SpherePacking.CohnElkies
+
+variable {d : ℕ}
 variable {f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ)} (hne_zero : f ≠ 0)
 variable (hReal : ∀ x : EuclideanSpace ℝ (Fin d), ↑(f x).re = (f x))
 variable (hRealFourier : ∀ x : EuclideanSpace ℝ (Fin d), ↑(𝓕 f x).re = (𝓕 f x))
@@ -1141,15 +1143,14 @@ private lemma re_mul_conj_eq_norm_sq_step {d : ℕ}
   rw [mul_assoc, mul_conj, Complex.normSq_eq_norm_sq]; norm_cast
 
 include d f hP hRealFourier hCohnElkies₁ hD_unique_covers in
-theorem le_numReps_mul_re_f_zero (hd : 0 < d) :
-    (1 / ZLattice.covolume P.lattice volume) *
+theorem numReps_mul_re_f_zero_ge (hd : 0 < d) :
+    ↑(P.numReps' hd hD_isBounded) * (f 0).re ≥
+      (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
-                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
-      ≤ ↑(P.numReps' hd hD_isBounded) * (f 0).re := by
-  rw [← ge_iff_le]
+                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
   calc ↑(P.numReps' hd hD_isBounded) * (f 0).re
   _ ≥ ∑' (x : P.centers) (y : ↑(P.centers ∩ D)), (f (x - ↑y)).re :=
         numReps_mul_f_zero_ge_double_tsum hCohnElkies₁ hP hD_isBounded hD_unique_covers hd
@@ -1202,14 +1203,14 @@ theorem le_numReps_mul_re_f_zero (hd : 0 < d) :
 
 include d f hCohnElkies₂ in omit [Nonempty ↑P.centers] in
 theorem numReps_sq_mul_re_fourier_zero_div_le (hd : 0 < d) :
-    ↑(P.numReps' hd hD_isBounded) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume ≤
-      (1 / ZLattice.covolume P.lattice volume) *
+    (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
             (norm (∑' x : ↑(P.centers ∩ D),
               exp (2 * π * I *
-                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2) := by
-  rw [← ge_iff_le]
+                ⟪↑x, (m : EuclideanSpace ℝ (Fin d))⟫_[ℝ])) ^ 2)
+      ≥
+      ↑(P.numReps' hd hD_isBounded) ^ 2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume := by
   calc (1 / ZLattice.covolume P.lattice volume) *
         ∑' m : dualLattice P.lattice,
           (𝓕 ⇑f m).re *
@@ -1318,9 +1319,10 @@ public theorem LinearProgrammingBound_periodic (hd : 0 < d) :
       volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) (1 / 2)) := by
   haveI : Fact (0 < d) := ⟨hd⟩
   rw [P.density_eq' hd]
-  suffices hCalc : (P.numReps' hd hD_isBounded)^2 * (𝓕 f 0).re /
-      ZLattice.covolume P.lattice volume ≤ (P.numReps' hd hD_isBounded) * (f 0).re by
+  suffices hCalc : (P.numReps' hd hD_isBounded) * (f 0).re ≥
+    (P.numReps' hd hD_isBounded)^2 * (𝓕 f 0).re / ZLattice.covolume P.lattice volume by
     rw [hP]
+    rw [ge_iff_le] at hCalc
     by_cases h𝓕f : 𝓕 f 0 = 0
     · exact density_le_of_fourier_zero (P := P) hne_zero hReal hRealFourier hCohnElkies₂ h𝓕f
     rw [← PeriodicSpherePacking.numReps_eq_numReps' (S := P) Fact.out hD_isBounded
@@ -1329,11 +1331,11 @@ public theorem LinearProgrammingBound_periodic (hd : 0 < d) :
       (nonempty_quotient_iff _).2 ‹_›
     exact density_le_of_hCalc_of_ne_zero (P := P) hRealFourier hCohnElkies₂
       (ZLattice.covolume_pos P.lattice volume) h𝓕f hCalc
-  exact le_trans
-    (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D)
-      (hCohnElkies₂ := hCohnElkies₂) hD_isBounded hd)
-    (le_numReps_mul_re_f_zero (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
+  exact ge_trans
+    (numReps_mul_re_f_zero_ge (P := P) (D := D) hRealFourier hCohnElkies₁ hP hD_isBounded
       hD_unique_covers hd)
+    (numReps_sq_mul_re_fourier_zero_div_le (P := P) (D := D) (hCohnElkies₂ := hCohnElkies₂)
+      hD_isBounded hd)
 
 end Fundamental_Domain_Dependent
 
@@ -1352,5 +1354,3 @@ public theorem LinearProgrammingBound (hd : 0 < d) : SpherePackingConstant d ≤
     (ZSpan.fundamentalDomain_isBounded _) (PeriodicSpherePacking.fundamental_domain_unique_covers
       (S := P) (((ZLattice.module_free ℝ P.lattice).chooseBasis).reindex
         (PeriodicSpherePacking.basis_index_equiv P))) hd
-
-end SpherePacking.CohnElkies

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -17,9 +17,9 @@ public import SpherePacking.ForMathlib.DualLattice
 
 Cohn-Elkies upper bound on `SpherePackingConstant d` via `LinearProgrammingBound`. Also contains
 the periodizing constructions and boundary-control machinery (merged from `BoundaryControl`):
-`periodizedCenters`, `periodize_to_periodicSpherePacking`, the coordinate boxes
-`cubeBox d (Set.Ico 0 L)`/`cubeBox d (Set.Icc r (L - r))`, the cube lattice `cubeLattice`, and the
-main result `periodic_constant_eq_constant`.
+`periodizedCenters`, `periodize_to_periodicSpherePacking`, the inline coordinate cubes
+`{x | ∀ i, x i ∈ Set.Ico 0 L}`/`{x | ∀ i, x i ∈ Set.Icc r (L - r)}`, the cube lattice
+`cubeLattice`, and the main result `periodic_constant_eq_constant`.
 -/
 
 section PeriodicPackingBoundaryControl
@@ -99,8 +99,9 @@ public lemma ball_vadd_subset_vadd {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin 
   lattice_isZLattice := inferInstance
 
 /-- A ball of radius `r` centred in the inner cube `[r, L-r]^d` is contained in `[0, L)^d`. -/
-lemma ball_subset_cubeBox_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ cubeBox d (Set.Icc r (L - r))) : ball x r ⊆ cubeBox d (Set.Ico 0 L) :=
+lemma ball_subset_cube_of_mem_inner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)}
+    (hx : ∀ i, x i ∈ Set.Icc r (L - r)) :
+    ball x r ⊆ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} :=
   fun y hy i => by
   have h₁ : |y i - x i| ≤ ‖y - x‖ := by simpa using abs_coord_le_norm (y - x) i
   have h₂ : ‖y - x‖ < r := by simpa [dist_eq_norm] using hy
@@ -138,12 +139,13 @@ public lemma vadd_unique_covers {Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))
 
 namespace PeriodicConstantApprox
 
-public lemma ball_subset_vadd_cubeBox_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
+public lemma ball_subset_vadd_cube_of_mem_vadd_inner {L r : ℝ} (hL : 0 < L)
     {v : cubeLattice d L hL} {x : EuclideanSpace ℝ (Fin d)}
-    (hx : x ∈ v +ᵥ cubeBox d (Set.Icc r (L - r))) :
-    ball x r ⊆ v +ᵥ cubeBox d (Set.Ico 0 L) := by
+    (hx : x ∈ v +ᵥ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Icc r (L - r)}) :
+    ball x r ⊆ v +ᵥ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} := by
   obtain ⟨y, hy, rfl⟩ := hx
-  have hball : ball y r ⊆ cubeBox d (Set.Ico 0 L) := ball_subset_cubeBox_of_mem_inner hy
+  have hball : ball y r ⊆ {z : EuclideanSpace ℝ (Fin d) | ∀ i, z i ∈ Set.Ico 0 L} :=
+    ball_subset_cube_of_mem_inner hy
   intro z hz
   refine ⟨z - v, hball ?_, by simp [vadd_eq_add]⟩
   change dist z ((v : EuclideanSpace ℝ (Fin d)) + y) < r at hz
@@ -183,24 +185,25 @@ lemma neg_fundamentalDomainCover_mem_ball {C R : ℝ}
 
 end FundamentalDomainCover
 
-lemma card_finite_lattice_in_ball_mul_volume_cubeBox_le_volume_ball {L : ℝ} (hL : 0 < L)
-    {R C : ℝ} (hC : cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C) :
+lemma card_finite_lattice_in_ball_mul_volume_cube_le_volume_ball {L : ℝ} (hL : 0 < L)
+    {R C : ℝ}
+    (hC : {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ⊆
+      ball (0 : EuclideanSpace ℝ (Fin d)) C) :
     ((finite_lattice_in_ball (d := d) L hL (R + C)).toFinset.card :
-        ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) ≤
+        ℝ≥0∞) * volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ≤
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := by
-  -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells.
+  -- `htSet` abbreviates the finiteness fact whose `toFinset` indexes the cells;
+  -- `Q` abbreviates the cube `[0, L)^d`.
   set htSet := finite_lattice_in_ball (d := d) L hL (R + C)
-  have hvadd : ∀ g : ↥(cubeLattice d L hL),
-      volume (g +ᵥ cubeBox d (Set.Ico 0 L)) = volume (cubeBox d (Set.Ico 0 L)) :=
-    fun g => measure_vadd volume g _
-  have hms : MeasurableSet (cubeBox d (Set.Ico 0 L)) := measurableSet_cubeBox measurableSet_Ico
-  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))
-      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ cubeBox d (Set.Ico 0 L)) := by
-        simp_rw [hvadd, Finset.sum_const, nsmul_eq_mul]
-    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ cubeBox d (Set.Ico 0 L)) := (measure_biUnion_finset
+  set Q : Set (EuclideanSpace ℝ (Fin d)) := {x | ∀ i, x i ∈ Set.Ico 0 L} with hQ
+  calc (↑htSet.toFinset.card : ℝ≥0∞) * volume Q
+      = ∑ g ∈ htSet.toFinset, volume (g +ᵥ Q) := by
+        simp_rw [measure_vadd, Finset.sum_const, nsmul_eq_mul]
+    _ = volume (⋃ g ∈ htSet.toFinset, g +ᵥ Q) := (measure_biUnion_finset
         (fun _ _ _ _ hgh => disjoint_vadd_of_unique_covers (d := d)
           (cubeLattice_unique_covers L hL) hgh)
-        (fun g _ => hms.const_vadd g)).symm
+        (fun g _ => (hQ ▸ measurableSet_cube measurableSet_Ico :
+          MeasurableSet Q).const_vadd g)).symm
     _ ≤ volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + (2 * C))) := volume.mono <| by
         rintro y hy
         obtain ⟨g, hgT, x, hx, rfl⟩ := Set.mem_iUnion₂.1 hy
@@ -212,28 +215,21 @@ lemma card_finite_lattice_in_ball_mul_volume_cubeBox_le_volume_ball {L : ℝ} (h
 
 section BoundaryControl
 
-/-- The constant vector `(c, …, c)`. Used only to recentre the outer cube in the shell estimate;
-kept (with `constVec_apply`) to avoid repeating the `WithLp.toLp` spelling at its many sites. -/
-def constVec (d : ℕ) (c : ℝ) : EuclideanSpace ℝ (Fin d) := WithLp.toLp 2 (fun _ : Fin d => c)
-
-@[simp] lemma constVec_apply {c : ℝ} (i : Fin d) : constVec d c i = c := rfl
-
-lemma cubeBox_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
-    ((cubeBox d (Set.Ico 0 L) \ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))) +
+lemma cube_boundary_half_add_ball_subset_outer_diff_inner (L : ℝ) :
+    (({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} \
+          {x | ∀ i, x i ∈ Set.Icc 2⁻¹ (L - 2⁻¹)}) +
         ball (0 : EuclideanSpace ℝ (Fin d)) 2⁻¹)
-      ⊆ ((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-        cubeBox d (Set.Icc 1 (L - 1)) := by
+      ⊆ {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+        {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)} := by
   rintro z ⟨x, hx, y, hy, rfl⟩
   have hyi : ∀ i : Fin d, |y i| < (2⁻¹ : ℝ) := fun i =>
     (abs_coord_le_norm y i).trans_lt (by simpa [mem_ball_zero_iff] using hy)
   rw [Set.mem_diff] at hx
-  refine ⟨Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => ?_, fun hz_inner => ?_⟩
-  · -- Each coordinate of `x + y`, shifted by `+ 1/2`, lands in `[0, L + 1]`.
-    simp only [vadd_eq_add, neg_neg, constVec_apply, PiLp.add_apply, PiLp.neg_apply,
-      Set.mem_Icc]
-    refine ⟨?_, ?_⟩  -- lower bound `0`, upper bound `L + 1`
-    · linarith [(hx.1 i).1, abs_lt.mp (hyi i)]
-    · linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)]
+  refine ⟨fun i => ?_, fun hz_inner => ?_⟩
+  · -- Each coordinate of `x + y` lands in `[-1/2, L + 1/2]`.
+    simp only [PiLp.add_apply, Set.mem_Icc]
+    exact ⟨by linarith [(hx.1 i).1, abs_lt.mp (hyi i)],
+      by linarith [(hx.1 i).2.le, abs_lt.mp (hyi i)]⟩
   · obtain ⟨i, hi⟩ : ∃ i : Fin d, ¬ x i ∈ Set.Icc (2⁻¹ : ℝ) (L - 2⁻¹) :=
       not_forall.mp hx.2
     rw [Set.mem_Icc, not_and_or] at hi
@@ -248,10 +244,11 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
     {g : cubeLattice d L hL} {s : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_centers : ∀ x ∈ s, x ∈ S.centers)
     (hs_boundary : ∀ x ∈ s,
-      x ∈ (g +ᵥ cubeBox d (Set.Ico 0 L)) \ (g +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹)))) :
+      x ∈ (g +ᵥ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L}) \
+        (g +ᵥ {y | ∀ i, y i ∈ Set.Icc 2⁻¹ (L - 2⁻¹)})) :
     (s.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) ≤
-      volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-        cubeBox d (Set.Icc 1 (L - 1))) := by
+      volume ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+        {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) := by
   -- `r` abbreviates the common ball radius, matching the statement's `2⁻¹`.
   let r : ℝ := (2⁻¹ : ℝ)
   have hdisj : (s : Set (EuclideanSpace ℝ (Fin d))).PairwiseDisjoint fun x => ball x r :=
@@ -259,20 +256,19 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       dsimp [r]; linarith [show (1 : ℝ) ≤ dist x y by
         simpa [hSsep] using S.centers_dist' x y (hs_centers x hx) (hs_centers y hy) hxy])
   have hsub : (⋃ x ∈ s, ball x r) ⊆
-      g +ᵥ (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-            cubeBox d (Set.Icc 1 (L - 1))) := fun y hy => by
+      g +ᵥ ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+            {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) := fun y hy => by
     obtain ⟨x, hxS, hyBall⟩ : ∃ x ∈ s, y ∈ ball x r := by aesop
     have hxB := hs_boundary x hxS
     -- `x0`, `y0`: pull `x`, `y` back by `-g` to the base cube (referenced repeatedly below).
     set x0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ x
     set y0 : EuclideanSpace ℝ (Fin d) := (-(g : EuclideanSpace ℝ (Fin d))) +ᵥ y
-    have hxB1' : x0 ∈ cubeBox d (Set.Ico 0 L) := Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1
-    have hxB2' : x0 ∉ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹)) :=
-      fun h => hxB.2 (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)
-    have hy0 : y0 ∈ ((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-        cubeBox d (Set.Icc 1 (L - 1)) := by
-      apply cubeBox_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
-      refine ⟨x0, ⟨hxB1', hxB2'⟩, y0 - x0, ?_, by simp [sub_eq_add_neg, add_left_comm]⟩
+    have hy0 : y0 ∈ {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+        {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)} := by
+      apply cube_boundary_half_add_ball_subset_outer_diff_inner (d := d) L
+      refine ⟨x0, ⟨Set.mem_vadd_set_iff_neg_vadd_mem.mp hxB.1,
+        fun h => hxB.2 (Set.mem_vadd_set_iff_neg_vadd_mem.mpr h)⟩, y0 - x0, ?_,
+        by simp [sub_eq_add_neg, add_left_comm]⟩
       have : ‖y - x‖ < r := by simpa [Metric.mem_ball, dist_eq_norm] using hyBall
       simpa [Metric.mem_ball, dist_eq_norm, x0, y0, r] using this
     exact Set.mem_vadd_set_iff_neg_vadd_mem.mpr hy0
@@ -280,39 +276,30 @@ lemma card_mul_volume_ball_le_volume_outer_diff_inner {L : ℝ} (hL : 0 < L)
       = volume (⋃ x ∈ s, ball x r) := by
         simpa [Measure.addHaar_ball_center, mul_comm, mul_assoc] using
           (measure_biUnion_finset (μ := volume) hdisj (fun _ _ => measurableSet_ball)).symm
-    _ ≤ volume (g +ᵥ (((constVec d (-(2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-          cubeBox d (Set.Icc 1 (L - 1)))) := volume.mono hsub
+    _ ≤ volume (g +ᵥ
+          ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+            {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)})) := volume.mono hsub
     _ = _ := measure_vadd volume g _
 
 end BoundaryControl
 
 lemma volume_cubeShell_eq_pow (L : ℝ) :
-    volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-        cubeBox d (Set.Icc 1 (L - 1))) =
+    volume ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+        {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) =
       (ENNReal.ofReal (L + 1)) ^ d - (ENNReal.ofReal (L - 2)) ^ d := by
-  have hsub : cubeBox d (Set.Icc 1 (L - 1)) ⊆
-      (constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1)) := fun x hx =>
-    Set.mem_vadd_set_iff_neg_vadd_mem.2 fun i => by
-      have h1 := (hx i).1
-      have h2 := (hx i).2
-      simp only [constVec, vadd_eq_add,
-        WithLp.ofLp_add, WithLp.ofLp_neg, Pi.add_apply, Pi.neg_apply, neg_neg, Set.mem_Icc]
-      exact ⟨by linarith, by linarith⟩
-  have hmeas : MeasurableSet (cubeBox d (Set.Icc (1 : ℝ) (L - 1))) :=
-    measurableSet_cubeBox measurableSet_Icc
-  have hOuter : volume (cubeBox d (Set.Icc (0 : ℝ) (L + 1))) = ENNReal.ofReal (L + 1) ^ d := by
-    rw [volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, sub_zero]
-  have hInner : volume (cubeBox d (Set.Icc (1 : ℝ) (L - 1))) = ENNReal.ofReal (L - 2) ^ d := by
-    rw [volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, show L - 1 - 1 = L - 2 by ring]
-  simpa [measure_vadd, hOuter, hInner] using
-    measure_diff (μ := volume) hsub hmeas.nullMeasurableSet
-      (by simp [hInner])
+  have hsub : {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc 1 (L - 1)} ⊆
+      {x | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} :=
+    fun x hx i => ⟨by linarith [(hx i).1], by linarith [(hx i).2]⟩
+  simpa [volume_cube_Icc, show L + 2⁻¹ - -(2⁻¹ : ℝ) = L + 1 by ring,
+    show L - 1 - 1 = L - 2 by ring] using
+    measure_diff (μ := volume) hsub (measurableSet_cube measurableSet_Icc).nullMeasurableSet
+      (by simp [volume_cube_Icc])
 
 lemma toNNReal_covolume_cubeLattice (L : ℝ) (hL : 0 < L) :
     Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) =
-      (volume (cubeBox d (Set.Ico 0 L))).toNNReal := by
+      (volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}).toNNReal := by
   have hcov : ZLattice.covolume (cubeLattice d L hL) volume =
-      (volume (cubeBox d (Set.Ico 0 L))).toReal := by
+      (volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}).toReal := by
     simpa [Measure.real, fundamentalDomain_cubeBasis L hL] using
       ZLattice.covolume_eq_measure_fundamentalDomain (L := cubeLattice d L hL) (μ := volume)
         (by simpa [cubeLattice] using ZSpan.isAddFundamentalDomain (cubeBasis d L hL) volume :
@@ -324,18 +311,19 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
     {L : ℝ} (hL : 0 < L) {g : cubeLattice d L hL}
     (F : Finset (EuclideanSpace ℝ (Fin d)))
     (hF_centers : ∀ x ∈ F, x ∈ S.centers)
-    (hF_inner : ∀ x ∈ F, x ∈ g +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))) :
+    (hF_inner : ∀ x ∈ F,
+      x ∈ g +ᵥ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Icc 2⁻¹ (L - 2⁻¹)}) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ P.density =
         (F.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
           Real.toNNReal (ZLattice.covolume (cubeLattice d L hL) volume) := by
   -- Assemble the periodic packing `P` from the cube cell `D` and the representatives `Fset`.
-  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ cubeBox d (Set.Ico 0 L)
+  let D : Set (EuclideanSpace ℝ (Fin d)) := g +ᵥ {y | ∀ i, y i ∈ Set.Ico 0 L}
   let Fset : Set (EuclideanSpace ℝ (Fin d)) := (F : Set (EuclideanSpace ℝ (Fin d)))
   have hD_unique := vadd_unique_covers (cubeLattice_unique_covers L hL) g
   let P : PeriodicSpherePacking d :=
     periodize_to_periodicSpherePacking (d := d) S (Λ := cubeLattice d L hL) D Fset
       (hD_unique_covers := hD_unique) (hF_centers := by assumption)
-      (hF_ball := fun x hx => ball_subset_vadd_cubeBox_of_mem_vadd_inner hL <| by
+      (hF_ball := fun x hx => ball_subset_vadd_cube_of_mem_vadd_inner hL <| by
         simpa [hSsep] using hF_inner x (by simpa [Fset] using hx))
   have hPsep : P.separation = 1 := by simpa [P, hSsep]
   -- The translated inner cube `Fset` sits inside the translated full cube `D`.
@@ -351,7 +339,7 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
   -- `D` is bounded, being a translate of the cube.
   have hD_bounded : IsBounded D := by
     simpa [D, Submodule.vadd_def, vadd_eq_add] using
-      (isBounded_cubeBox_Ico L hL).vadd (g : EuclideanSpace ℝ (Fin d))
+      (isBounded_cube_Ico L hL).vadd (g : EuclideanSpace ℝ (Fin d))
   have hnumReps : P.numReps = F.card := by
     exact_mod_cast show (P.numReps : ENat) = (F.card : ENat) by
       simpa [hPcD, Fset, Set.encard_coe_eq_coe_finsetCard] using
@@ -361,12 +349,12 @@ lemma periodize_cube_density_eq (hd : 0 < d) (S : SpherePacking d) (hSsep : S.se
 
 /-- The cube-shell error ratio `volume(shell) / volume([0, L)^d)` tends to `0` as `L → ∞`:
 the shell volume grows like `(L + 1) ^ d - (L - 2) ^ d` while the cube volume grows like `L ^ d`. -/
-lemma tendsto_volume_cubeShell_div_volume_cubeBox_zero :
+lemma tendsto_volume_cubeShell_div_volume_cube_zero :
     Tendsto
         (fun L : ℝ =>
-          volume (((constVec d (- (2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-              cubeBox d (Set.Icc 1 (L - 1))) /
-            volume (cubeBox d (Set.Ico 0 L)))
+          volume ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+              {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) /
+            volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L})
         atTop (𝓝 (0 : ℝ≥0∞)) := by
   -- `f` is the real shell/cube volume ratio, whose `→ 0` limit we transfer to `ℝ≥0∞`.
   let f : ℝ → ℝ := fun L : ℝ => ((L + 1) ^ d - (L - 2) ^ d) / (L ^ d)
@@ -385,9 +373,7 @@ lemma tendsto_volume_cubeShell_div_volume_cubeBox_zero :
     simpa using (ENNReal.continuous_ofReal.tendsto (0 : ℝ)).comp hf).congr' ?_
   filter_upwards [eventually_gt_atTop (2 : ℝ)] with L hL2
   have hL2' : 0 ≤ L - 2 := by linarith
-  have hvol : volume (cubeBox d (Set.Ico (0 : ℝ) L)) = (ENNReal.ofReal L) ^ d := by
-    rw [volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
-  rw [volume_cubeShell_eq_pow L, hvol,
+  rw [volume_cubeShell_eq_pow L, volume_cube_Ico, sub_zero,
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L + 1), ← ENNReal.ofReal_pow hL2',
     ← ENNReal.ofReal_pow (by linarith : (0:ℝ) ≤ L), ← ENNReal.ofReal_sub _ (pow_nonneg hL2' d)]
   simpa [f] using ENNReal.ofReal_div_of_pos (x := (L + 1)^d - (L - 2)^d) (pow_pos (by linarith) d)
@@ -396,19 +382,22 @@ lemma tendsto_volume_cubeShell_div_volume_cubeBox_zero :
 `volume(shell) / volume(cube)` smaller than the headroom `c - b`. -/
 private lemma exists_L_and_C_for_cubeShellErr_lt {b c : ℝ≥0∞} (hbc : b < c) :
     ∃ L : ℝ, 0 < L ∧ ∃ C : ℝ, 0 < C ∧
-      cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
-      volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ cubeBox d (Set.Icc 0 (L + 1))) \
-          cubeBox d (Set.Icc 1 (L - 1))) / volume (cubeBox d (Set.Ico 0 L)) < c - b := by
+      {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ⊆
+        ball (0 : EuclideanSpace ℝ (Fin d)) C ∧
+      volume ({x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \
+          {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) /
+        volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} < c - b := by
   obtain ⟨L, hLpos, hLerr⟩ := ((eventually_gt_atTop (0 : ℝ)).and
-    (tendsto_volume_cubeShell_div_volume_cubeBox_zero.eventually
+    (tendsto_volume_cubeShell_div_volume_cube_zero.eventually
       (Iio_mem_nhds (tsub_pos_of_lt hbc)))).exists
   obtain ⟨C, hC⟩ : ∃ C : ℝ,
-      cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C := by
-    simpa using (isBounded_cubeBox_Ico L hLpos).subset_ball 0
+      {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ⊆
+        ball (0 : EuclideanSpace ℝ (Fin d)) C := by
+    simpa using (isBounded_cube_Ico L hLpos).subset_ball 0
   have hCpos : 0 < C := by
     simpa [Metric.mem_ball, dist_eq_norm] using
-      hC (fun i => ⟨le_rfl, hLpos⟩ :
-        (0 : EuclideanSpace ℝ (Fin d)) ∈ cubeBox d (Set.Ico 0 L))
+      hC (show (0 : EuclideanSpace ℝ (Fin d)) ∈ {x | ∀ i, x i ∈ Set.Ico 0 L} from
+        fun i => ⟨le_rfl, hLpos⟩)
   exact ⟨L, hLpos, C, hCpos, hC, hLerr⟩
 
 /-- Given `c < S.density` and headroom `δ < c`, find `R > 0` with `c < S.finiteDensity R` and the
@@ -440,18 +429,17 @@ private lemma exists_R_finiteDensity_gt_and_ratio_gt (hd : 0 < d)
 `s = S.centers ∩ ball 0 R₁`. The resulting cell `sg ⊆ s` satisfies the volume comparison
 `s.encard * volume(cube) ≤ sg.card * volume(ball (R₁ + 2 * C))`. -/
 private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
-    (hC : cubeBox d (Set.Ico 0 L) ⊆ ball (0 : EuclideanSpace ℝ (Fin d)) C)
+    (hC : {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ⊆
+      ball (0 : EuclideanSpace ℝ (Fin d)) C)
     (S : SpherePacking d) {R₁ : ℝ} (hR₁ : 0 < R₁ + C) :
     ∃ g0 : cubeLattice d L hL, ∃ sg : Finset (EuclideanSpace ℝ (Fin d)),
-      (∀ x ∈ sg, x ∈ S.centers) ∧ (∀ x ∈ sg, x ∈ g0 +ᵥ cubeBox d (Set.Ico 0 L)) ∧
+      (∀ x ∈ sg, x ∈ S.centers) ∧
+        (∀ x ∈ sg, x ∈ g0 +ᵥ {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}) ∧
         ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) *
-            volume (cubeBox d (Set.Ico 0 L)) ≤
+            volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) := by
   have hX : (S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).Finite :=
     SpherePacking.finite_centers_inter_ball S R₁
-  have hC' : fundamentalDomain (cubeBasis d L hL) ⊆
-      ball (0 : EuclideanSpace ℝ (Fin d)) C := by
-    rw [fundamentalDomain_cubeBasis L hL]; exact hC
   -- Pigeonhole: `s` = centres in `ball 0 R₁`, `t` = lattice translates meeting `ball 0 (R₁+C)`,
   -- `f` sends each centre to its covering translate; `sg` (below) is the fullest fibre.
   let s : Finset (EuclideanSpace ℝ (Fin d)) := hX.toFinset
@@ -461,34 +449,36 @@ private lemma exists_pigeonhole_lattice_cell {L : ℝ} (hL : 0 < L) {C : ℝ}
     fun x => -fundamentalDomainCover (cubeBasis d L hL) x
   have hf_maps : (s : Set (EuclideanSpace ℝ (Fin d))).MapsTo f t := fun _ hx =>
     htSet.mem_toFinset.2 <|
-      neg_fundamentalDomainCover_mem_ball (cubeBasis d L hL) hC' (hX.mem_toFinset.1 hx).2
+      neg_fundamentalDomainCover_mem_ball (cubeBasis d L hL)
+        (fundamentalDomain_cubeBasis L hL ▸ hC) (hX.mem_toFinset.1 hx).2
   obtain ⟨g0, _, hg0max⟩ := Finset.exists_max_image t (fun g => (s.filter fun x => f x = g).card)
     ⟨0, htSet.mem_toFinset.2 (by simpa only [Set.mem_setOf_eq, Metric.mem_ball,
       ZeroMemClass.coe_zero, dist_self] using hR₁)⟩
   let sg : Finset (EuclideanSpace ℝ (Fin d)) := s.filter fun x => f x = g0
   refine ⟨g0, sg, fun x hx => (hX.mem_toFinset.1 (Finset.mem_filter.1 hx).1).1,
     fun x hx => ?_, ?_⟩
-  · have h : g0 = -fundamentalDomainCover (cubeBasis d L hL) x :=
-      (Finset.mem_filter.1 hx).2.symm
-    refine h ▸ Set.mem_vadd_set_iff_neg_vadd_mem.mpr ?_
-    have hspec := fundamentalDomainCover_spec (cubeBasis d L hL) x
-    rw [fundamentalDomain_cubeBasis L hL] at hspec
-    simpa [neg_neg] using hspec
+  · -- `x` lies in the `g0`-translate of the cube: the witness is the covering translate of `x`,
+    -- since `g0` is its negation on the fibre.
+    refine ⟨_, fundamentalDomain_cubeBasis L hL ▸
+      fundamentalDomainCover_spec (cubeBasis d L hL) x, ?_⟩
+    rw [show g0 = -fundamentalDomainCover (cubeBasis d L hL) x from
+      (Finset.mem_filter.1 hx).2.symm, vadd_vadd, neg_add_cancel, zero_vadd]
   · have hs_le : (s.card : ℝ≥0∞) ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) := by
       have hcard : s.card ≤ t.card * sg.card := by
         simpa [Finset.card_eq_sum_card_fiberwise hf_maps, Finset.sum_const] using
           Finset.sum_le_sum hg0max
       exact_mod_cast hcard
-    have ht_vol : ((t.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))) ≤
+    have ht_vol : ((t.card : ℝ≥0∞) *
+          volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}) ≤
         volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R₁ + 2 * C)) :=
-      card_finite_lattice_in_ball_mul_volume_cubeBox_le_volume_ball hL hC
+      card_finite_lattice_in_ball_mul_volume_cube_le_volume_ball hL hC
     have hs_enc : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) R₁).encard : ℝ≥0∞) = s.card :=
       congrArg ((↑) : ENat → ℝ≥0∞) hX.encard_eq_coe_toFinset_card
-    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))
-        = (s.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) := by rw [hs_enc]
-      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L)) :=
-          mul_le_mul_left hs_le _
-      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume (cubeBox d (Set.Ico 0 L))) := by ac_rfl
+    set Q : Set (EuclideanSpace ℝ (Fin d)) := {x | ∀ i, x i ∈ Set.Ico 0 L}
+    calc ((S.centers ∩ ball _ R₁).encard : ℝ≥0∞) * volume Q
+        = (s.card : ℝ≥0∞) * volume Q := by rw [hs_enc]
+      _ ≤ (t.card : ℝ≥0∞) * (sg.card : ℝ≥0∞) * volume Q := mul_le_mul_left hs_le _
+      _ = (sg.card : ℝ≥0∞) * ((t.card : ℝ≥0∞) * volume Q) := by ac_rfl
       _ ≤ _ := mul_le_mul_right ht_vol _
 
 /-- From the pigeonhole volume comparison, a density-ratio lower bound, and a finite-density bound,
@@ -501,21 +491,19 @@ private lemma sg_card_mul_volBall_div_volCube_gt (hd : 0 < d)
       volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))))
     {sg : Finset (EuclideanSpace ℝ (Fin d))}
     (hs_mul : ((S.centers ∩ ball (0 : EuclideanSpace ℝ (Fin d)) (R + 2⁻¹)).encard : ℝ≥0∞) *
-        volume (cubeBox d (Set.Ico 0 L)) ≤
+        volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} ≤
           (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))) :
     δ < (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-      volume (cubeBox d (Set.Ico 0 L)) := by
+      volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} := by
   -- Abbreviations for the three volumes appearing in the inequality chase.
-  set volCube := volume (cubeBox d (Set.Ico 0 L))
+  set volCube := volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}
   set volBall := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   set V := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (R + Cshift))
   have hvolCube_ne0 : volCube ≠ 0 := by
-    have hvol : volume (cubeBox d (Set.Ico (0 : ℝ) L)) = (ENNReal.ofReal L) ^ d := by
-      rw [volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
-    simpa [volCube, hvol] using
+    simpa [volCube, volume_cube_Ico, sub_zero] using
       pow_ne_zero d (ENNReal.ofReal_pos.mpr hL).ne'
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_cubeBox_Ico L hL).measure_lt_top.ne
+    (isBounded_cube_Ico L hL).measure_lt_top.ne
   -- Cancelling a common factor of `volCube` from the numerator and an outer division.
   have hcancel : ∀ a c : ℝ≥0∞, a * volCube / c / volCube = a / c := fun a c => by
     simp only [div_eq_mul_inv,
@@ -548,27 +536,28 @@ private lemma exists_periodicSpherePacking_density_gt_aux (hd : 0 < d)
     (S : SpherePacking d) (hSsep : S.separation = 1) {L : ℝ} (hL : 0 < L)
     {g0 : cubeLattice d L hL} {sg : Finset (EuclideanSpace ℝ (Fin d))} {δ : ℝ≥0∞}
     (hsg_centers : ∀ x ∈ sg, x ∈ S.centers)
-    (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ cubeBox d (Set.Ico 0 L))
-    (hsg_density : δ + volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ
-            cubeBox d (Set.Icc 0 (L + 1))) \ cubeBox d (Set.Icc 1 (L - 1))) /
-          volume (cubeBox d (Set.Ico 0 L)) <
+    (hsg_memCube : ∀ x ∈ sg, x ∈ g0 +ᵥ {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L})
+    (hsg_density : δ + volume ({x : EuclideanSpace ℝ (Fin d) |
+            ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \ {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)}) /
+          volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} <
         (sg.card : ℝ≥0∞) * volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ)) /
-          volume (cubeBox d (Set.Ico 0 L))) :
+          volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}) :
     ∃ P : PeriodicSpherePacking d, P.separation = 1 ∧ δ < P.density := by
   -- Abbreviations for the shell, cube, and unit-ball volumes used in the density bound.
-  set shellVol : ℝ≥0∞ := volume (((constVec (d := d) (-(2⁻¹ : ℝ))) +ᵥ
-      cubeBox d (Set.Icc 0 (L + 1))) \ cubeBox d (Set.Icc 1 (L - 1)))
-  set volCube : ℝ≥0∞ := volume (cubeBox d (Set.Ico 0 L))
+  set shellVol : ℝ≥0∞ := volume ({x : EuclideanSpace ℝ (Fin d) |
+      ∀ i, x i ∈ Set.Icc (-(2⁻¹ : ℝ)) (L + 2⁻¹)} \ {x | ∀ i, x i ∈ Set.Icc 1 (L - 1)})
+  set volCube : ℝ≥0∞ := volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L}
   set volBall : ℝ≥0∞ := volume (ball (0 : EuclideanSpace ℝ (Fin d)) (2⁻¹ : ℝ))
   have hvolCube_ne_top : volCube ≠ ∞ :=
-    (isBounded_cubeBox_Ico L hL).measure_lt_top.ne
+    (isBounded_cube_Ico L hL).measure_lt_top.ne
   -- Split `sg` by the inner cube: `F` (kept representatives) and `sb` (boundary, bounded by shell).
-  let innerSet : Set (EuclideanSpace ℝ (Fin d)) := g0 +ᵥ cubeBox d (Set.Icc 2⁻¹ (L - 2⁻¹))
+  let innerSet : Set (EuclideanSpace ℝ (Fin d)) :=
+    g0 +ᵥ {x | ∀ i, x i ∈ Set.Icc 2⁻¹ (L - 2⁻¹)}
   letI : DecidablePred (fun x : EuclideanSpace ℝ (Fin d) => x ∈ innerSet) := Classical.decPred _
   let F : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∈ innerSet
   let sb : Finset (EuclideanSpace ℝ (Fin d)) := sg.filter fun x => x ∉ innerSet
   have hsb_vol : (sb.card : ℝ≥0∞) * volBall ≤ shellVol := by
-    simpa [volBall, shellVol, constVec] using
+    simpa [volBall, shellVol] using
       card_mul_volume_ball_le_volume_outer_diff_inner S hL hSsep
         (fun x hx => hsg_centers x (Finset.mem_filter.1 hx).1)
         (fun x hx => ⟨hsg_memCube x (Finset.mem_filter.1 hx).1, by

--- a/SpherePacking/CohnElkies/LPBound.lean
+++ b/SpherePacking/CohnElkies/LPBound.lean
@@ -648,13 +648,6 @@ section LPPrereqs
 variable {d : ℕ} [Fact (0 < d)]
 variable (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ] [IsZLattice ℝ Λ]
 
-/- The dual `ℤ`-lattice for the Euclidean inner product is *notation*, not a definition (declared
-locally here and in `PoissonSummationGeneral.lean`): it elaborates literally to
-`LinearMap.BilinForm.dualSubmodule`, so the discreteness instance
-`instDiscreteTopology_dualSubmodule_innerₗ` from `ForMathlib/DualLattice.lean` applies directly. -/
-local notation:max "dualLattice " L:max =>
-  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
-
 /-- Convenience: `Fin d` is nonempty when `0 < d`. -/
 public instance instNonemptyFin : Nonempty (Fin d) := ⟨0, Fact.out⟩
 
@@ -695,6 +688,15 @@ end
 
 end LPPrereqs
 
+/- The dual `ℤ`-lattice for the Euclidean inner product is *notation*, not a definition (declared
+locally here and in `PoissonSummationGeneral.lean`): it elaborates literally to
+`LinearMap.BilinForm.dualSubmodule`, so the discreteness instance
+`instDiscreteTopology_dualSubmodule_innerₗ` from `ForMathlib/DualLattice.lean` applies directly.
+Declared at file level so it scopes over the remaining sections (cf. `conj` below); the dimension
+`d` in the expansion resolves at each use site, hence the disabled precheck. -/
+set_option quotPrecheck false in
+local notation:max "dualLattice " L:max =>
+  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
 
 namespace SpherePacking.CohnElkies
 variable {d : ℕ}

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -5,6 +5,7 @@ Authors: Auguste Poiroux
 -/
 module
 public import Mathlib
+public import SpherePacking.ForMathlib.FourierComp
 
 /-! # Poisson summation for Schwartz functions
 
@@ -18,37 +19,6 @@ Three layers:
 
 open scoped BigOperators FourierTransform Real
 open MeasureTheory
-
-namespace SpherePacking.ForMathlib.Fourier
-
-variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
-  [MeasurableSpace V] [BorelSpace V]
-
-/-- Change-of-variables for the Fourier transform under an invertible linear map. For
-`A : V ≃ₗ[ℝ] V`, `𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A.symm).adjoint w)`. -/
-public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w : V) :
-    𝓕 (fun x ↦ f (A x)) w =
-      (abs (LinearMap.det (A : V →ₗ[ℝ] V)))⁻¹ •
-        𝓕 f (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) := by
-  have hmap : Measure.map (⇑A) (volume : Measure V) =
-      ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹| • (volume : Measure V) :=
-    Measure.map_linearMap_addHaar_eq_smul_addHaar volume (LinearEquiv.isUnit_det' A).ne_zero
-  have hinner (y : V) :
-      inner ℝ (A.symm y) w = inner ℝ y (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) :=
-    (LinearMap.adjoint_inner_right _ y w).symm
-  calc 𝓕 (fun x ↦ f (A x)) w
-      = ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y
-          ∂Measure.map (⇑A) (volume : Measure V) := by
-        simpa [Real.fourier_eq] using
-          (integral_map_equiv (μ := (volume : Measure V))
-            A.toContinuousLinearEquiv.toHomeomorph.toMeasurableEquiv
-            fun y ↦ Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y).symm
-    _ = |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ •
-          ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y := by
-        rw [hmap, integral_smul_measure, ENNReal.toReal_ofReal (abs_nonneg _), abs_inv]
-    _ = _ := by simp only [Real.fourier_eq, hinner]
-
-end SpherePacking.ForMathlib.Fourier
 
 namespace SchwartzMap.UnitAddTorus
 

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -828,19 +828,18 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
         ∑' m : dualLattice L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
   -- Abbreviations: the dual-lattice summand `F`, the determinant `detA` of the change of
-  -- variables and its reciprocal `cC = |detA|⁻¹`, and the integer-vector embedding `iv`.
+  -- variables, and its reciprocal `cC = |detA|⁻¹`.
   let F : dualLattice L → ℂ :=
     fun m => (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ])
   let detA : ℝ := (LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((latticeEquiv L) : E →ₗ[ℝ] E)
   let cC : ℂ := ((abs detA)⁻¹ : ℝ)
-  let iv : (Fin d → ℤ) → E := intVec
   have hfourier (w : E) : 𝓕 (fun x : E => f ((latticeEquiv L) x)) w =
       cC * 𝓕 (fun x : E => f x) (dualEquiv L w) := by
     simpa [dualEquiv_apply, detA, cC, Complex.real_smul] using
       SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv
         (A := latticeEquiv L) (f := fun x : E => f x) w
-  have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (iv n)) *
-        Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, iv n⟫_[ℝ])) =
+  have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (intVec n)) *
+        Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, intVec n⟫_[ℝ])) =
       cC * ∑' m : dualLattice L, F m := by
     rw [← (PoissonSummation.Standard.equivIntVec.trans
       ((LinearEquiv.restrictScalars ℤ (dualEquiv L)).ofSubmodules _ _ <| by
@@ -848,9 +847,9 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
             map_standardLattice_dualEquiv_eq (L := L)).toEquiv).tsum_eq
       (f := F), ← tsum_mul_left]
     exact tsum_congr fun n ↦ by
-      simpa [F, mul_assoc, poissonSummation_lattice_inner_swap (L := L) v (w := iv n)] using
-        congrArg (· * Complex.exp (2 * π * Complex.I * ⟪v, dualEquiv L (iv n)⟫_[ℝ]))
-          (hfourier (w := iv n))
+      simpa [F, mul_assoc, poissonSummation_lattice_inner_swap (L := L) v (w := intVec n)] using
+        congrArg (· * Complex.exp (2 * π * Complex.I * ⟪v, dualEquiv L (intVec n)⟫_[ℝ]))
+          (hfourier (w := intVec n))
   rw [hreindex]
   simp [F, cC, show ZLattice.covolume L = abs detA from by
     simpa [latticeEquiv, detA] using covolume_eq_abs_det_latticeEquiv (L := L), one_div]

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -5,6 +5,7 @@ Authors: Auguste Poiroux
 -/
 module
 public import Mathlib
+public import SpherePacking.ForMathlib.DualLattice
 public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.SchwartzLatticeSummable
 public import SpherePacking.ForMathlib.UnitAddTorusQuotient

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -636,44 +636,50 @@ public noncomputable abbrev dualLattice (L : Submodule ℤ E) : Submodule ℤ E 
 
 /-- A `Fin d`-indexed integral basis of the `ℤ`-lattice `L` (Mathlib's `chooseBasis` reindexed
 along `finrank ℤ L = d`). Kept as a named definition: a fixed integral frame for `L` whose
-determinant against `stdBasis` computes the covolume. -/
+determinant against the standard basis computes the covolume. -/
 noncomputable def zBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Basis (Fin d) ℤ L :=
   (Module.Free.chooseBasis ℤ L).reindex <| Fintype.equivOfCardEq <| by
     simpa [(ZLattice.rank (K := ℝ) (L := L)).trans (by simp : _ = d)] using
       (Module.finrank_eq_card_chooseBasisIndex (R := ℤ) (M := L)).symm
 
-/-- The `ℝ`-basis of `E` spanned by `zBasis L` (Mathlib's `Basis.ofZLatticeBasis`). Kept as a named
-definition: the real frame realizing `L`, namely the image of `stdBasis` under `latticeEquiv L`. -/
+/-- The `ℝ`-basis of `E` realizing the `ℤ`-lattice `L`, i.e. `zBasis L` viewed over `ℝ` via
+Mathlib's `Basis.ofZLatticeBasis`. Kept as a named definition: it is the image of the standard
+basis under `latticeEquiv L`, and computing against it gives the covolume. -/
 noncomputable def rBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Basis (Fin d) ℝ E := (zBasis (d := d) L).ofZLatticeBasis ℝ L
 
-/-- The standard basis of `E = ℝ^d` as an `ℝ`-basis, i.e. `(EuclideanSpace.basisFun _ _).toBasis`.
-Kept as a named definition: the orthonormal reference frame (and `ℤ`-basis of the standard lattice)
-against which the lattice determinant and covolume are measured. -/
-noncomputable def stdBasis : Basis (Fin d) ℝ E := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis
-
-/-- The `ℝ`-linear automorphism of `E` sending the standard basis to `rBasis L`, hence the standard
-lattice `ℤ^d` onto `L`. Kept as a named definition: it is the change-of-variables map underlying
-the reduction of lattice Poisson summation to the standard-lattice case, used throughout this
-section and reused via its adjoints `Bₗ`/`Aadjₗ`. -/
+/-- The `ℝ`-linear automorphism of `E` sending the standard basis `(EuclideanSpace.basisFun _ _)`
+to `rBasis L`, hence the standard lattice `ℤ^d` onto `L`. Kept as a named definition: it is the
+change-of-variables map underlying the reduction of lattice Poisson summation to the
+standard-lattice case, used throughout this section (and, via its inverse-adjoint, on the
+dual side). -/
 noncomputable def latticeEquiv (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
-    E ≃ₗ[ℝ] E := (stdBasis (d := d)).equiv (rBasis (d := d) L) (Equiv.refl (Fin d))
+    E ≃ₗ[ℝ] E :=
+  ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).equiv (rBasis (d := d) L) (Equiv.refl (Fin d))
 
-@[simp] lemma latticeEquiv_apply_stdBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L]
-    (i : Fin d) : latticeEquiv (d := d) L ((stdBasis (d := d)) i) = (rBasis (d := d) L) i :=
-  Basis.equiv_apply (b := stdBasis (d := d)) (b' := rBasis (d := d) L) (e := Equiv.refl _) (i := i)
+/-- `latticeEquiv L` sends the `i`-th standard basis vector to the `i`-th vector of `rBasis L`.
+(Not a `simp` lemma: `(basisFun _ _).toBasis i` is itself simp-normalised to `EuclideanSpace.single
+i 1`, so this would never fire.) -/
+lemma latticeEquiv_apply_basisFun (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L]
+    (i : Fin d) :
+    latticeEquiv (d := d) L ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis i) =
+      rBasis (d := d) L i :=
+  Basis.equiv_apply (b := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) (b' := rBasis (d := d) L)
+    (e := Equiv.refl _) (i := i)
 
 lemma map_standardLattice_eq (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
         (SchwartzMap.standardLattice d) = L := by
-  have hrange : (fun a : E => latticeEquiv (d := d) L a) '' Set.range (stdBasis (d := d)) =
+  have hrange : (fun a : E => latticeEquiv (d := d) L a) ''
+        Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis) =
       Set.range (rBasis (d := d) L) := by
-    rw [← Set.range_comp]; simp [Function.comp_def]
+    rw [← Set.range_comp]; simp only [Function.comp_def, latticeEquiv_apply_basisFun]
   calc Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
           (SchwartzMap.standardLattice d)
-      = Submodule.span ℤ ((fun a : E => latticeEquiv (d := d) L a) '' Set.range (stdBasis (d := d)))
-        := by simp [SchwartzMap.standardLattice, stdBasis, Submodule.map_span]
+      = Submodule.span ℤ ((fun a : E => latticeEquiv (d := d) L a) ''
+            Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) := by
+        simp [SchwartzMap.standardLattice, Submodule.map_span]
     _ = Submodule.span ℤ (Set.range (rBasis (d := d) L)) := by rw [hrange]
     _ = L := by
         simpa [rBasis] using Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis L)
@@ -698,11 +704,12 @@ lemma covolume_eq_abs_det_latticeEquiv :
   have hr : rBasis (d := d) L = fun i : Fin d => (zBasis (d := d) L i : E) :=
     funext fun i => by simp [rBasis]
   have hcovol : ZLattice.covolume L =
-      |(stdBasis (d := d)).det (fun i : Fin d => (zBasis (d := d) L i : E))| := by
-    simpa [stdBasis, volume_real_fundamentalDomain_basisFun] using
+      |((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).det
+        (fun i : Fin d => (zBasis (d := d) L i : E))| := by
+    simpa [volume_real_fundamentalDomain_basisFun] using
       ZLattice.covolume_eq_det_mul_measureReal (L := L) (b := zBasis (d := d) L)
-        (b₀ := stdBasis (d := d)) (μ := (volume : Measure E))
-  rw [hcovol, ← hr]; simp [latticeEquiv, stdBasis]
+        (b₀ := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) (μ := (volume : Measure E))
+  rw [hcovol, ← hr]; simp [latticeEquiv]
 
 end CovolumeDet
 

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -131,14 +131,14 @@ sums and Fourier coefficients. -/
 
 /-- The `i`-th coordinate of `intVec k` is `(k i : ℝ)`. -/
 @[simp] public lemma intVec_apply (k : Fin d → ℤ) (i : Fin d) :
-    intVec (d := d) k i = (k i : ℝ) := rfl
+    intVec k i = (k i : ℝ) := rfl
 
-@[simp] lemma intVec_neg (k : Fin d → ℤ) : intVec (d := d) (-k) = -intVec (d := d) k := by
+@[simp] lemma intVec_neg (k : Fin d → ℤ) : intVec (-k) = -intVec k := by
   ext i; simp [intVec_apply]
 
 /-- Every integer vector lies in the standard lattice. -/
 public lemma intVec_mem_standardLattice (k : Fin d → ℤ) :
-    intVec (d := d) k ∈ SchwartzMap.standardLattice d :=
+    intVec k ∈ SchwartzMap.standardLattice d :=
   (Module.Basis.mem_span_iff_repr_mem ℤ _ _).2 fun i ↦ ⟨k i, rfl⟩
 
 open TopologicalSpace UnitAddTorus
@@ -154,7 +154,7 @@ public lemma measurableSet_iocCube : MeasurableSet (iocCube (d := d)) := by
 
 /-- Every element of the standard lattice comes from an integer vector via `intVec`. -/
 public lemma exists_intVec_eq_of_mem_standardLattice (x : E)
-    (hx : x ∈ SchwartzMap.standardLattice d) : ∃ n : Fin d → ℤ, x = intVec (d := d) n := by
+    (hx : x ∈ SchwartzMap.standardLattice d) : ∃ n : Fin d → ℤ, x = intVec n := by
   choose n hn using ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis.mem_span_iff_repr_mem ℤ x).1 hx
   exact ⟨n, PiLp.ext fun i => (hn i).symm⟩
 
@@ -171,11 +171,11 @@ public lemma dualSubmodule_standardLattice_eq :
           hx (EuclideanSpace.basisFun (Fin d) ℝ i) (Submodule.subset_span ⟨i, by simp⟩))
       exact ⟨n, by simpa using hn⟩
     choose n hn using hcoord
-    have hx_eq : x = intVec (d := d) n := by ext i; simp [hn i]
-    exact hx_eq ▸ intVec_mem_standardLattice (d := d) n
+    have hx_eq : x = intVec n := by ext i; simp [hn i]
+    exact hx_eq ▸ intVec_mem_standardLattice n
   · intro hx y hy
-    obtain ⟨n, rfl⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) x hx
-    obtain ⟨m, rfl⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) y hy
+    obtain ⟨n, rfl⟩ := exists_intVec_eq_of_mem_standardLattice x hx
+    obtain ⟨m, rfl⟩ := exists_intVec_eq_of_mem_standardLattice y hy
     exact Submodule.mem_one.mpr ⟨∑ i : Fin d, n i * m i,
       by simp [innerₗ_apply_apply, PiLp.inner_apply, mul_comm]⟩
 
@@ -191,13 +191,13 @@ with its own continuity and open-quotient API. -/
 
 /-- `coeFunE` is invariant under translation by integer vectors. -/
 @[simp] public theorem coeFunE_add_intVec (x : E) (n : Fin d → ℤ) :
-    coeFunE (d := d) (x + intVec (d := d) n) = coeFunE (d := d) x := by
+    coeFunE (x + intVec n) = coeFunE x := by
   ext i; simp [coeFunE, UnitAddTorus.coeFun]
 
 /-- If two points map to the same torus point, their difference is an integer vector. -/
 public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
-    (h : coeFunE (d := d) x = coeFunE (d := d) y) :
-    ∃ n : Fin d → ℤ, x - y = intVec (d := d) n := by
+    (h : coeFunE x = coeFunE y) :
+    ∃ n : Fin d → ℤ, x - y = intVec n := by
   have key (i : Fin d) : ∃ n : ℤ, (n : ℝ) = x i - y i := by
     have h0 : ((x i - y i : ℝ) : UnitAddCircle) = 0 := by
       simpa [UnitAddCircle, AddCircle.coe_sub, coeFunE, UnitAddTorus.coeFun] using
@@ -210,42 +210,42 @@ public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
 /-- The cube `iocCube` is a fundamental domain for translation by the standard lattice. -/
 public theorem isAddFundamentalDomain_iocCube :
     MeasureTheory.IsAddFundamentalDomain (SchwartzMap.standardLattice d)
-      (iocCube (d := d)) (volume : Measure E) := by
+      (iocCube) (volume : Measure E) := by
   refine MeasureTheory.IsAddFundamentalDomain.mk'
-    (measurableSet_iocCube (d := d)).nullMeasurableSet fun x ↦ ?_
+    (measurableSet_iocCube).nullMeasurableSet fun x ↦ ?_
   choose n hn huniq using fun i : Fin d ↦ by
     simpa [one_smul, add_assoc] using
       existsUnique_add_zsmul_mem_Ioc (G := ℝ) (ha := zero_lt_one) (b := (x i : ℝ)) (c := (0 : ℝ))
-  have hmem : x + intVec (d := d) n ∈ iocCube (d := d) := fun i ↦ by
+  have hmem : x + intVec n ∈ iocCube := fun i ↦ by
     simpa [intVec_apply, zsmul_one] using hn i
-  have hmem_unique : ∀ n' : Fin d → ℤ, x + intVec (d := d) n' ∈ iocCube (d := d) → n' = n :=
+  have hmem_unique : ∀ n' : Fin d → ℤ, x + intVec n' ∈ iocCube → n' = n :=
     fun n' hn' ↦ funext fun i ↦ huniq i (n' i) (by simpa [intVec_apply, zsmul_one] using hn' i)
-  refine ⟨⟨intVec (d := d) n, intVec_mem_standardLattice (d := d) n⟩, ?_, fun ℓ hℓ ↦ ?_⟩
+  refine ⟨⟨intVec n, intVec_mem_standardLattice n⟩, ?_, fun ℓ hℓ ↦ ?_⟩
   · change (⟨intVec n, _⟩ : ↥(standardLattice d)) +ᵥ x ∈ iocCube
     rwa [Submodule.vadd_def, vadd_eq_add, add_comm]
-  · obtain ⟨n', hn'⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
-    have hℓ' : x + intVec (d := d) n' ∈ iocCube (d := d) := by rw [add_comm, ← hn']; exact hℓ
-    exact Subtype.ext (hn'.trans (congrArg (intVec (d := d)) (hmem_unique n' hℓ')))
+  · obtain ⟨n', hn'⟩ := exists_intVec_eq_of_mem_standardLattice (ℓ : E) ℓ.property
+    have hℓ' : x + intVec n' ∈ iocCube := by rw [add_comm, ← hn']; exact hℓ
+    exact Subtype.ext (hn'.trans (congrArg (intVec) (hmem_unique n' hℓ')))
 
 /-- Pull back Haar integration on `(ℝ/ℤ)^d` to `iocCube` in `E = ℝ^d`. -/
 public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) → ℂ)
     (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus (Fin d)))) :
     (∫ y : UnitAddTorus (Fin d), g y) =
-      ∫ x, g (coeFunE (d := d) x) ∂(volume : Measure E).restrict (iocCube (d := d)) := by
+      ∫ x, g (coeFunE x) ∂(volume : Measure E).restrict (iocCube) := by
   -- `f` is the measure-preserving identification `ℝ^d ≃ᵐ E`, used to transport the cube integral.
   let f : (Fin d → ℝ) ≃ᵐ E := MeasurableEquiv.toLp 2 (Fin d → ℝ)
   have hmp : MeasurePreserving (⇑f) (volume : Measure (Fin d → ℝ)) (volume : Measure E) := by
     simpa [f] using PiLp.volume_preserving_toLp (ι := Fin d)
-  have hpre : f ⁻¹' iocCube (d := d) = Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1 := by
+  have hpre : f ⁻¹' iocCube = Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1 := by
     ext x; simp [f, iocCube]
   calc
     (∫ y : UnitAddTorus (Fin d), g y)
         = ∫ x, g (UnitAddTorus.coeFun d x) ∂(volume : Measure (Fin d → ℝ)).restrict
             (Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1) := by
           simpa using UnitAddTorus.integral_eq_integral_preimage_coeFun d 0 g hg
-    _ = ∫ y, g (coeFunE (d := d) y) ∂(volume : Measure E).restrict (iocCube (d := d)) := by
+    _ = ∫ y, g (coeFunE y) ∂(volume : Measure E).restrict (iocCube) := by
           simpa [hpre, coeFunE] using
-            (hmp.restrict_preimage (measurableSet_iocCube (d := d))).integral_comp'
+            (hmp.restrict_preimage (measurableSet_iocCube)).integral_comp'
               (g := fun y : E ↦ g (UnitAddTorus.coeFun d (WithLp.ofLp y)))
 
 end SchwartzMap.PoissonSummation.Standard
@@ -264,10 +264,10 @@ local notation "Λ" => SchwartzMap.standardLattice d
 `ℤ^d`, both for Schwartz-decay summability and for the dual-lattice change of variables. -/
 @[expose] public noncomputable def equivIntVec : (Fin d → ℤ) ≃ Λ :=
   Equiv.ofBijective
-    (fun n : Fin d → ℤ => ⟨intVec (d := d) n, intVec_mem_standardLattice (d := d) n⟩) <| by
+    (fun n : Fin d → ℤ => ⟨intVec n, intVec_mem_standardLattice n⟩) <| by
     refine ⟨fun a b hab => funext fun i => ?_, fun ℓ => ?_⟩
     · simpa using congrArg (fun x : E => x i) (congrArg Subtype.val hab)
-    · obtain ⟨n, hn⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
+    · obtain ⟨n, hn⟩ := exists_intVec_eq_of_mem_standardLattice (ℓ : E) ℓ.property
       exact ⟨n, Subtype.ext hn.symm⟩
 
 variable (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ))
@@ -288,7 +288,7 @@ map: it carries the `ContinuousMap` structure used to take sup-norms over compac
   (f : C(E, ℂ)).comp (ContinuousMap.addRight (ℓ : E))
 
 @[simp] public lemma translate_apply (ℓ : Λ) (x : E) :
-    translate (d := d) f ℓ x = f (x + (ℓ : E)) := rfl
+    translate f ℓ x = f (x + (ℓ : E)) := rfl
 
 /-- Only finitely many standard lattice points lie in a closed ball of radius `r`. -/
 public lemma finite_norm_le_lattice (r : ℝ) :
@@ -308,7 +308,7 @@ private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x �
 
 /-- Schwartz decay: sup norms of translates restricted to a compact `K` are summable. -/
 public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) :
-    Summable (fun ℓ : Λ => ‖(translate (d := d) f ℓ).restrict K‖) := by
+    Summable (fun ℓ : Λ => ‖(translate f ℓ).restrict K‖) := by
   -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable over `Λ`.
   let k : ℕ := Module.finrank ℤ Λ + 1
   obtain ⟨C, hCpos, hC⟩ := f.decay k 0
@@ -317,7 +317,7 @@ public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) 
   have hsum : Summable fun ℓ : Λ => ‖(ℓ : E)‖⁻¹ ^ k := by
     simpa [k] using ZLattice.summable_norm_pow_inv (L := Λ) k (Nat.lt_succ_self _)
   refine (hsum.mul_left (C * 2 ^ k)).of_norm_bounded_eventually ?_
-  filter_upwards [(finite_norm_le_lattice (d := d) (max (2 * r) 1)).eventually_cofinite_notMem]
+  filter_upwards [(finite_norm_le_lattice (max (2 * r) 1)).eventually_cofinite_notMem]
     with ℓ hℓ
   have hRlt : max (2 * r) 1 < ‖(ℓ : E)‖ := lt_of_not_ge (by simpa using hℓ)
   have hnorm_pos : 0 < ‖(ℓ : E)‖ := one_pos.trans_le ((le_max_right _ _).trans hRlt.le)
@@ -330,7 +330,7 @@ public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) 
   have hinv : ‖x + (ℓ : E)‖⁻¹ ≤ 2 * ‖(ℓ : E)‖⁻¹ := by
     have h := inv_anti₀ (by positivity) hge
     rwa [mul_inv, one_div, inv_inv] at h
-  calc ‖(translate (d := d) f ℓ) (⟨x, hxK⟩ : K)‖
+  calc ‖(translate f ℓ) (⟨x, hxK⟩ : K)‖
       = ‖f (x + (ℓ : E))‖ := rfl
     _ ≤ C / ‖x + (ℓ : E)‖ ^ k := (le_div_iff₀' (pow_pos hpos k)).2 (hC _)
     _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
@@ -340,7 +340,7 @@ public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) 
 /-- The quotient map `coeFunE`, bundled as a continuous map. This packaging is what the
 `IsQuotientMap.lift`/`FactorsThrough` API consumes when descending periodic maps to the torus. -/
 @[expose] public noncomputable def coeFunEC : C(E, UnitAddTorus (Fin d)) :=
-  ⟨coeFunE (d := d), continuous_coeFunE⟩
+  ⟨coeFunE, continuous_coeFunE⟩
 
 section Periodization
 
@@ -349,28 +349,28 @@ continuous map `x ↦ ∑' n : ℤ^d, f (x + n)`. It is `ℤ^d`-periodic (`perio
 it descends to the torus `(ℝ/ℤ)^d` (`descended`); its torus Fourier coefficients are the values of
 `𝓕 f` on `ℤ^d`, which is the content of Poisson summation. -/
 @[expose] public noncomputable def periodization : C(E, ℂ) :=
-  ∑' ℓ : Λ, translate (d := d) f ℓ
+  ∑' ℓ : Λ, translate f ℓ
 
 public lemma periodization_apply (x : E) :
-    periodization (d := d) f x = ∑' ℓ : Λ, f (x + (ℓ : E)) := by
+    periodization f x = ∑' ℓ : Λ, f (x + (ℓ : E)) := by
   simpa [periodization, translate_apply] using
     (ContinuousMap.tsum_apply (ContinuousMap.summable_of_locally_summable_norm
-      (summable_norm_translate_restrict (d := d) f)) x).symm
+      (summable_norm_translate_restrict f)) x).symm
 
 /-- The periodization is invariant under translation by a lattice vector. -/
 public lemma periodization_add_lattice (x : E) (ℓ : Λ) :
-    periodization (d := d) f (x + (ℓ : E)) = periodization (d := d) f x := by
+    periodization f (x + (ℓ : E)) = periodization f x := by
   rw [periodization_apply, periodization_apply]
   simpa [add_assoc] using (Equiv.addLeft ℓ).tsum_eq fun m : Λ ↦ f (x + (m : E))
 
 /-- The periodization factors through the quotient `(ℝ/ℤ)^d`. -/
 public lemma periodization_factorsThrough :
-    Function.FactorsThrough (periodization (d := d) f) (coeFunEC (d := d)) := by
+    Function.FactorsThrough (periodization f) (coeFunEC) := by
   intro x y hxy
-  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq (d := d) (by simpa [coeFunEC] using hxy)
-  have hx : x = y + intVec (d := d) n := by rw [← hn]; abel
+  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq (by simpa [coeFunEC] using hxy)
+  have hx : x = y + intVec n := by rw [← hn]; abel
   rw [hx]
-  exact periodization_add_lattice (d := d) f y ⟨_, intVec_mem_standardLattice (d := d) n⟩
+  exact periodization_add_lattice f y ⟨_, intVec_mem_standardLattice n⟩
 
 end Periodization
 
@@ -383,42 +383,42 @@ public theorem isOpenQuotientMap_coeFunE : IsOpenQuotientMap (coeFunE (d := d)) 
 torus Fourier theory: the Fourier coefficients of `descended f` are the values of `𝓕 f` on the
 lattice. -/
 @[expose] public noncomputable def descended : C(UnitAddTorus (Fin d), ℂ) :=
-  isOpenQuotientMap_coeFunE.isQuotientMap.lift (periodization (d := d) f)
-    (periodization_factorsThrough (d := d) (f := f))
+  isOpenQuotientMap_coeFunE.isQuotientMap.lift (periodization f)
+    (periodization_factorsThrough (f := f))
 
 /-- Compatibility of `descended` with `coeFunE`: pulling back along the quotient gives back the
 periodization. -/
 public lemma descended_comp (x : E) :
-    descended (d := d) f (coeFunE (d := d) x) = periodization (d := d) f x :=
+    descended f (coeFunE x) = periodization f x :=
   congrArg (fun g : C(E, ℂ) => g x)
     (by simp [descended] :
-      (descended (d := d) f).comp (coeFunEC (d := d)) = periodization (d := d) f)
+      (descended f).comp (coeFunEC) = periodization f)
 
 public lemma mFourier_neg_apply_coeFunE (n : Fin d → ℤ) (x : E) :
-    UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) =
-      (𝐞 (-(inner ℝ x (intVec (d := d) n))) : ℂ) := by
-  have hinner : inner ℝ x (intVec (d := d) n) = ∑ i, (n i : ℝ) * (x.ofLp i : ℝ) := by
+    UnitAddTorus.mFourier (-n) (coeFunE x) =
+      (𝐞 (-(inner ℝ x (intVec n))) : ℂ) := by
+  have hinner : inner ℝ x (intVec n) = ∑ i, (n i : ℝ) * (x.ofLp i : ℝ) := by
     simp [intVec, PiLp.inner_apply]
   rw [hinner]
   simp [coeFunE, UnitAddTorus.mFourier_apply_coeFun_ofLp, Real.fourierChar_apply,
     Finset.sum_neg_distrib, mul_assoc, mul_comm]
 
 public lemma mFourier_apply_coeFunE_exp (n : Fin d → ℤ) (x : E) :
-    UnitAddTorus.mFourier n (coeFunE (d := d) x) =
-      Complex.exp (2 * Real.pi * Complex.I * ⟪x, intVec (d := d) n⟫_[ℝ]) := by
-  have h := mFourier_neg_apply_coeFunE (d := d) (n := -n) (x := x)
+    UnitAddTorus.mFourier n (coeFunE x) =
+      Complex.exp (2 * Real.pi * Complex.I * ⟪x, intVec n⟫_[ℝ]) := by
+  have h := mFourier_neg_apply_coeFunE (n := -n) (x := x)
   simp only [neg_neg, intVec_neg, inner_neg_right] at h
   rw [h, ← RCLike.inner_eq_wInner_one]
   simp [Real.fourierChar_apply, mul_assoc, mul_comm]
 
 public lemma mFourier_neg_apply_coeFunE_add_standardLattice (n : Fin d → ℤ) (ℓ : Λ) (x : E) :
-    UnitAddTorus.mFourier (-n) (coeFunE (d := d) (x + (ℓ : E))) =
-      UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) := by
-  obtain ⟨m, hm⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
+    UnitAddTorus.mFourier (-n) (coeFunE (x + (ℓ : E))) =
+      UnitAddTorus.mFourier (-n) (coeFunE x) := by
+  obtain ⟨m, hm⟩ := exists_intVec_eq_of_mem_standardLattice (ℓ : E) ℓ.property
   rw [hm, coeFunE_add_intVec]
 
 public lemma iocCube_subset_closedBall :
-    iocCube (d := d) ⊆ Metric.closedBall (0 : E) (Real.sqrt d) := fun x hx => by
+    iocCube ⊆ Metric.closedBall (0 : E) (Real.sqrt d) := fun x hx => by
   rw [Metric.mem_closedBall, dist_eq_norm, sub_zero, EuclideanSpace.norm_eq]
   refine Real.sqrt_le_sqrt ?_
   calc ∑ i : Fin d, ‖x i‖ ^ 2 ≤ ∑ _i : Fin d, (1 : ℝ) := by
@@ -426,9 +426,9 @@ public lemma iocCube_subset_closedBall :
         rw [Real.norm_eq_abs, abs_of_pos (hx i).1]; exact (hx i).2
     _ = d := by simp
 
-public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube (d := d)) < ⊤ :=
+public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube) < ⊤ :=
   ((Metric.isBounded_closedBall (x := (0 : E)) (r := Real.sqrt d)).subset
-    (iocCube_subset_closedBall (d := d))).measure_lt_top
+    (iocCube_subset_closedBall)).measure_lt_top
 
 /-- The closed ball of radius `√d`, packaged as `Compacts E`; it contains the fundamental cube
 `iocCube`. Kept as a named definition: it is the single compact on which the Schwartz-decay
@@ -439,50 +439,50 @@ def sqrtdBall : TopologicalSpace.Compacts E :=
 /-- On `iocCube`, the integrand `mFourier (-n) (coeFunE ·) * f (· + ℓ)` is bounded by the sup norm
 of the translate `f (· + ℓ)` restricted to `sqrtdBall`. -/
 lemma norm_mFourier_mul_translate_le (n : Fin d → ℤ) (ℓ : Λ) {x : E}
-    (hx : x ∈ iocCube (d := d)) :
-    ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖ ≤
-      ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+    (hx : x ∈ iocCube) :
+    ‖UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))‖ ≤
+      ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
   rw [norm_mul]
-  calc ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x)‖ * ‖f (x + (ℓ : E))‖
+  calc ‖UnitAddTorus.mFourier (-n) (coeFunE x)‖ * ‖f (x + (ℓ : E))‖
       ≤ 1 * ‖f (x + (ℓ : E))‖ := by
         gcongr
         simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
           ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) _
     _ = ‖f (x + (ℓ : E))‖ := one_mul _
-    _ ≤ ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+    _ ≤ ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
         simpa [translate_apply, ContinuousMap.restrict_apply] using
-          ContinuousMap.norm_coe_le_norm ((translate (d := d) f ℓ).restrict (sqrtdBall (d := d)))
-            ⟨x, iocCube_subset_closedBall (d := d) hx⟩
+          ContinuousMap.norm_coe_le_norm ((translate f ℓ).restrict (sqrtdBall (d := d)))
+            ⟨x, iocCube_subset_closedBall hx⟩
 
 public lemma integrableOn_mFourier_mul_translate_iocCube (n : Fin d → ℤ) (ℓ : Λ) :
     IntegrableOn
-        (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
-        (iocCube (d := d)) (volume : Measure E) :=
-  Measure.integrableOn_of_bounded (volume_iocCube_lt_top (d := d)).ne
-    (((UnitAddTorus.mFourier (-n)).continuous.comp (continuous_coeFunE (d := d))).mul
+        (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E)))
+        (iocCube) (volume : Measure E) :=
+  Measure.integrableOn_of_bounded (volume_iocCube_lt_top).ne
+    (((UnitAddTorus.mFourier (-n)).continuous.comp (continuous_coeFunE)).mul
         (f.continuous.comp (continuous_id.add continuous_const))).aestronglyMeasurable
-    (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun _ hx =>
-      norm_mFourier_mul_translate_le (d := d) f n ℓ hx)
+    (ae_restrict_of_forall_mem (measurableSet_iocCube) fun _ hx =>
+      norm_mFourier_mul_translate_le f n ℓ hx)
 
 section StandardPoissonSummation
 
 open UnitAddTorus PoissonSummation.Standard
 
 lemma summable_integral_norm_mFourier_mul_translate_iocCube (n : Fin d → ℤ) :
-    Summable (fun ℓ : Λ => ∫ x in iocCube (d := d),
-        ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖
+    Summable (fun ℓ : Λ => ∫ x in iocCube,
+        ‖UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))‖
         ∂(volume : Measure E)) := by
   -- `μ` is the (finite) restriction of Lebesgue measure to the fundamental cube.
-  set μ : Measure E := (volume : Measure E).restrict (iocCube (d := d)) with hμ
-  have : IsFiniteMeasure μ := ⟨by simpa [hμ] using volume_iocCube_lt_top (d := d)⟩
-  refine ((summable_norm_translate_restrict (d := d) f (sqrtdBall (d := d))).mul_left
+  set μ : Measure E := (volume : Measure E).restrict (iocCube) with hμ
+  have : IsFiniteMeasure μ := ⟨by simpa [hμ] using volume_iocCube_lt_top⟩
+  refine ((summable_norm_translate_restrict f (sqrtdBall)).mul_left
     (μ.real Set.univ)).of_nonneg_of_le (fun _ => by positivity) fun ℓ => ?_
-  calc ∫ x, ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖ ∂μ
-      ≤ ∫ _, ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ ∂μ :=
+  calc ∫ x, ‖UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))‖ ∂μ
+      ≤ ∫ _, ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ ∂μ :=
         integral_mono_of_nonneg (ae_of_all _ fun _ => norm_nonneg _) (integrable_const _)
-          (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x hx =>
-            norm_mFourier_mul_translate_le (d := d) f n ℓ hx)
-    _ = μ.real Set.univ * ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+          (ae_restrict_of_forall_mem (measurableSet_iocCube) fun x hx =>
+            norm_mFourier_mul_translate_le f n ℓ hx)
+    _ = μ.real Set.univ * ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
         rw [integral_const, smul_eq_mul]
 
 /-- The ambient `volume` on `UnitAddCircle` is the probability measure `haarAddCircle` baked into
@@ -506,94 +506,94 @@ private lemma mFourierCoeff_eq_integral_volume (n : Fin d → ℤ) (g : UnitAddT
 /-- The `n`-th torus Fourier coefficient of `descended f` is the integral over the unit cube
 of `mFourier(-n)(coeFunE x)` times the periodization `∑' ℓ, f (x + ℓ)`. -/
 private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
-    UnitAddTorus.mFourierCoeff (descended (d := d) f) n =
-      ∫ x in iocCube (d := d),
-        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
+    UnitAddTorus.mFourierCoeff (descended f) n =
+      ∫ x in iocCube,
+        UnitAddTorus.mFourier (-n) (coeFunE x) *
           (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E) := by
-  have hpull : (∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended (d := d) f y) =
-        ∫ x in iocCube (d := d), UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) •
-            descended (d := d) f (coeFunE (d := d) x) ∂(volume : Measure E) :=
+  have hpull : (∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended f y) =
+        ∫ x in iocCube, UnitAddTorus.mFourier (-n) (coeFunE x) •
+            descended f (coeFunE x) ∂(volume : Measure E) :=
     integral_eq_integral_preimage_coeFunE
       (fun y => UnitAddTorus.mFourier (-n) y • descended f y)
       ((UnitAddTorus.mFourier (-n)).continuous.smul
-        (descended (d := d) f).continuous).aestronglyMeasurable
+        (descended f).continuous).aestronglyMeasurable
   calc
-    UnitAddTorus.mFourierCoeff (descended (d := d) f) n
-        = ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended (d := d) f y :=
-          mFourierCoeff_eq_integral_volume (d := d) n (descended (d := d) f)
-    _ = ∫ x in iocCube (d := d),
-          UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) •
-            descended (d := d) f (coeFunE (d := d) x)
+    UnitAddTorus.mFourierCoeff (descended f) n
+        = ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended f y :=
+          mFourierCoeff_eq_integral_volume n (descended f)
+    _ = ∫ x in iocCube,
+          UnitAddTorus.mFourier (-n) (coeFunE x) •
+            descended f (coeFunE x)
             ∂(volume : Measure E) := by simpa using hpull
     _ = _ :=
-          integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube (d := d))
-            fun _ _ => by simp [descended_comp (d := d) (f := f),
-              periodization_apply (d := d) (f := f), smul_eq_mul]
+          integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube)
+            fun _ _ => by simp [descended_comp (f := f),
+              periodization_apply (f := f), smul_eq_mul]
 
 /-- The integrand `mFourier(-n)(coeFunE x) * f x` is integrable over `E`: it is `f` (integrable,
 being Schwartz) scaled by the factor `mFourier(-n) ∘ coeFunE`, which has norm `≤ 1`. -/
 lemma integrable_mFourier_mul (n : Fin d → ℤ) :
-    Integrable (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x)
+    Integrable (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE x) * f x)
       (volume : Measure E) := by
   simpa using Integrable.bdd_mul (μ := (volume : Measure E))
     (SchwartzMap.integrable (μ := (volume : Measure E)) f)
     (((UnitAddTorus.mFourier (-n)).continuous.comp
-      (continuous_coeFunE (d := d))).aestronglyMeasurable)
+      (continuous_coeFunE)).aestronglyMeasurable)
     (ae_of_all _ fun x => by
       simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
-        (ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) (coeFunE (d := d) x)))
+        (ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) (coeFunE x)))
 
 /-- Interchange of the cube-integral and the lattice sum: the cube-integral of
 `mFourier(-n)(coeFunE ·)` against the periodization is the lattice sum of the cube-integrals of the
 individual translates (`integral_tsum_of_summable_integral_norm`). -/
 lemma integral_iocCube_periodization_eq_tsum (n : Fin d → ℤ) :
-    (∫ x in iocCube (d := d),
-        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
+    (∫ x in iocCube,
+        UnitAddTorus.mFourier (-n) (coeFunE x) *
           (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
-      ∑' ℓ : Λ, ∫ x in iocCube (d := d),
-        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))
+      ∑' ℓ : Λ, ∫ x in iocCube,
+        UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))
           ∂(volume : Measure E) := by
   simpa [tsum_mul_left, mul_assoc] using
     (MeasureTheory.integral_tsum_of_summable_integral_norm
-        (μ := (volume : Measure E).restrict (iocCube (d := d)))
+        (μ := (volume : Measure E).restrict (iocCube))
         (F := fun ℓ : Λ => fun x : E =>
-          UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
+          UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E)))
         (fun ℓ => by
           simpa [IntegrableOn] using
-            (integrableOn_mFourier_mul_translate_iocCube (d := d) (f := f) n ℓ))
-        (summable_integral_norm_mFourier_mul_translate_iocCube (d := d) (f := f) n)).symm
+            (integrableOn_mFourier_mul_translate_iocCube (f := f) n ℓ))
+        (summable_integral_norm_mFourier_mul_translate_iocCube (f := f) n)).symm
 
 /-- The integral over the unit cube of `mFourier(-n)(coeFunE x)` times the periodization of `f`
 equals the integral of `mFourier(-n)(coeFunE x) * f x` over the whole space, by swapping the
 integral with the lattice sum (`integral_iocCube_periodization_eq_tsum`) and applying the
 fundamental-domain property of `iocCube`. -/
 private lemma integral_iocCube_mFourier_periodization_eq_integral (n : Fin d → ℤ) :
-    (∫ x in iocCube (d := d),
-        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
+    (∫ x in iocCube,
+        UnitAddTorus.mFourier (-n) (coeFunE x) *
           (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
-      ∫ x : E, UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x ∂(volume : Measure E) := by
+      ∫ x : E, UnitAddTorus.mFourier (-n) (coeFunE x) * f x ∂(volume : Measure E) := by
   -- `g` is the full integrand, abbreviated for the fundamental-domain unfolding below.
-  let g : E → ℂ := fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x
+  let g : E → ℂ := fun x : E => UnitAddTorus.mFourier (-n) (coeFunE x) * f x
   have hterm : ∀ ℓ : Λ,
-      (∫ x in iocCube (d := d), g (ℓ +ᵥ x) ∂(volume : Measure E)) =
-          ∫ x in iocCube (d := d),
-            UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
+      (∫ x in iocCube, g (ℓ +ᵥ x) ∂(volume : Measure E)) =
+          ∫ x in iocCube,
+            UnitAddTorus.mFourier (-n) (coeFunE x) *
               f (x + (ℓ : E)) ∂(volume : Measure E) := fun ℓ =>
-    integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x _ => by
+    integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube) fun x _ => by
       simp [g, Submodule.vadd_def, vadd_eq_add, add_comm,
-        mFourier_neg_apply_coeFunE_add_standardLattice (d := d) (n := n) (ℓ := ℓ) (x := x)]
-  rw [integral_iocCube_periodization_eq_tsum (d := d) (f := f) n]
+        mFourier_neg_apply_coeFunE_add_standardLattice (n := n) (ℓ := ℓ) (x := x)]
+  rw [integral_iocCube_periodization_eq_tsum (f := f) n]
   simpa [g, hterm] using
-    ((isAddFundamentalDomain_iocCube (d := d)).integral_eq_tsum'' g
-      (integrable_mFourier_mul (d := d) (f := f) n)).symm
+    ((isAddFundamentalDomain_iocCube).integral_eq_tsum'' g
+      (integrable_mFourier_mul (f := f) n)).symm
 
 lemma mFourierCoeff_descended (n : Fin d → ℤ) :
-    UnitAddTorus.mFourierCoeff (descended (d := d) f) n =
-      𝓕 (fun x : E => f x) (intVec (d := d) n) := by
-  rw [mFourierCoeff_descended_eq_iocCube_integral (d := d) (f := f) (n := n),
-      integral_iocCube_mFourier_periodization_eq_integral (d := d) (f := f) (n := n)]
+    UnitAddTorus.mFourierCoeff (descended f) n =
+      𝓕 (fun x : E => f x) (intVec n) := by
+  rw [mFourierCoeff_descended_eq_iocCube_integral (f := f) (n := n),
+      integral_iocCube_mFourier_periodization_eq_integral (f := f) (n := n)]
   simp [Real.fourier_eq, Circle.smul_def, smul_eq_mul,
-    mFourier_neg_apply_coeFunE (d := d) (n := n)]
+    mFourier_neg_apply_coeFunE (n := n)]
 
 /-- Schwartz–Fourier decay over the lattice: `𝓕 f` is summable in norm over `Λ = ℤ^d`. The decay
 order `d + 1` exceeds the lattice rank, so `‖·‖⁻¹ ^ (d + 1)` is summable and dominates `𝓕 f`. -/
@@ -608,7 +608,7 @@ lemma summable_norm_fourier_lattice :
   refine Summable.of_norm_bounded_eventually
     ((by simpa using ZLattice.summable_norm_pow_inv (L := Λ) (n := d + 1) hk :
       Summable (fun ℓ : Λ => (‖(ℓ : E)‖⁻¹ ^ (d + 1) : ℝ))).mul_left C) ?_
-  filter_upwards [(finite_norm_le_lattice (d := d) 1).compl_mem_cofinite] with ℓ hℓ
+  filter_upwards [(finite_norm_le_lattice 1).compl_mem_cofinite] with ℓ hℓ
   simpa [Real.norm_of_nonneg (norm_nonneg _), div_eq_mul_inv, inv_pow, one_div] using
     (le_div_iff₀' (pow_pos (lt_trans (by positivity)
       (lt_of_not_ge (by simpa using hℓ) : (1 : ℝ) < ‖(ℓ : E)‖)) _)).2 (hC' (ℓ : E))
@@ -616,27 +616,27 @@ lemma summable_norm_fourier_lattice :
 /-- The Fourier-decay summability of `summable_norm_fourier_lattice`, reindexed over `ℤ^d` along
 `equivIntVec`. -/
 lemma summable_norm_fourier_intVec :
-    Summable (fun n : Fin d → ℤ => ‖𝓕 (fun x : E => f x) (intVec (d := d) n)‖) := by
-  simpa [equivIntVec] using (summable_norm_fourier_lattice (d := d) (f := f)).comp_injective
-    (equivIntVec (d := d)).injective
+    Summable (fun n : Fin d → ℤ => ‖𝓕 (fun x : E => f x) (intVec n)‖) := by
+  simpa [equivIntVec] using (summable_norm_fourier_lattice (f := f)).comp_injective
+    (equivIntVec).injective
 
 lemma summable_mFourierCoeff_descended :
-    Summable (UnitAddTorus.mFourierCoeff (descended (d := d) f)) :=
+    Summable (UnitAddTorus.mFourierCoeff (descended f)) :=
   Summable.of_norm <| by
-    simpa [mFourierCoeff_descended (d := d) (f := f)] using
-      summable_norm_fourier_intVec (d := d) (f := f)
+    simpa [mFourierCoeff_descended (f := f)] using
+      summable_norm_fourier_intVec (f := f)
 
 /-- Poisson summation for Schwartz functions over the standard lattice `ℤ^d`. -/
 public theorem poissonSummation_standard (v : E) :
-    (∑' ℓ : Λ, f (v + (ℓ : E))) = ∑' n : Fin d → ℤ, 𝓕 (fun x : E => f x) (intVec (d := d) n) *
-        Complex.exp (2 * Real.pi * Complex.I * ⟪v, intVec (d := d) n⟫_[ℝ]) := by
-  simpa [descended_comp (d := d) (f := f) v, periodization_apply (d := d) (f := f), smul_eq_mul,
-    mFourierCoeff_descended (d := d) (f := f), mFourier_apply_coeFunE_exp (d := d), mul_assoc,
+    (∑' ℓ : Λ, f (v + (ℓ : E))) = ∑' n : Fin d → ℤ, 𝓕 (fun x : E => f x) (intVec n) *
+        Complex.exp (2 * Real.pi * Complex.I * ⟪v, intVec n⟫_[ℝ]) := by
+  simpa [descended_comp (f := f) v, periodization_apply (f := f), smul_eq_mul,
+    mFourierCoeff_descended (f := f), mFourier_apply_coeFunE_exp, mul_assoc,
     mul_left_comm, mul_comm] using
     (UnitAddTorus.hasSum_mFourier_series_apply_of_summable
-        (f := descended (d := d) f)
-        (summable_mFourierCoeff_descended (d := d) (f := f))
-        (coeFunE (d := d) v)).tsum_eq.symm
+        (f := descended f)
+        (summable_mFourierCoeff_descended (f := f))
+        (coeFunE v)).tsum_eq.symm
 
 end StandardPoissonSummation
 
@@ -669,7 +669,7 @@ noncomputable def zBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice 
 Mathlib's `Basis.ofZLatticeBasis`. Kept as a named definition: it is the image of the standard
 basis under `latticeEquiv L`, and computing against it gives the covolume. -/
 noncomputable def rBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
-    Basis (Fin d) ℝ E := (zBasis (d := d) L).ofZLatticeBasis ℝ L
+    Basis (Fin d) ℝ E := (zBasis L).ofZLatticeBasis ℝ L
 
 /-- The `ℝ`-linear automorphism of `E` sending the standard basis `(EuclideanSpace.basisFun _ _)`
 to `rBasis L`, hence the standard lattice `ℤ^d` onto `L`. Kept as a named definition: it is the
@@ -678,31 +678,31 @@ standard-lattice case, used throughout this section (and, via its inverse-adjoin
 dual side). -/
 noncomputable def latticeEquiv (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     E ≃ₗ[ℝ] E :=
-  ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).equiv (rBasis (d := d) L) (Equiv.refl (Fin d))
+  ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).equiv (rBasis L) (Equiv.refl (Fin d))
 
 /-- `latticeEquiv L` sends the `i`-th standard basis vector to the `i`-th vector of `rBasis L`.
 (Not a `simp` lemma: `(basisFun _ _).toBasis i` is itself simp-normalised to `EuclideanSpace.single
 i 1`, so this would never fire.) -/
 lemma latticeEquiv_apply_basisFun (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L]
     (i : Fin d) :
-    latticeEquiv (d := d) L ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis i) =
-      rBasis (d := d) L i :=
-  Basis.equiv_apply (b := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) (b' := rBasis (d := d) L)
+    latticeEquiv L ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis i) =
+      rBasis L i :=
+  Basis.equiv_apply (b := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) (b' := rBasis L)
     (e := Equiv.refl _) (i := i)
 
 lemma map_standardLattice_eq (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
-    Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
+    Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
         (SchwartzMap.standardLattice d) = L := by
-  have hrange : (fun a : E => latticeEquiv (d := d) L a) ''
+  have hrange : (fun a : E => latticeEquiv L a) ''
         Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis) =
-      Set.range (rBasis (d := d) L) := by
+      Set.range (rBasis L) := by
     rw [← Set.range_comp]; simp only [Function.comp_def, latticeEquiv_apply_basisFun]
-  calc Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
+  calc Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
           (SchwartzMap.standardLattice d)
-      = Submodule.span ℤ ((fun a : E => latticeEquiv (d := d) L a) ''
+      = Submodule.span ℤ ((fun a : E => latticeEquiv L a) ''
             Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) := by
         simp [SchwartzMap.standardLattice, Submodule.map_span]
-    _ = Submodule.span ℤ (Set.range (rBasis (d := d) L)) := by rw [hrange]
+    _ = Submodule.span ℤ (Set.range (rBasis L)) := by rw [hrange]
     _ = L := by
         simpa [rBasis] using Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis L)
 
@@ -723,13 +723,13 @@ variable (L : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology L] [
 onto `L` scales the unit-covolume standard lattice by exactly its determinant. -/
 lemma covolume_eq_abs_det_latticeEquiv :
     ZLattice.covolume L = |(LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((latticeEquiv L).toLinearMap)| := by
-  have hr : rBasis (d := d) L = fun i : Fin d => (zBasis (d := d) L i : E) :=
+  have hr : rBasis L = fun i : Fin d => (zBasis L i : E) :=
     funext fun i => by simp [rBasis]
   have hcovol : ZLattice.covolume L =
       |((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).det
-        (fun i : Fin d => (zBasis (d := d) L i : E))| := by
+        (fun i : Fin d => (zBasis L i : E))| := by
     simpa [volume_real_fundamentalDomain_basisFun] using
-      ZLattice.covolume_eq_det_mul_measureReal (L := L) (b := zBasis (d := d) L)
+      ZLattice.covolume_eq_det_mul_measureReal (L := L) (b := zBasis L)
         (b₀ := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) (μ := (volume : Measure E))
   rw [hcovol, ← hr]; simp [latticeEquiv]
 
@@ -764,21 +764,21 @@ lemma dualEquiv_symm_apply (x : E) :
 `L`. Kept as a named definition: it transports lattice sums between `ℤ^d` and `L`. -/
 noncomputable def equivStandardLattice : SchwartzMap.standardLattice d ≃ₗ[ℤ] L :=
   (LinearEquiv.restrictScalars ℤ (latticeEquiv L)).ofSubmodules (SchwartzMap.standardLattice d) L
-    (by simpa [LinearEquiv.restrictScalars_apply] using map_standardLattice_eq (d := d) L)
+    (by simpa [LinearEquiv.restrictScalars_apply] using map_standardLattice_eq L)
 
 @[simp] lemma equivStandardLattice_apply (x : SchwartzMap.standardLattice d) :
-    ((equivStandardLattice (d := d) L x : L) : E) = (latticeEquiv L) x := by
+    ((equivStandardLattice L x : L) : E) = (latticeEquiv L) x := by
   simp [equivStandardLattice]
 
 /-- The dual change of variables `dualEquiv L` carries the standard lattice `ℤ^d` onto the dual
 lattice `L*`. This is what lets `dualEquiv L` reindex the spectral sum over `L*`. -/
 lemma map_standardLattice_dualEquiv_eq :
     Submodule.map ((dualEquiv L).toLinearMap.restrictScalars ℤ) (standardLattice d) =
-      dualLattice (d := d) L := by
+      dualLattice L := by
   have hmapL : Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
-      (standardLattice d) = L := map_standardLattice_eq (d := d) L
-  have hdualStd : dualLattice (d := d) (standardLattice d) = standardLattice d := by
-    simpa [dualLattice] using PoissonSummation.Standard.dualSubmodule_standardLattice_eq (d := d)
+      (standardLattice d) = L := map_standardLattice_eq L
+  have hdualStd : dualLattice (standardLattice d) = standardLattice d := by
+    simpa [dualLattice] using PoissonSummation.Standard.dualSubmodule_standardLattice_eq
   have hBA (y w : E) : inner ℝ (dualEquiv L y) ((latticeEquiv L) w) = inner ℝ y w := by
     simpa [dualEquiv_apply] using LinearMap.adjoint_inner_left ((latticeEquiv L).symm.toLinearMap)
       ((latticeEquiv L) w) y
@@ -791,8 +791,8 @@ lemma map_standardLattice_dualEquiv_eq :
     obtain ⟨w, hw, rfl⟩ : (z : E) ∈ Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
         (standardLattice d) := by rw [hmapL]; exact hz
     simpa [dualLattice, innerₗ_apply_apply, hBA] using
-      (by simpa [hdualStd] using hy : y ∈ dualLattice (d := d) (standardLattice d)) w hw
-  · suffices hydual : (dualEquiv L).symm x ∈ dualLattice (d := d) (standardLattice d) by
+      (by simpa [hdualStd] using hy : y ∈ dualLattice (standardLattice d)) w hw
+  · suffices hydual : (dualEquiv L).symm x ∈ dualLattice (standardLattice d) by
       simpa [hdualStd] using hydual
     intro w hw
     have hwL : (latticeEquiv L) w ∈ L := by
@@ -807,7 +807,7 @@ private lemma poissonSummation_lattice_lhs (f : SchwartzMap E ℂ) (v : E) :
     (∑' ℓ : SchwartzMap.standardLattice d, f (v + (latticeEquiv L) (ℓ : E))) =
       ∑' ℓ : L, f (v + (ℓ : E)) := by
   simpa [equivStandardLattice_apply] using
-    (equivStandardLattice (d := d) L).toEquiv.tsum_eq (f := fun ℓ : L => f (v + (ℓ : E)))
+    (equivStandardLattice L).toEquiv.tsum_eq (f := fun ℓ : L => f (v + (ℓ : E)))
 
 /-- Inner-product rewrite for exponentials: `⟪(latticeEquiv L).symm v, w⟫ = ⟪v, dualEquiv L w⟫`. -/
 private lemma poissonSummation_lattice_inner_swap (v w : E) :
@@ -821,19 +821,19 @@ to the dual lattice `L*` along `dualEquiv = (latticeEquiv L).symm.adjoint`. -/
 private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
     (∑' n : Fin d → ℤ,
         (𝓕 (fun x : E => f ((latticeEquiv L) x))
-          (intVec (d := d) n)) *
+          (intVec n)) *
           Complex.exp (2 * π * Complex.I *
-            ⟪(latticeEquiv L).symm v, intVec (d := d) n⟫_[ℝ])) =
+            ⟪(latticeEquiv L).symm v, intVec n⟫_[ℝ])) =
       (1 / ZLattice.covolume L) *
-        ∑' m : dualLattice (d := d) L,
+        ∑' m : dualLattice L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
   -- Abbreviations: the dual-lattice summand `F`, the determinant `detA` of the change of
   -- variables and its reciprocal `cC = |detA|⁻¹`, and the integer-vector embedding `iv`.
-  let F : dualLattice (d := d) L → ℂ :=
+  let F : dualLattice L → ℂ :=
     fun m => (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ])
   let detA : ℝ := (LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((latticeEquiv L) : E →ₗ[ℝ] E)
   let cC : ℂ := ((abs detA)⁻¹ : ℝ)
-  let iv : (Fin d → ℤ) → E := intVec (d := d)
+  let iv : (Fin d → ℤ) → E := intVec
   have hfourier (w : E) : 𝓕 (fun x : E => f ((latticeEquiv L) x)) w =
       cC * 𝓕 (fun x : E => f x) (dualEquiv L w) := by
     simpa [dualEquiv_apply, detA, cC, Complex.real_smul] using
@@ -841,11 +841,11 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
         (A := latticeEquiv L) (f := fun x : E => f x) w
   have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (iv n)) *
         Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, iv n⟫_[ℝ])) =
-      cC * ∑' m : dualLattice (d := d) L, F m := by
+      cC * ∑' m : dualLattice L, F m := by
     rw [← (PoissonSummation.Standard.equivIntVec.trans
       ((LinearEquiv.restrictScalars ℤ (dualEquiv L)).ofSubmodules _ _ <| by
           simpa [LinearEquiv.restrictScalars_apply] using
-            map_standardLattice_dualEquiv_eq (d := d) (L := L)).toEquiv).tsum_eq
+            map_standardLattice_dualEquiv_eq (L := L)).toEquiv).tsum_eq
       (f := F), ← tsum_mul_left]
     exact tsum_congr fun n ↦ by
       simpa [F, mul_assoc, poissonSummation_lattice_inner_swap (L := L) v (w := iv n)] using
@@ -853,13 +853,13 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
           (hfourier (w := iv n))
   rw [hreindex]
   simp [F, cC, show ZLattice.covolume L = abs detA from by
-    simpa [latticeEquiv, detA] using covolume_eq_abs_det_latticeEquiv (d := d) (L := L), one_div]
+    simpa [latticeEquiv, detA] using covolume_eq_abs_det_latticeEquiv (L := L), one_div]
 
 /-- Poisson summation over a full-rank `ℤ`-lattice `L`. -/
 public theorem poissonSummation_lattice (f : SchwartzMap E ℂ) (v : E) :
     (∑' ℓ : L, f (v + (ℓ : E))) =
       (1 / ZLattice.covolume L) *
-        ∑' m : dualLattice (d := d) L,
+        ∑' m : dualLattice L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
   -- `A` is the change of variables `ℤ^d → L`; `g = f ∘ A` is again Schwartz.
   -- The local instance short-circuits a `ContinuousSMul ℝ E` search that otherwise loops on
@@ -875,15 +875,15 @@ public theorem poissonSummation_lattice (f : SchwartzMap E ℂ) (v : E) :
     rw [tsum_congr hg]
     exact poissonSummation_lattice_lhs (L := L) f v
   have hrhs : (∑' n : Fin d → ℤ,
-        (𝓕 (fun x : E => g x) (intVec (d := d) n)) *
+        (𝓕 (fun x : E => g x) (intVec n)) *
           Complex.exp (2 * π * Complex.I *
-            ⟪A.symm v, intVec (d := d) n⟫_[ℝ])) =
+            ⟪A.symm v, intVec n⟫_[ℝ])) =
       (1 / ZLattice.covolume L) *
-        ∑' m : dualLattice (d := d) L,
+        ∑' m : dualLattice L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
     simpa [g, A] using poissonSummation_lattice_rhs (L := L) f v
   simpa [hlhs, hrhs] using
     poissonSummation_standard
-      (d := d) (f := g) (v := A.symm v)
+      (f := g) (v := A.symm v)
 
 end SchwartzMap.PoissonSummationLattices

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -717,13 +717,26 @@ section PoissonSummationLattices
 
 variable (L : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology L] [IsZLattice ℝ L]
 
-/-- The adjoint of `(latticeEquiv L)⁻¹`; it carries the standard lattice onto the dual lattice
-`L*`, and is the engine of the change of variables on the spectral side of Poisson summation. -/
-noncomputable def Bₗ : E →ₗ[ℝ] E := (latticeEquiv L).symm.toLinearMap.adjoint
+/-- The **dual change of variables**: the inverse-adjoint `((latticeEquiv L).symm).adjoint` of
+`latticeEquiv L`, packaged as a linear automorphism of `E` with inverse `(latticeEquiv L).adjoint`.
+It carries the standard lattice `ℤ^d` onto the dual lattice `L*`
+(`map_standardLattice_dualEquiv_eq`), so its `tsum_eq` reindexes the spectral side of Poisson
+summation. Kept as a named definition: it is the spectral-side counterpart of `latticeEquiv`. -/
+noncomputable def dualEquiv : E ≃ₗ[ℝ] E :=
+  LinearEquiv.ofLinear ((latticeEquiv L).symm.toLinearMap.adjoint)
+    ((latticeEquiv L).toLinearMap.adjoint)
+    (by simp [← LinearMap.adjoint_comp,
+      show (latticeEquiv L).toLinearMap ∘ₗ (latticeEquiv L).symm.toLinearMap = LinearMap.id from by
+        ext x; simp])
+    (by simp [← LinearMap.adjoint_comp,
+      show (latticeEquiv L).symm.toLinearMap ∘ₗ (latticeEquiv L).toLinearMap = LinearMap.id from by
+        ext x; simp])
 
-/-- The adjoint of `latticeEquiv L`. Kept as a named definition: it is the two-sided inverse of
-`Bₗ L`, supplying `adjointSymmEquiv` with its inverse map. -/
-noncomputable def Aadjₗ : E →ₗ[ℝ] E := (latticeEquiv L).toLinearMap.adjoint
+lemma dualEquiv_apply (x : E) :
+    dualEquiv L x = (latticeEquiv L).symm.toLinearMap.adjoint x := rfl
+
+lemma dualEquiv_symm_apply (x : E) :
+    (dualEquiv L).symm x = (latticeEquiv L).toLinearMap.adjoint x := rfl
 
 /-- `latticeEquiv L` restricted to a `ℤ`-linear equivalence from the standard lattice `ℤ^d` onto
 `L`. Kept as a named definition: it transports lattice sums between `ℤ^d` and `L`. -/
@@ -735,44 +748,29 @@ noncomputable def equivStandardLattice : SchwartzMap.standardLattice d ≃ₗ[�
     ((equivStandardLattice (d := d) L x : L) : E) = (latticeEquiv L) x := by
   simp [equivStandardLattice]
 
-lemma Bₗ_comp_Aadjₗ : Bₗ L ∘ₗ Aadjₗ L = (LinearMap.id : E →ₗ[ℝ] E) := by
-  simp [Bₗ, Aadjₗ, ← LinearMap.adjoint_comp,
-    show (latticeEquiv L).toLinearMap ∘ₗ (latticeEquiv L).symm.toLinearMap = LinearMap.id from by
-      ext x; simp]
-
-lemma Aadjₗ_comp_Bₗ : Aadjₗ L ∘ₗ Bₗ L = (LinearMap.id : E →ₗ[ℝ] E) := by
-  simp [Bₗ, Aadjₗ, ← LinearMap.adjoint_comp,
-    show (latticeEquiv L).symm.toLinearMap ∘ₗ (latticeEquiv L).toLinearMap = LinearMap.id from by
-      ext x; simp]
-
-/-- `Bₗ L` as a linear automorphism of `E`, with inverse `Aadjₗ L`. Kept as a named definition: it
-realizes the standard-lattice-to-dual-lattice transport as an equivalence, so its `tsum_eq`
-reindexes the spectral sum. -/
-noncomputable def adjointSymmEquiv : E ≃ₗ[ℝ] E where
-  toLinearMap := Bₗ L
-  invFun := Aadjₗ L
-  left_inv x := by simpa using DFunLike.congr_fun (Aadjₗ_comp_Bₗ L) x
-  right_inv x := by simpa using DFunLike.congr_fun (Bₗ_comp_Aadjₗ L) x
-
-lemma map_standardLattice_adjointSymm_eq_dualSubmodule :
-    Submodule.map ((Bₗ L).restrictScalars ℤ) (standardLattice d) = dualLattice (d := d) L := by
+/-- The dual change of variables `dualEquiv L` carries the standard lattice `ℤ^d` onto the dual
+lattice `L*`. This is what lets `dualEquiv L` reindex the spectral sum over `L*`. -/
+lemma map_standardLattice_dualEquiv_eq :
+    Submodule.map ((dualEquiv L).toLinearMap.restrictScalars ℤ) (standardLattice d) =
+      dualLattice (d := d) L := by
   have hmapL : Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
       (standardLattice d) = L := map_standardLattice_eq (d := d) L
   have hdualStd : dualLattice (d := d) (standardLattice d) = standardLattice d := by
     simpa [dualLattice] using PoissonSummation.Standard.dualSubmodule_standardLattice_eq (d := d)
-  have hBA (y w : E) : inner ℝ ((Bₗ L) y) ((latticeEquiv L) w) = inner ℝ y w := by
-    simpa [Bₗ] using LinearMap.adjoint_inner_left ((latticeEquiv L).symm.toLinearMap)
+  have hBA (y w : E) : inner ℝ (dualEquiv L y) ((latticeEquiv L) w) = inner ℝ y w := by
+    simpa [dualEquiv_apply] using LinearMap.adjoint_inner_left ((latticeEquiv L).symm.toLinearMap)
       ((latticeEquiv L) w) y
-  have hAadj (p w : E) : inner ℝ ((Aadjₗ L) p) w = inner ℝ p ((latticeEquiv L) w) := by
-    simpa [Aadjₗ] using LinearMap.adjoint_inner_left ((latticeEquiv L).toLinearMap) w p
+  have hAadj (p w : E) : inner ℝ ((dualEquiv L).symm p) w = inner ℝ p ((latticeEquiv L) w) := by
+    simpa [dualEquiv_symm_apply] using
+      LinearMap.adjoint_inner_left ((latticeEquiv L).toLinearMap) w p
   ext x
-  refine ⟨?_, fun hx => ⟨(Aadjₗ L) x, ?_, ?_⟩⟩
+  refine ⟨?_, fun hx => ⟨(dualEquiv L).symm x, ?_, ?_⟩⟩
   · rintro ⟨y, hy, rfl⟩ z hz
     obtain ⟨w, hw, rfl⟩ : (z : E) ∈ Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
         (standardLattice d) := by rw [hmapL]; exact hz
     simpa [dualLattice, innerₗ_apply_apply, hBA] using
       (by simpa [hdualStd] using hy : y ∈ dualLattice (d := d) (standardLattice d)) w hw
-  · suffices hydual : (Aadjₗ L) x ∈ dualLattice (d := d) (standardLattice d) by
+  · suffices hydual : (dualEquiv L).symm x ∈ dualLattice (d := d) (standardLattice d) by
       simpa [hdualStd] using hydual
     intro w hw
     have hwL : (latticeEquiv L) w ∈ L := by
@@ -780,7 +778,7 @@ lemma map_standardLattice_adjointSymm_eq_dualSubmodule :
         ((latticeEquiv L).toLinearMap.restrictScalars ℤ) (standardLattice d) := ⟨w, hw, rfl⟩
       rwa [hmapL] at hmem
     simpa [dualLattice, innerₗ_apply_apply, hAadj] using hx ((latticeEquiv L) w) hwL
-  · simpa using DFunLike.congr_fun (Bₗ_comp_Aadjₗ L) x
+  · simp
 
 /-- LHS rewrite for `poissonSummation_lattice`: pull back the lattice sum along `latticeEquiv`. -/
 private lemma poissonSummation_lattice_lhs (f : SchwartzMap E ℂ) (v : E) :
@@ -789,14 +787,15 @@ private lemma poissonSummation_lattice_lhs (f : SchwartzMap E ℂ) (v : E) :
   simpa [equivStandardLattice_apply] using
     (equivStandardLattice (d := d) L).toEquiv.tsum_eq (f := fun ℓ : L => f (v + (ℓ : E)))
 
-/-- Inner-product rewrite for exponentials: `⟪(latticeEquiv L).symm v, w⟫ = ⟪v, Bₗ L w⟫`. -/
+/-- Inner-product rewrite for exponentials: `⟪(latticeEquiv L).symm v, w⟫ = ⟪v, dualEquiv L w⟫`. -/
 private lemma poissonSummation_lattice_inner_swap (v w : E) :
-    ⟪(latticeEquiv L).symm v, w⟫_[ℝ] = ⟪v, (Bₗ L) w⟫_[ℝ] := by
+    ⟪(latticeEquiv L).symm v, w⟫_[ℝ] = ⟪v, dualEquiv L w⟫_[ℝ] := by
   simp only [← RCLike.inner_eq_wInner_one]
-  simpa [Bₗ] using (LinearMap.adjoint_inner_right ((latticeEquiv L).symm.toLinearMap) v w).symm
+  simpa [dualEquiv_apply] using
+    (LinearMap.adjoint_inner_right ((latticeEquiv L).symm.toLinearMap) v w).symm
 
 /-- RHS rewrite for `poissonSummation_lattice`: descend the standard-lattice dual sum
-to the dual lattice `L*` along `Bₗ = (latticeEquiv L).symm.adjoint`. -/
+to the dual lattice `L*` along `dualEquiv = (latticeEquiv L).symm.adjoint`. -/
 private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
     (∑' n : Fin d → ℤ,
         (𝓕 (fun x : E => f ((latticeEquiv L) x))
@@ -814,21 +813,21 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
   let cC : ℂ := ((abs detA)⁻¹ : ℝ)
   let iv : (Fin d → ℤ) → E := intVec (d := d)
   have hfourier (w : E) : 𝓕 (fun x : E => f ((latticeEquiv L) x)) w =
-      cC * 𝓕 (fun x : E => f x) ((Bₗ L) w) := by
-    simpa [Bₗ, detA, cC, Complex.real_smul] using
+      cC * 𝓕 (fun x : E => f x) (dualEquiv L w) := by
+    simpa [dualEquiv_apply, detA, cC, Complex.real_smul] using
       SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv
         (A := latticeEquiv L) (f := fun x : E => f x) w
   have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (iv n)) *
         Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, iv n⟫_[ℝ])) =
       cC * ∑' m : dualLattice (d := d) L, F m := by
     rw [← (PoissonSummation.Standard.equivIntVec.trans
-      ((LinearEquiv.restrictScalars ℤ (adjointSymmEquiv L)).ofSubmodules _ _ <| by
+      ((LinearEquiv.restrictScalars ℤ (dualEquiv L)).ofSubmodules _ _ <| by
           simpa [LinearEquiv.restrictScalars_apply] using
-            map_standardLattice_adjointSymm_eq_dualSubmodule (d := d) (L := L)).toEquiv).tsum_eq
+            map_standardLattice_dualEquiv_eq (d := d) (L := L)).toEquiv).tsum_eq
       (f := F), ← tsum_mul_left]
     exact tsum_congr fun n ↦ by
       simpa [F, mul_assoc, poissonSummation_lattice_inner_swap (L := L) v (w := iv n)] using
-        congrArg (· * Complex.exp (2 * π * Complex.I * ⟪v, (Bₗ L) (iv n)⟫_[ℝ]))
+        congrArg (· * Complex.exp (2 * π * Complex.I * ⟪v, dualEquiv L (iv n)⟫_[ℝ]))
           (hfourier (w := iv n))
   rw [hreindex]
   simp [F, cC, show ZLattice.covolume L = abs detA from by

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -6,6 +6,7 @@ Authors: Auguste Poiroux
 module
 public import Mathlib
 public import SpherePacking.ForMathlib.FourierComp
+public import SpherePacking.ForMathlib.SchwartzLatticeSummable
 public import SpherePacking.ForMathlib.UnitAddTorusQuotient
 
 /-! # Poisson summation for Schwartz functions
@@ -209,61 +210,18 @@ public instance instVAddInvariantMeasure_standardLattice :
   measure_preimage_vadd _ _ _ := by
     simp [Submodule.vadd_def, vadd_eq_add, MeasureTheory.measure_preimage_add]
 
-/-- Translate the Schwartz function `f` by a lattice vector, as a continuous map. Kept as a named
-map: it carries the `ContinuousMap` structure used to take sup-norms over compacts and to assemble
-`periodization` as a `tsum` of continuous maps. -/
-@[expose] public noncomputable def translate (ℓ : Λ) : C(E, ℂ) :=
-  (f : C(E, ℂ)).comp (ContinuousMap.addRight (ℓ : E))
+/-- Translate the Schwartz function `f` by a lattice vector, as a continuous map. This `Λ`-indexed
+specialization of `SchwartzMap.translateCM` is what assembles `periodization` as a `tsum` of
+continuous maps. -/
+@[expose] public noncomputable def translate (ℓ : Λ) : C(E, ℂ) := f.translateCM (ℓ : E)
 
 @[simp] public lemma translate_apply (ℓ : Λ) (x : E) :
     translate f ℓ x = f (x + (ℓ : E)) := rfl
 
-/-- Only finitely many standard lattice points lie in a closed ball of radius `r`. -/
-public lemma finite_norm_le_lattice (r : ℝ) :
-    ({ℓ : Λ | ‖(ℓ : E)‖ ≤ r} : Set _).Finite := by
-  have : DiscreteTopology (Λ).toAddSubgroup := inferInstanceAs (DiscreteTopology Λ)
-  have hfin : (Metric.closedBall (0 : E) r ∩ ((Λ).toAddSubgroup : Set E)).Finite :=
-    Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
-      Metric.isBounded_closedBall AddSubgroup.isClosed_of_discrete
-  refine .of_finite_image (hfin.subset ?_) Subtype.coe_injective.injOn
-  rintro _ ⟨ℓ, hℓ, rfl⟩
-  exact ⟨by simpa [Metric.mem_closedBall, dist_eq_norm] using hℓ, ℓ.2⟩
-
-private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x ℓ : G} {r : ℝ}
-    (hx : ‖x‖ ≤ r) (hℓ : 2 * r < ‖ℓ‖) : 1 / 2 * ‖ℓ‖ ≤ ‖x + ℓ‖ := by
-  have h : ‖ℓ‖ - ‖x‖ ≤ ‖x + ℓ‖ := by simpa [add_comm] using norm_sub_norm_le ℓ (-x)
-  linarith
-
 /-- Schwartz decay: sup norms of translates restricted to a compact `K` are summable. -/
 public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) :
-    Summable (fun ℓ : Λ => ‖(translate f ℓ).restrict K‖) := by
-  -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable over `Λ`.
-  let k : ℕ := Module.finrank ℤ Λ + 1
-  obtain ⟨C, hCpos, hC⟩ := f.decay k 0
-  simp_rw [norm_iteratedFDeriv_zero] at hC
-  obtain ⟨r, hrK⟩ := K.isCompact.isBounded.subset_closedBall (0 : E)
-  have hsum : Summable fun ℓ : Λ => ‖(ℓ : E)‖⁻¹ ^ k := by
-    simpa [k] using ZLattice.summable_norm_pow_inv (L := Λ) k (Nat.lt_succ_self _)
-  refine (hsum.mul_left (C * 2 ^ k)).of_norm_bounded_eventually ?_
-  filter_upwards [(finite_norm_le_lattice (max (2 * r) 1)).eventually_cofinite_notMem]
-    with ℓ hℓ
-  have hRlt : max (2 * r) 1 < ‖(ℓ : E)‖ := lt_of_not_ge (by simpa using hℓ)
-  have hnorm_pos : 0 < ‖(ℓ : E)‖ := one_pos.trans_le ((le_max_right _ _).trans hRlt.le)
-  rw [norm_norm]
-  refine (ContinuousMap.norm_le _ (by positivity)).2 fun ⟨x, hxK⟩ => ?_
-  have hxr : ‖x‖ ≤ r := by simpa using hrK hxK
-  have hge : 1 / 2 * ‖(ℓ : E)‖ ≤ ‖x + (ℓ : E)‖ :=
-    half_norm_le_norm_add hxr ((le_max_left _ _).trans_lt hRlt)
-  have hpos : 0 < ‖x + (ℓ : E)‖ := (by positivity : (0 : ℝ) < 1 / 2 * ‖(ℓ : E)‖).trans_le hge
-  have hinv : ‖x + (ℓ : E)‖⁻¹ ≤ 2 * ‖(ℓ : E)‖⁻¹ := by
-    have h := inv_anti₀ (by positivity) hge
-    rwa [mul_inv, one_div, inv_inv] at h
-  calc ‖(translate f ℓ) (⟨x, hxK⟩ : K)‖
-      = ‖f (x + (ℓ : E))‖ := rfl
-    _ ≤ C / ‖x + (ℓ : E)‖ ^ k := (le_div_iff₀' (pow_pos hpos k)).2 (hC _)
-    _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
-    _ ≤ C * (2 * ‖(ℓ : E)‖⁻¹) ^ k := by gcongr
-    _ = C * 2 ^ k * ‖(ℓ : E)‖⁻¹ ^ k := by rw [mul_pow, mul_assoc]
+    Summable (fun ℓ : Λ => ‖(translate f ℓ).restrict K‖) :=
+  f.summable_norm_translateCM_restrict (SchwartzMap.standardLattice d) K
 
 /-- The quotient map `coeFunE`, bundled as a continuous map. This packaging is what the
 `IsQuotientMap.lift`/`FactorsThrough` API consumes when descending periodic maps to the torus. -/
@@ -523,23 +481,13 @@ lemma mFourierCoeff_descended (n : Fin d → ℤ) :
   simp [Real.fourier_eq, Circle.smul_def, smul_eq_mul,
     mFourier_neg_apply_coeFunE (n := n)]
 
-/-- Schwartz–Fourier decay over the lattice: `𝓕 f` is summable in norm over `Λ = ℤ^d`. The decay
-order `d + 1` exceeds the lattice rank, so `‖·‖⁻¹ ^ (d + 1)` is summable and dominates `𝓕 f`. -/
+/-- Schwartz–Fourier decay over the lattice: `𝓕 f` is summable in norm over `Λ = ℤ^d`, since `𝓕 f`
+is again a Schwartz function (`SchwartzMap.summable_norm_comp_add`). -/
 lemma summable_norm_fourier_lattice :
     Summable (fun ℓ : Λ => ‖𝓕 (fun y : E => f y) (ℓ : E)‖) := by
-  have hrank : Module.finrank ℤ Λ = d := by
-    simpa using (ZLattice.rank (K := ℝ) (L := Λ)).trans (by simp)
-  have hk : Module.finrank ℤ Λ < d + 1 := by omega
-  obtain ⟨C, _, hC⟩ := (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).decay (d + 1) 0
-  have hC' : ∀ x : E, ‖x‖ ^ (d + 1) * ‖𝓕 (fun y : E => f y) x‖ ≤ C := by
-    simpa [FourierTransform.fourierCLE_apply, fourier_coe, norm_iteratedFDeriv_zero] using hC
-  refine Summable.of_norm_bounded_eventually
-    ((by simpa using ZLattice.summable_norm_pow_inv (L := Λ) (n := d + 1) hk :
-      Summable (fun ℓ : Λ => (‖(ℓ : E)‖⁻¹ ^ (d + 1) : ℝ))).mul_left C) ?_
-  filter_upwards [(finite_norm_le_lattice 1).compl_mem_cofinite] with ℓ hℓ
-  simpa [Real.norm_of_nonneg (norm_nonneg _), div_eq_mul_inv, inv_pow, one_div] using
-    (le_div_iff₀' (pow_pos (lt_trans (by positivity)
-      (lt_of_not_ge (by simpa using hℓ) : (1 : ℝ) < ‖(ℓ : E)‖)) _)).2 (hC' (ℓ : E))
+  simpa [FourierTransform.fourierCLE_apply, fourier_coe] using
+    (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).summable_norm_comp_add
+      (SchwartzMap.standardLattice d) 0
 
 /-- The Fourier-decay summability of `summable_norm_fourier_lattice`, reindexed over `ℤ^d` along
 `equivIntVec`. -/

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -217,10 +217,11 @@ public instance instVAddInvariantMeasure_standardLattice :
   measure_preimage_vadd _ _ _ := by
     simp [Submodule.vadd_def, vadd_eq_add, MeasureTheory.measure_preimage_add]
 
-/-- Translate the Schwartz function `f` by a lattice vector, as a continuous map. This `Λ`-indexed
-specialization of `SchwartzMap.translateCM` is what assembles `periodization` as a `tsum` of
+/-- Translate the Schwartz function `f` by a lattice vector, as the continuous map
+`x ↦ f (x + ℓ)`. This `Λ`-indexed family is what assembles `periodization` as a `tsum` of
 continuous maps. -/
-@[expose] public noncomputable def translate (ℓ : Λ) : C(E, ℂ) := f.translateCM (ℓ : E)
+@[expose] public noncomputable def translate (ℓ : Λ) : C(E, ℂ) :=
+  (f : C(E, ℂ)).comp (ContinuousMap.addRight (ℓ : E))
 
 @[simp] public lemma translate_apply (ℓ : Λ) (x : E) :
     translate f ℓ x = f (x + (ℓ : E)) := rfl
@@ -228,7 +229,7 @@ continuous maps. -/
 /-- Schwartz decay: sup norms of translates restricted to a compact `K` are summable. -/
 public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) :
     Summable (fun ℓ : Λ => ‖(translate f ℓ).restrict K‖) :=
-  f.summable_norm_translateCM_restrict (SchwartzMap.standardLattice d) K
+  f.summable_norm_restrict_comp_addRight (SchwartzMap.standardLattice d) K
 
 /-- The quotient map `coeFunE`, bundled as a continuous map. This packaging is what the
 `IsQuotientMap.lift`/`FactorsThrough` API consumes when descending periodic maps to the torus. -/
@@ -293,7 +294,7 @@ public lemma mFourier_neg_apply_coeFunE (n : Fin d → ℤ) (x : E) :
   have hinner : inner ℝ x (intVec n) = ∑ i, (n i : ℝ) * (x.ofLp i : ℝ) := by
     simp [intVec, PiLp.inner_apply]
   rw [hinner]
-  simp [coeFunE, UnitAddTorus.mFourier_apply_coeFun_ofLp, Real.fourierChar_apply,
+  simp [coeFunE, UnitAddTorus.mFourier_apply_coeFun, Real.fourierChar_apply,
     Finset.sum_neg_distrib, mul_assoc, mul_comm]
 
 public lemma mFourier_apply_coeFunE_exp (n : Fin d → ℤ) (x : E) :

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -6,6 +6,7 @@ Authors: Auguste Poiroux
 module
 public import Mathlib
 public import SpherePacking.ForMathlib.FourierComp
+public import SpherePacking.ForMathlib.UnitAddTorusQuotient
 
 /-! # Poisson summation for Schwartz functions
 
@@ -19,49 +20,6 @@ Three layers:
 
 open scoped BigOperators FourierTransform Real
 open MeasureTheory
-
-namespace SchwartzMap.UnitAddTorus
-
-/-- The coordinatewise quotient map `(Fin n → ℝ) → (ℝ/ℤ)^n`. Kept as a named definition: it is the
-fundamental projection presenting the torus as a quotient of `ℝ^n`, with its own continuity, open-
-quotient, and integral-pullback API. -/
-public def coeFun (n : ℕ) : (Fin n → ℝ) → UnitAddTorus (Fin n) :=
-  fun x i => (x i : UnitAddCircle)
-
-/-- The coordinatewise quotient map `coeFun` is continuous. -/
-@[continuity, fun_prop]
-public theorem continuous_coeFun {n : ℕ} : Continuous (coeFun n) :=
-  continuous_pi fun i => (AddCircle.continuous_mk' 1).comp (continuous_apply i)
-
-/-- `coeFun` is an open quotient map, so it presents `(ℝ/ℤ)^n` as a quotient of `ℝ^n`. -/
-public theorem isOpenQuotientMap_coeFun (n : ℕ) : IsOpenQuotientMap (coeFun n) :=
-  .piMap fun _ ↦ QuotientAddGroup.isOpenQuotientMap_mk
-
-/-- Evaluate the additive character `mFourier k` on a point `x : ℝ^n` viewed in the torus
-via `coeFun`. -/
-public theorem mFourier_apply_coeFun_ofLp (n : ℕ) (k : Fin n → ℤ) (x : EuclideanSpace ℝ (Fin n)) :
-    UnitAddTorus.mFourier k (coeFun n (WithLp.ofLp x)) =
-      Complex.exp (2 * π * Complex.I * (∑ i : Fin n, (k i : ℝ) * x i)) := by
-  simp [UnitAddTorus.mFourier, coeFun, ← Complex.exp_sum, Finset.mul_sum, mul_assoc]
-
-/-- Pull back Haar integration on `(ℝ/ℤ)^n` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^n`. -/
-public theorem integral_eq_integral_preimage_coeFun (n : ℕ) (t : ℝ) (g : UnitAddTorus (Fin n) → ℂ)
-    (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus (Fin n)))) :
-    (∫ y : UnitAddTorus (Fin n), g y) =
-      ∫ x, g (coeFun n x) ∂(volume : Measure (Fin n → ℝ)).restrict
-        (Set.univ.pi fun _ : Fin n => Set.Ioc t (t + 1)) := by
-  have hmp : MeasurePreserving (coeFun n)
-      (Measure.pi fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)))
-      (volume : Measure (UnitAddTorus (Fin n))) :=
-    measurePreserving_pi _ _ fun _ => UnitAddCircle.measurePreserving_mk t
-  have hrestrict : (volume : Measure (Fin n → ℝ)).restrict
-        (Set.univ.pi fun _ : Fin n => Set.Ioc t (t + 1)) =
-      Measure.pi fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)) :=
-    Measure.restrict_pi_pi _ _
-  rw [hrestrict, ← hmp.map_eq]
-  exact integral_map hmp.aemeasurable (hmp.map_eq.symm ▸ hg)
-
-end SchwartzMap.UnitAddTorus
 
 namespace SchwartzMap
 
@@ -153,7 +111,7 @@ public lemma dualSubmodule_standardLattice_eq :
 a named definition: it is the quotient map through which the periodization descends to the torus,
 with its own continuity and open-quotient API. -/
 @[expose] public def coeFunE : E → UnitAddTorus (Fin d) :=
-  fun x ↦ UnitAddTorus.coeFun d (WithLp.ofLp x)
+  fun x ↦ UnitAddTorus.coeFun (Fin d) (WithLp.ofLp x)
 
 /-- Continuity of the quotient map `coeFunE`. -/
 @[continuity] public theorem continuous_coeFunE : Continuous (coeFunE (d := d)) :=
@@ -162,7 +120,7 @@ with its own continuity and open-quotient API. -/
 /-- `coeFunE` is invariant under translation by integer vectors. -/
 @[simp] public theorem coeFunE_add_intVec (x : E) (n : Fin d → ℤ) :
     coeFunE (x + intVec n) = coeFunE x := by
-  ext i; simp [coeFunE, UnitAddTorus.coeFun]
+  ext i; simp [coeFunE]
 
 /-- If two points map to the same torus point, their difference is an integer vector. -/
 public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
@@ -170,7 +128,7 @@ public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
     ∃ n : Fin d → ℤ, x - y = intVec n := by
   have key (i : Fin d) : ∃ n : ℤ, (n : ℝ) = x i - y i := by
     have h0 : ((x i - y i : ℝ) : UnitAddCircle) = 0 := by
-      simpa [UnitAddCircle, AddCircle.coe_sub, coeFunE, UnitAddTorus.coeFun] using
+      simpa [UnitAddCircle, AddCircle.coe_sub, coeFunE] using
         sub_eq_zero.2 (congrFun h i)
     obtain ⟨n, hn⟩ := (AddCircle.coe_eq_zero_iff (p := (1 : ℝ))).1 h0
     exact ⟨n, by simpa using hn⟩
@@ -210,13 +168,13 @@ public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) �
     ext x; simp [f, iocCube]
   calc
     (∫ y : UnitAddTorus (Fin d), g y)
-        = ∫ x, g (UnitAddTorus.coeFun d x) ∂(volume : Measure (Fin d → ℝ)).restrict
+        = ∫ x, g (UnitAddTorus.coeFun (Fin d) x) ∂(volume : Measure (Fin d → ℝ)).restrict
             (Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1) := by
-          simpa using UnitAddTorus.integral_eq_integral_preimage_coeFun d 0 g hg
+          simpa using UnitAddTorus.integral_eq_integral_preimage_coeFun (ι := Fin d) 0 g hg
     _ = ∫ y, g (coeFunE y) ∂(volume : Measure E).restrict (iocCube) := by
           simpa [hpre, coeFunE] using
             (hmp.restrict_preimage (measurableSet_iocCube)).integral_comp'
-              (g := fun y : E ↦ g (UnitAddTorus.coeFun d (WithLp.ofLp y)))
+              (g := fun y : E ↦ g (UnitAddTorus.coeFun (Fin d) (WithLp.ofLp y)))
 
 end SchwartzMap.PoissonSummation.Standard
 
@@ -346,7 +304,7 @@ end Periodization
 
 /-- The quotient map `coeFunE : E → (ℝ/ℤ)^d` presents the torus as an open quotient of `E`. -/
 public theorem isOpenQuotientMap_coeFunE : IsOpenQuotientMap (coeFunE (d := d)) := by
-  simpa [coeFunE] using (UnitAddTorus.isOpenQuotientMap_coeFun d).comp
+  simpa [coeFunE] using (UnitAddTorus.isOpenQuotientMap_coeFun (Fin d)).comp
     (PiLp.homeomorph (p := (2 : ENNReal)) (β := fun _ : Fin d ↦ ℝ)).isOpenQuotientMap
 
 /-- Descend the periodization to a continuous function on the torus `(ℝ/ℤ)^d`. This bridges to the

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -4,7 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib
+public import Mathlib.Algebra.Module.ZLattice.Covolume
+public import Mathlib.Algebra.Module.ZLattice.Summable
+public import Mathlib.Analysis.CStarAlgebra.Classes
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import Mathlib.Analysis.Fourier.AddCircleMulti
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
+public import Mathlib.Analysis.RCLike.Inner
+public import Mathlib.Data.Real.Hom
+public import Mathlib.Data.Real.StarOrdered
+public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
+public import Mathlib.Topology.Separation.CompletelyRegular
 
 /-! # Poisson summation for Schwartz functions
 

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -486,6 +486,24 @@ lemma summable_integral_norm_mFourier_mul_translate_iocCube (n : Fin d → ℤ) 
     _ = μ.real Set.univ * ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
         rw [integral_const, smul_eq_mul]
 
+/-- The ambient `volume` on `UnitAddCircle` is the probability measure `haarAddCircle` baked into
+`UnitAddTorus.mFourierCoeff`: both come from `AddCircle 1`, whose total measure is `1`. -/
+private lemma volume_unitAddCircle_eq_haar :
+    (volume : Measure UnitAddCircle) = AddCircle.haarAddCircle (T := 1) := by
+  simp [UnitAddCircle, AddCircle.volume_eq_smul_haarAddCircle]
+
+/-- `UnitAddTorus.mFourierCoeff g n` as an integral against the file's ambient `volume` on the
+torus. `mFourierCoeff` is defined using `haarAddCircle`; this bridges the resulting measure-space
+diamond to the ambient `volume`, which agrees by `volume_unitAddCircle_eq_haar`. -/
+private lemma mFourierCoeff_eq_integral_volume (n : Fin d → ℤ) (g : UnitAddTorus (Fin d) → ℂ) :
+    UnitAddTorus.mFourierCoeff g n =
+      ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • g y := by
+  have hvol : (@volume (UnitAddTorus (Fin d))
+        (@MeasureSpace.pi (Fin d) (Fin.fintype d) (fun _ => UnitAddCircle)
+          (fun _ => instMeasureSpaceUnitAddCircle))) = volume :=
+    congrArg Measure.pi (funext fun _ => volume_unitAddCircle_eq_haar.symm)
+  simp [UnitAddTorus.mFourierCoeff, smul_eq_mul, hvol]
+
 /-- The `n`-th torus Fourier coefficient of `descended f` is the integral over the unit cube
 of `mFourier(-n)(coeFunE x)` times the periodization `∑' ℓ, f (x + ℓ)`. -/
 private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
@@ -502,18 +520,8 @@ private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
         (descended (d := d) f).continuous).aestronglyMeasurable
   calc
     UnitAddTorus.mFourierCoeff (descended (d := d) f) n
-        = ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended (d := d) f y := by
-            have hvol : (@volume (UnitAddTorus (Fin d))
-                  (@MeasureSpace.pi (Fin d) (Fin.fintype d) (fun _ => UnitAddCircle)
-                    (fun _ => instMeasureSpaceUnitAddCircle))) =
-                @volume (UnitAddTorus (Fin d))
-                  (@MeasureSpace.pi (Fin d) (Fin.fintype d) (fun _ => UnitAddCircle)
-                    (fun _ => AddCircle.measureSpace (1 : ℝ))) :=
-              congrArg Measure.pi (funext fun _ => by
-                change (AddCircle.haarAddCircle (T := (1 : ℝ)) : Measure UnitAddCircle) =
-                  @volume UnitAddCircle (AddCircle.measureSpace (1 : ℝ))
-                simp [UnitAddCircle, AddCircle.volume_eq_smul_haarAddCircle])
-            simp [UnitAddTorus.mFourierCoeff, smul_eq_mul, hvol]
+        = ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended (d := d) f y :=
+          mFourierCoeff_eq_integral_volume (d := d) n (descended (d := d) f)
     _ = ∫ x in iocCube (d := d),
           UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) •
             descended (d := d) f (coeFunE (d := d) x)

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -4,17 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib.Algebra.Module.ZLattice.Covolume
-public import Mathlib.Algebra.Module.ZLattice.Summable
-public import Mathlib.Analysis.CStarAlgebra.Classes
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
-public import Mathlib.Analysis.Fourier.AddCircleMulti
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
-public import Mathlib.Analysis.RCLike.Inner
-public import Mathlib.Data.Real.Hom
-public import Mathlib.Data.Real.StarOrdered
-public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
-public import Mathlib.Topology.Separation.CompletelyRegular
+public import Mathlib
 
 /-! # Poisson summation for Schwartz functions
 

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Auguste Poiroux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Auguste Poiroux
+-/
 module
 public import Mathlib.Algebra.Module.Submodule.Equiv
 public import Mathlib.Algebra.Module.Submodule.Map

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -4,30 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib.Algebra.Module.Submodule.Equiv
-public import Mathlib.Algebra.Module.Submodule.Map
-public import Mathlib.Algebra.Module.ZLattice.Covolume
-public import Mathlib.Algebra.Module.ZLattice.Summable
-public import Mathlib.Analysis.Complex.Exponential
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
-public import Mathlib.Analysis.Fourier.AddCircleMulti
-public import Mathlib.Analysis.Fourier.FourierTransform
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
-public import Mathlib.Analysis.InnerProductSpace.PiL2
-public import Mathlib.Analysis.RCLike.Inner
-public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
-public import Mathlib.MeasureTheory.Constructions.Pi
-public import Mathlib.MeasureTheory.Group.FundamentalDomain
-public import Mathlib.MeasureTheory.Integral.Bochner.Basic
-public import Mathlib.MeasureTheory.Integral.Pi
-public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
-public import Mathlib.Topology.Algebra.Group.Quotient
-public import Mathlib.Topology.Algebra.InfiniteSum.Ring
-public import Mathlib.Topology.ContinuousMap.Compact
-public import Mathlib.Topology.MetricSpace.Bounded
-import Mathlib.Analysis.Normed.Operator.Banach
-import Mathlib.LinearAlgebra.Determinant
-import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+public import Mathlib
 
 /-! # Poisson summation for Schwartz functions
 
@@ -53,81 +30,49 @@ public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w
     𝓕 (fun x ↦ f (A x)) w =
       (abs (LinearMap.det (A : V →ₗ[ℝ] V)))⁻¹ •
         𝓕 f (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) := by
-  simp only [Real.fourier_eq]
-  let g : V → ℂ := fun y ↦ Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y
-  let e : V ≃ᵐ V := A.toContinuousLinearEquiv.toHomeomorph.toMeasurableEquiv
-  calc (∫ x : V, Real.fourierChar (-(inner ℝ x w)) • f (A x)) =
-        ∫ y : V, g y ∂Measure.map (⇑A) (volume : Measure V) := by
-          simpa [g, e] using (MeasureTheory.integral_map_equiv (μ := (volume : Measure V)) e g).symm
-    _ = (abs (LinearMap.det (A : V →ₗ[ℝ] V)))⁻¹ • ∫ y : V, g y := by
-          rw [show Measure.map (⇑A) (volume : Measure V) =
-              ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹| • (volume : Measure V) by
-            simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar (μ := (volume : Measure V))
-              (LinearEquiv.isUnit_det' A).ne_zero, MeasureTheory.integral_smul_measure]
-          rw [show ((ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹|).toReal : ℝ) =
-            |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ by simp [abs_inv]]
-    _ = _ := by simp [g, show (fun y : V ↦ Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y) =
-                    fun y : V ↦
-                      Real.fourierChar (-(inner ℝ y
-                        (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w))) • f y by
-                  funext y; simp [LinearMap.adjoint_inner_right]]
+  have hmap : Measure.map (⇑A) (volume : Measure V) =
+      ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹| • (volume : Measure V) :=
+    Measure.map_linearMap_addHaar_eq_smul_addHaar volume (LinearEquiv.isUnit_det' A).ne_zero
+  have hinner (y : V) :
+      inner ℝ (A.symm y) w = inner ℝ y (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) :=
+    (LinearMap.adjoint_inner_right _ y w).symm
+  calc 𝓕 (fun x ↦ f (A x)) w
+      = ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y
+          ∂Measure.map (⇑A) (volume : Measure V) := by
+        simpa [Real.fourier_eq] using
+          (integral_map_equiv (μ := (volume : Measure V))
+            A.toContinuousLinearEquiv.toHomeomorph.toMeasurableEquiv
+            fun y ↦ Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y).symm
+    _ = |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ •
+          ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y := by
+        rw [hmap, integral_smul_measure, ENNReal.toReal_ofReal (abs_nonneg _), abs_inv]
+    _ = _ := by simp only [Real.fourier_eq, hinner]
 
 end SpherePacking.ForMathlib.Fourier
 
 namespace SchwartzMap.UnitAddTorus
 
-/-- The coordinatewise quotient map `(Fin n → ℝ) → (ℝ/ℤ)^n`. -/
-@[expose] public def coeFun (n : ℕ) : (Fin n → ℝ) → UnitAddTorus (Fin n) :=
+/-- The coordinatewise quotient map `(Fin n → ℝ) → (ℝ/ℤ)^n`. Kept as a named definition: it is the
+fundamental projection presenting the torus as a quotient of `ℝ^n`, with its own continuity, open-
+quotient, and integral-pullback API. -/
+public def coeFun (n : ℕ) : (Fin n → ℝ) → UnitAddTorus (Fin n) :=
   fun x i => (x i : UnitAddCircle)
 
-/-- Continuity of the coordinatewise quotient map `coeFun`. -/
-@[continuity]
-public theorem continuous_coeFun {n : ℕ} : Continuous (coeFun n) := by
-  simpa [coeFun, UnitAddCircle] using
-    (continuous_pi fun i => (AddCircle.continuous_mk' (p := (1 : ℝ))).comp (continuous_apply i))
-
-/-- A homeomorphism `α × (Fin n → α) ≃ (Fin (n+1) → α)`, specialized to constant families. -/
-def finSuccPiHomeomorph (α : Type*) [TopologicalSpace α] (n : ℕ) :
-    (α × (Fin n → α)) ≃ₜ (Fin n.succ → α) where
-  toEquiv := Fin.consEquiv (fun _ ↦ α)
-  continuous_toFun := by
-    simpa [Fin.consEquiv] using Continuous.finCons (by fun_prop) (by fun_prop)
-  continuous_invFun := by fun_prop
+/-- The coordinatewise quotient map `coeFun` is continuous. -/
+@[continuity, fun_prop]
+public theorem continuous_coeFun {n : ℕ} : Continuous (coeFun n) :=
+  continuous_pi fun i => (AddCircle.continuous_mk' 1).comp (continuous_apply i)
 
 /-- `coeFun` is an open quotient map, so it presents `(ℝ/ℤ)^n` as a quotient of `ℝ^n`. -/
-public theorem isOpenQuotientMap_coeFun (n : ℕ) : IsOpenQuotientMap (coeFun n) := by
-  induction n with
-  | zero =>
-      have h : coeFun 0 =
-          (Homeomorph.homeomorphOfUnique (Fin 0 → ℝ) (UnitAddTorus (Fin 0)) : _ → _) :=
-        funext fun _ => Subsingleton.elim _ _
-      simpa [h] using
-        (Homeomorph.homeomorphOfUnique (Fin 0 → ℝ) (UnitAddTorus (Fin 0))).isOpenQuotientMap
-  | succ n ih =>
-      have h₁ : IsOpenQuotientMap (fun x : ℝ => (x : UnitAddCircle)) := by
-        simpa using
-          (QuotientAddGroup.isOpenQuotientMap_mk (G := ℝ) (N := AddSubgroup.zmultiples (1 : ℝ)))
-      let eX := (finSuccPiHomeomorph (α := ℝ) n).symm
-      let eY := finSuccPiHomeomorph (α := UnitAddCircle) n
-      have hconj : coeFun n.succ =
-          (fun x => eY (Prod.map (fun x : ℝ => (x : UnitAddCircle)) (coeFun n) (eX x))) := by
-        funext x; ext i
-        cases i using Fin.cases with
-        | zero => simp [coeFun, eY, finSuccPiHomeomorph, eX, Prod.map]
-        | succ i => simp [coeFun, eY, finSuccPiHomeomorph, eX, Prod.map, Fin.tail]
-      simpa [hconj] using
-        (IsOpenQuotientMap.comp eY.isOpenQuotientMap
-          (IsOpenQuotientMap.comp (IsOpenQuotientMap.prodMap h₁ ih) eX.isOpenQuotientMap))
+public theorem isOpenQuotientMap_coeFun (n : ℕ) : IsOpenQuotientMap (coeFun n) :=
+  .piMap fun _ ↦ QuotientAddGroup.isOpenQuotientMap_mk
 
 /-- Evaluate the additive character `mFourier k` on a point `x : ℝ^n` viewed in the torus
 via `coeFun`. -/
 public theorem mFourier_apply_coeFun_ofLp (n : ℕ) (k : Fin n → ℤ) (x : EuclideanSpace ℝ (Fin n)) :
     UnitAddTorus.mFourier k (coeFun n (WithLp.ofLp x)) =
       Complex.exp (2 * π * Complex.I * (∑ i : Fin n, (k i : ℝ) * x i)) := by
-  simpa [UnitAddTorus.mFourier, ContinuousMap.coe_mk, coeFun, fourier_coe_apply, Finset.mul_sum,
-    mul_assoc, mul_left_comm, mul_comm] using
-    (Complex.exp_sum (s := (Finset.univ : Finset (Fin n)))
-        (f := fun i : Fin n => 2 * π * Complex.I * ((k i : ℝ) * (WithLp.ofLp x i)))).symm
+  simp [UnitAddTorus.mFourier, coeFun, ← Complex.exp_sum, Finset.mul_sum, mul_assoc]
 
 /-- Pull back Haar integration on `(ℝ/ℤ)^n` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^n`. -/
 public theorem integral_eq_integral_preimage_coeFun (n : ℕ) (t : ℝ) (g : UnitAddTorus (Fin n) → ℂ)
@@ -137,22 +82,14 @@ public theorem integral_eq_integral_preimage_coeFun (n : ℕ) (t : ℝ) (g : Uni
         (Set.univ.pi fun _ : Fin n => Set.Ioc t (t + 1)) := by
   have hmp : MeasurePreserving (coeFun n)
       (Measure.pi fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)))
-      (volume : Measure (UnitAddTorus (Fin n))) := by
-    simpa [coeFun] using
-      (MeasureTheory.measurePreserving_pi
-        (μ := fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)))
-        (ν := fun _ : Fin n => (volume : Measure UnitAddCircle))
-        (hf := fun _ => UnitAddCircle.measurePreserving_mk t))
-  have h1 : (∫ y : UnitAddTorus (Fin n), g y) =
-      ∫ x, g (coeFun n x) ∂(Measure.pi fun _ : Fin n =>
-        (volume : Measure ℝ).restrict (Set.Ioc t (t + 1))) := by
-    rw [← hmp.map_eq]
-    simpa using MeasureTheory.integral_map (hφ := hmp.aemeasurable) (f := g)
-      (hfm := by simpa [hmp.map_eq] using hg)
-  simpa [(by simpa using (Measure.restrict_pi_pi
-    (μ := fun _ : Fin n => (volume : Measure ℝ)) (s := fun _ : Fin n => Set.Ioc t (t + 1))) :
-    (volume : Measure (Fin n → ℝ)).restrict (Set.univ.pi fun _ : Fin n => Set.Ioc t (t + 1)) =
-    Measure.pi fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1))).symm] using h1
+      (volume : Measure (UnitAddTorus (Fin n))) :=
+    measurePreserving_pi _ _ fun _ => UnitAddCircle.measurePreserving_mk t
+  have hrestrict : (volume : Measure (Fin n → ℝ)).restrict
+        (Set.univ.pi fun _ : Fin n => Set.Ioc t (t + 1)) =
+      Measure.pi fun _ : Fin n => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)) :=
+    Measure.restrict_pi_pi _ _
+  rw [hrestrict, ← hmp.map_eq]
+  exact integral_map hmp.aemeasurable (hmp.map_eq.symm ▸ hg)
 
 end SchwartzMap.UnitAddTorus
 
@@ -165,18 +102,20 @@ local notation "E" => EuclideanSpace ℝ (Fin d)
 
 section StandardLattice
 
-/-- The standard `ℤ`-lattice in `E = ℝ^d`, i.e. the span of the standard basis over `ℤ`. -/
-@[expose] public noncomputable def standardLattice (d : ℕ) :
+/-- The standard `ℤ`-lattice in `E = ℝ^d`, i.e. the span of the standard basis over `ℤ`. Kept as a
+named definition: it is the base lattice to which every full-rank lattice is reduced, and the
+domain of all the periodization/descent machinery. -/
+@[expose] public def standardLattice (d : ℕ) :
     Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
   Submodule.span ℤ (Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis))
 
 namespace standardLattice
 
-public instance instDiscreteTopology : DiscreteTopology (standardLattice d) := by
-  unfold standardLattice; infer_instance
+public instance instDiscreteTopology : DiscreteTopology (standardLattice d) :=
+  inferInstanceAs <| DiscreteTopology (Submodule.span ℤ (Set.range _))
 
-public instance instIsZLattice : IsZLattice ℝ (standardLattice d) := by
-  unfold standardLattice; infer_instance
+public instance instIsZLattice : IsZLattice ℝ (standardLattice d) :=
+  inferInstanceAs <| IsZLattice ℝ (Submodule.span ℤ (Set.range _))
 
 end StandardLattice.standardLattice
 
@@ -184,70 +123,74 @@ namespace PoissonSummation
 
 namespace Standard
 
-/-- Embed an integer vector `k : ℤ^d` into `E = ℝ^d`. -/
+/-- Embed an integer vector `k : ℤ^d` into `E = ℝ^d`. Kept as a named definition: it is the
+concrete parametrization of the standard lattice (`equivIntVec`) used pervasively to index lattice
+sums and Fourier coefficients. -/
 @[expose] public noncomputable def intVec (k : Fin d → ℤ) : E :=
-  WithLp.toLp (2 : ENNReal) (fun i : Fin d => (k i : ℝ))
+  WithLp.toLp 2 fun i ↦ (k i : ℝ)
 
+/-- The `i`-th coordinate of `intVec k` is `(k i : ℝ)`. -/
 @[simp] public lemma intVec_apply (k : Fin d → ℤ) (i : Fin d) :
-    intVec (d := d) k i = (k i : ℝ) := by simp [intVec]
+    intVec (d := d) k i = (k i : ℝ) := rfl
 
+@[simp] lemma intVec_neg (k : Fin d → ℤ) : intVec (d := d) (-k) = -intVec (d := d) k := by
+  ext i; simp [intVec_apply]
+
+/-- Every integer vector lies in the standard lattice. -/
 public lemma intVec_mem_standardLattice (k : Fin d → ℤ) :
-    intVec (d := d) k ∈ SchwartzMap.standardLattice d := by
-  rw [show intVec (d := d) k =
-      ∑ i : Fin d, (k i) • ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis i) by
-    ext j; simp [intVec, OrthonormalBasis.coe_toBasis, EuclideanSpace.basisFun_apply,
-      Pi.single_apply]]
-  exact Submodule.sum_mem _ fun i _ ↦ Submodule.smul_mem _ _ (Submodule.subset_span ⟨i, rfl⟩)
+    intVec (d := d) k ∈ SchwartzMap.standardLattice d :=
+  (Module.Basis.mem_span_iff_repr_mem ℤ _ _).2 fun i ↦ ⟨k i, rfl⟩
 
 open TopologicalSpace UnitAddTorus
 
-/-- The half-open cube `(0,1]^d`, used as a fundamental domain for the action of `ℤ^d` on `ℝ^d`. -/
-@[expose] public def iocCube : Set E := {x | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
+/-- The half-open cube `(0,1]^d`. Kept as a named definition: it is the explicit fundamental domain
+for `ℤ^d` (`isAddFundamentalDomain_iocCube`) over which every torus integral is unfolded. -/
+public def iocCube : Set E := {x | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
 
+/-- The half-open cube `(0,1]^d` is measurable. -/
 public lemma measurableSet_iocCube : MeasurableSet (iocCube (d := d)) := by
-  rw [show iocCube (d := d) = ⋂ i : Fin d, {x : E | x i ∈ Set.Ioc (0 : ℝ) 1} by
-    ext x; simp [iocCube]]
-  exact .iInter fun i ↦ ((PiLp.continuous_apply (p := (2 : ENNReal))
-    (β := fun _ : Fin d ↦ ℝ) i).measurable) measurableSet_Ioc
+  unfold iocCube
+  measurability
 
 /-- Every element of the standard lattice comes from an integer vector via `intVec`. -/
 public lemma exists_intVec_eq_of_mem_standardLattice (x : E)
     (hx : x ∈ SchwartzMap.standardLattice d) : ∃ n : Fin d → ℤ, x = intVec (d := d) n := by
-  choose n hn using (Module.Basis.mem_span_iff_repr_mem (R := ℤ)
-    (b := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) x).1
-    (by simpa [SchwartzMap.standardLattice, standardLattice] using hx)
-  exact ⟨n, by ext i; simpa [intVec_apply] using (hn i).symm⟩
+  choose n hn using ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis.mem_span_iff_repr_mem ℤ x).1 hx
+  exact ⟨n, PiLp.ext fun i => (hn i).symm⟩
 
 /-- The dual of the standard lattice (for the Euclidean inner product) is the standard lattice. -/
 public lemma dualSubmodule_standardLattice_eq :
     LinearMap.BilinForm.dualSubmodule (B := (innerₗ E : LinearMap.BilinForm ℝ E))
         (SchwartzMap.standardLattice d) = SchwartzMap.standardLattice d := by
   ext x
-  refine ⟨fun hx ↦ ?_, fun hx y hy ↦ ?_⟩
-  · choose n hn using show ∀ i : Fin d, ∃ n : ℤ, (n : ℝ) = x i from fun i ↦ by
-      rcases Submodule.mem_one.mp (show inner ℝ x (EuclideanSpace.basisFun (Fin d) ℝ i) ∈
-          (1 : Submodule ℤ ℝ) by
-        simpa [innerₗ_apply_apply] using hx _ (Submodule.subset_span ⟨i, by simp⟩)) with ⟨n, hn⟩
-      exact ⟨n, by simpa [-EuclideanSpace.basisFun_apply] using hn⟩
-    exact (show x = intVec (d := d) n by ext i; simp [intVec_apply, hn i]) ▸
-      intVec_mem_standardLattice (d := d) n
-  · rcases exists_intVec_eq_of_mem_standardLattice (d := d) x hx with ⟨n, rfl⟩
-    rcases exists_intVec_eq_of_mem_standardLattice (d := d) y hy with ⟨m, rfl⟩
-    exact Submodule.mem_one.mpr ⟨∑ i : Fin d, n i * m i, by
-      simp only [innerₗ_apply_apply, intVec, PiLp.inner_apply, map_sum, Int.cast_mul,
-        algebraMap_int_eq, eq_intCast]
-      refine Finset.sum_congr rfl fun i _ => ?_
-      rw [show inner ℝ ((n i : ℝ)) ((m i : ℝ)) = (n i : ℝ) * (m i : ℝ) from
-        (RCLike.inner_apply' (n i : ℝ) (m i : ℝ)).trans (by simp)]⟩
+  constructor
+  · intro hx
+    have hcoord : ∀ i : Fin d, ∃ n : ℤ, (n : ℝ) = x i := fun i ↦ by
+      have hmem : x i ∈ (1 : Submodule ℤ ℝ) := by
+        simpa [innerₗ_apply_apply, EuclideanSpace.inner_single_right] using
+          hx (EuclideanSpace.basisFun (Fin d) ℝ i) (Submodule.subset_span ⟨i, by simp⟩)
+      obtain ⟨n, hn⟩ := Submodule.mem_one.mp hmem
+      exact ⟨n, by simpa using hn⟩
+    choose n hn using hcoord
+    have hx_eq : x = intVec (d := d) n := by ext i; simp [hn i]
+    exact hx_eq ▸ intVec_mem_standardLattice (d := d) n
+  · intro hx y hy
+    obtain ⟨n, rfl⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) x hx
+    obtain ⟨m, rfl⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) y hy
+    exact Submodule.mem_one.mpr ⟨∑ i : Fin d, n i * m i,
+      by simp [innerₗ_apply_apply, PiLp.inner_apply, mul_comm]⟩
 
-/-- The quotient map `E = ℝ^d → (ℝ/ℤ)^d`. -/
+/-- The quotient map `E = ℝ^d → (ℝ/ℤ)^d` (the `EuclideanSpace`/`WithLp` form of `coeFun`). Kept as
+a named definition: it is the quotient map through which the periodization descends to the torus,
+with its own continuity and open-quotient API. -/
 @[expose] public def coeFunE : E → UnitAddTorus (Fin d) :=
-  fun x ↦ UnitAddTorus.coeFun d ((WithLp.ofLp : E → (Fin d → ℝ)) x)
+  fun x ↦ UnitAddTorus.coeFun d (WithLp.ofLp x)
 
-@[continuity] public theorem continuous_coeFunE : Continuous (coeFunE (d := d)) := by
-  simpa [coeFunE] using (UnitAddTorus.continuous_coeFun (n := d)).comp
-    (PiLp.continuous_ofLp (p := (2 : ENNReal)) (β := fun _ : Fin d ↦ ℝ))
+/-- Continuity of the quotient map `coeFunE`. -/
+@[continuity] public theorem continuous_coeFunE : Continuous (coeFunE (d := d)) :=
+  UnitAddTorus.continuous_coeFun.comp (PiLp.continuous_ofLp _ _)
 
+/-- `coeFunE` is invariant under translation by integer vectors. -/
 @[simp] public theorem coeFunE_add_intVec (x : E) (n : Fin d → ℤ) :
     coeFunE (d := d) (x + intVec (d := d) n) = coeFunE (d := d) x := by
   ext i; simp [coeFunE, UnitAddTorus.coeFun]
@@ -256,11 +199,13 @@ public lemma dualSubmodule_standardLattice_eq :
 public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
     (h : coeFunE (d := d) x = coeFunE (d := d) y) :
     ∃ n : Fin d → ℤ, x - y = intVec (d := d) n := by
-  choose n hn using show ∀ i : Fin d, ∃ n : ℤ, (n : ℝ) = (x i - y i : ℝ) from fun i ↦ by
-    rcases (AddCircle.coe_eq_zero_iff (p := (1 : ℝ)) (x := (x i - y i : ℝ))).1 (by
+  have key (i : Fin d) : ∃ n : ℤ, (n : ℝ) = x i - y i := by
+    have h0 : ((x i - y i : ℝ) : UnitAddCircle) = 0 := by
       simpa [UnitAddCircle, AddCircle.coe_sub, coeFunE, UnitAddTorus.coeFun] using
-        sub_eq_zero.2 (congrArg (fun t ↦ t i) h)) with ⟨n, hn⟩
+        sub_eq_zero.2 (congrFun h i)
+    obtain ⟨n, hn⟩ := (AddCircle.coe_eq_zero_iff (p := (1 : ℝ))).1 h0
     exact ⟨n, by simpa using hn⟩
+  choose n hn using key
   exact ⟨n, by ext i; simp [intVec, hn i]⟩
 
 /-- The cube `iocCube` is a fundamental domain for translation by the standard lattice. -/
@@ -269,49 +214,39 @@ public theorem isAddFundamentalDomain_iocCube :
       (iocCube (d := d)) (volume : Measure E) := by
   refine MeasureTheory.IsAddFundamentalDomain.mk'
     (measurableSet_iocCube (d := d)).nullMeasurableSet fun x ↦ ?_
-  choose n hn hn_unique using fun i : Fin d ↦ by
+  choose n hn huniq using fun i : Fin d ↦ by
     simpa [one_smul, add_assoc] using
       existsUnique_add_zsmul_mem_Ioc (G := ℝ) (ha := zero_lt_one) (b := (x i : ℝ)) (c := (0 : ℝ))
-  have hn : x + intVec (d := d) n ∈ iocCube (d := d) := fun i ↦ by
-    simpa [intVec_apply, iocCube, zsmul_one] using hn i
-  have hn_unique : ∀ n' : Fin d → ℤ, x + intVec (d := d) n' ∈ iocCube (d := d) → n' = n :=
-    fun n' hn' ↦ funext fun i ↦ hn_unique i (n' i) (by
-      simpa [intVec_apply, zsmul_one] using
-        (show ∀ j : Fin d, (x + intVec (d := d) n') j ∈
-          Set.Ioc (0:ℝ) 1 by simpa [iocCube] using hn') i)
+  have hmem : x + intVec (d := d) n ∈ iocCube (d := d) := fun i ↦ by
+    simpa [intVec_apply, zsmul_one] using hn i
+  have hmem_unique : ∀ n' : Fin d → ℤ, x + intVec (d := d) n' ∈ iocCube (d := d) → n' = n :=
+    fun n' hn' ↦ funext fun i ↦ huniq i (n' i) (by simpa [intVec_apply, zsmul_one] using hn' i)
   refine ⟨⟨intVec (d := d) n, intVec_mem_standardLattice (d := d) n⟩, ?_, fun ℓ hℓ ↦ ?_⟩
   · change (⟨intVec n, _⟩ : ↥(standardLattice d)) +ᵥ x ∈ iocCube
-    rw [Submodule.vadd_def, vadd_eq_add, add_comm]
-    exact hn
-  · rcases exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property with ⟨n', hn'⟩
-    apply Subtype.ext
-    simp only [hn']
-    apply congrArg
-    apply hn_unique n'
-    have hℓ' : (ℓ : E) +ᵥ x ∈ iocCube := hℓ
-    rw [vadd_eq_add, hn', add_comm] at hℓ'
-    exact hℓ'
+    rwa [Submodule.vadd_def, vadd_eq_add, add_comm]
+  · obtain ⟨n', hn'⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
+    have hℓ' : x + intVec (d := d) n' ∈ iocCube (d := d) := by rw [add_comm, ← hn']; exact hℓ
+    exact Subtype.ext (hn'.trans (congrArg (intVec (d := d)) (hmem_unique n' hℓ')))
 
 /-- Pull back Haar integration on `(ℝ/ℤ)^d` to `iocCube` in `E = ℝ^d`. -/
 public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) → ℂ)
     (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus (Fin d)))) :
     (∫ y : UnitAddTorus (Fin d), g y) =
       ∫ x, g (coeFunE (d := d) x) ∂(volume : Measure E).restrict (iocCube (d := d)) := by
+  -- `f` is the measure-preserving identification `ℝ^d ≃ᵐ E`, used to transport the cube integral.
   let f : (Fin d → ℝ) ≃ᵐ E := MeasurableEquiv.toLp 2 (Fin d → ℝ)
   have hmp : MeasurePreserving (⇑f) (volume : Measure (Fin d → ℝ)) (volume : Measure E) := by
-    simpa [f, MeasurableEquiv.coe_toLp] using PiLp.volume_preserving_toLp (ι := Fin d)
+    simpa [f] using PiLp.volume_preserving_toLp (ι := Fin d)
+  have hpre : f ⁻¹' iocCube (d := d) = Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1 := by
+    ext x; simp [f, iocCube]
   calc
     (∫ y : UnitAddTorus (Fin d), g y)
         = ∫ x, g (UnitAddTorus.coeFun d x) ∂(volume : Measure (Fin d → ℝ)).restrict
-            (Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) (0 + 1)) := by
-          simpa using UnitAddTorus.integral_eq_integral_preimage_coeFun
-            (n := d) (t := (0 : ℝ)) g hg
+            (Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1) := by
+          simpa using UnitAddTorus.integral_eq_integral_preimage_coeFun d 0 g hg
     _ = ∫ y, g (coeFunE (d := d) y) ∂(volume : Measure E).restrict (iocCube (d := d)) := by
-          simpa [show f ⁻¹' (iocCube (d := d)) =
-              Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) (0 + 1) by
-            ext x; simp [f, iocCube, MeasurableEquiv.coe_toLp], coeFunE, f] using
-            MeasurePreserving.integral_comp'
-              (MeasurePreserving.restrict_preimage hmp (measurableSet_iocCube (d := d)))
+          simpa [hpre, coeFunE] using
+            (hmp.restrict_preimage (measurableSet_iocCube (d := d))).integral_comp'
               (g := fun y : E ↦ g (UnitAddTorus.coeFun d (WithLp.ofLp y)))
 
 end SchwartzMap.PoissonSummation.Standard
@@ -325,229 +260,231 @@ variable {d : ℕ}
 local notation "E" => EuclideanSpace ℝ (Fin d)
 local notation "Λ" => SchwartzMap.standardLattice d
 
-/-- Equivalence between integer vectors `Fin d → ℤ` and the standard lattice `Λ = ℤ^d ⊆ ℝ^d`. -/
+/-- The canonical equivalence between integer vectors `Fin d → ℤ` and the standard lattice
+`Λ = ℤ^d ⊆ ℝ^d`. Kept as a named definition: it reindexes sums over the lattice as sums over
+`ℤ^d`, both for Schwartz-decay summability and for the dual-lattice change of variables. -/
 @[expose] public noncomputable def equivIntVec : (Fin d → ℤ) ≃ Λ :=
   Equiv.ofBijective
-    (fun n : Fin d → ℤ => ⟨intVec (d := d) n, intVec_mem_standardLattice (d := d) n⟩)
-    ⟨fun a b hab => funext fun i => by
-      simpa [intVec_apply] using congrArg (fun x : E => x i) (congrArg Subtype.val hab),
-    fun ℓ =>
-      let ⟨n, hn⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (x := (ℓ : E)) ℓ.property
-      ⟨n, Subtype.ext hn.symm⟩⟩
+    (fun n : Fin d → ℤ => ⟨intVec (d := d) n, intVec_mem_standardLattice (d := d) n⟩) <| by
+    refine ⟨fun a b hab => funext fun i => ?_, fun ℓ => ?_⟩
+    · simpa using congrArg (fun x : E => x i) (congrArg Subtype.val hab)
+    · obtain ⟨n, hn⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
+      exact ⟨n, Subtype.ext hn.symm⟩
 
 variable (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ))
 
 public instance instMeasurableVAdd_standardLattice : MeasurableVAdd Λ E where
-  measurable_const_vadd _ := by
-    simpa [Submodule.vadd_def, vadd_eq_add] using (continuous_const.add continuous_id).measurable
-  measurable_vadd_const _ := by simpa [Submodule.vadd_def, vadd_eq_add] using
-    (continuous_subtype_val.add continuous_const).measurable
+  measurable_const_vadd _ := by simp only [Submodule.vadd_def, vadd_eq_add]; fun_prop
+  measurable_vadd_const _ := by simp only [Submodule.vadd_def, vadd_eq_add]; fun_prop
 
 public instance instVAddInvariantMeasure_standardLattice :
     MeasureTheory.VAddInvariantMeasure Λ E (volume : Measure E) where
   measure_preimage_vadd _ _ _ := by
     simp [Submodule.vadd_def, vadd_eq_add, MeasureTheory.measure_preimage_add]
 
-/-- Translate the Schwartz function `f` by a lattice vector, as a continuous map. -/
+/-- Translate the Schwartz function `f` by a lattice vector, as a continuous map. Kept as a named
+map: it carries the `ContinuousMap` structure used to take sup-norms over compacts and to assemble
+`periodization` as a `tsum` of continuous maps. -/
 @[expose] public noncomputable def translate (ℓ : Λ) : C(E, ℂ) :=
-  (⟨f, f.continuous⟩ : C(E, ℂ)).comp (ContinuousMap.addRight (ℓ : E))
+  (f : C(E, ℂ)).comp (ContinuousMap.addRight (ℓ : E))
 
 @[simp] public lemma translate_apply (ℓ : Λ) (x : E) :
     translate (d := d) f ℓ x = f (x + (ℓ : E)) := rfl
 
 /-- Only finitely many standard lattice points lie in a closed ball of radius `r`. -/
 public lemma finite_norm_le_lattice (r : ℝ) :
-    ( {ℓ : Λ | ‖(ℓ : E)‖ ≤ r} : Set _ ).Finite := by
-  haveI : DiscreteTopology ((Λ).toAddSubgroup) := (inferInstance : DiscreteTopology Λ)
-  have hfinE : Set.Finite (Metric.closedBall (0 : E) r ∩ ((Λ).toAddSubgroup : Set E)) :=
+    ({ℓ : Λ | ‖(ℓ : E)‖ ≤ r} : Set _).Finite := by
+  have : DiscreteTopology (Λ).toAddSubgroup := inferInstanceAs (DiscreteTopology Λ)
+  have hfin : (Metric.closedBall (0 : E) r ∩ ((Λ).toAddSubgroup : Set E)).Finite :=
     Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
       Metric.isBounded_closedBall AddSubgroup.isClosed_of_discrete
-  let e : Λ ↪ E := ⟨fun ℓ => (ℓ : E), Subtype.coe_injective⟩
-  refine (Set.Finite.preimage_embedding e
-    (by simpa [Submodule.coe_toAddSubgroup] using hfinE)).subset fun ℓ hℓ => by
-      simpa [e, Metric.mem_closedBall, dist_eq_norm] using hℓ
+  refine .of_finite_image (hfin.subset ?_) Subtype.coe_injective.injOn
+  rintro _ ⟨ℓ, hℓ, rfl⟩
+  exact ⟨by simpa [Metric.mem_closedBall, dist_eq_norm] using hℓ, ℓ.2⟩
+
+private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x ℓ : G} {r : ℝ}
+    (hx : ‖x‖ ≤ r) (hℓ : 2 * r < ‖ℓ‖) : 1 / 2 * ‖ℓ‖ ≤ ‖x + ℓ‖ := by
+  have h : ‖ℓ‖ - ‖x‖ ≤ ‖x + ℓ‖ := by simpa [add_comm] using norm_sub_norm_le ℓ (-x)
+  linarith
 
 /-- Schwartz decay: sup norms of translates restricted to a compact `K` are summable. -/
 public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) :
     Summable (fun ℓ : Λ => ‖(translate (d := d) f ℓ).restrict K‖) := by
+  -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable over `Λ`.
   let k : ℕ := Module.finrank ℤ Λ + 1
   obtain ⟨C, hCpos, hC⟩ := f.decay k 0
   simp_rw [norm_iteratedFDeriv_zero] at hC
   obtain ⟨r, hrK⟩ := K.isCompact.isBounded.subset_closedBall (0 : E)
-  let r0 : ℝ := max r 0
-  have hrK0 : (K : Set E) ⊆ Metric.closedBall (0 : E) r0 :=
-    fun x hx => Metric.closedBall_subset_closedBall (le_max_left r 0) (hrK hx)
-  have h_event : ∀ᶠ ℓ : Λ in Filter.cofinite,
-      ‖(translate (d := d) f ℓ).restrict K‖ ≤ (C * (2 ^ k : ℝ)) * (‖(ℓ : E)‖⁻¹ ^ k) := by
-    filter_upwards [(finite_norm_le_lattice (d := d) (r := max (2 * r0) 1)
-      ).eventually_cofinite_notMem] with ℓ hℓ
-    have hRlt : max (2 * r0) 1 < ‖(ℓ : E)‖ := lt_of_not_ge (by simpa using hℓ)
-    have hnorm_lt : 2 * r0 < ‖(ℓ : E)‖ := lt_of_le_of_lt (le_max_left _ _) hRlt
-    have hnorm_pos : 0 < ‖(ℓ : E)‖ := lt_trans (by positivity) hRlt
-    refine (ContinuousMap.norm_le _ (by positivity)).2 fun ⟨x, hxK⟩ => ?_
-    have hxnorm : ‖(x : E)‖ ≤ r0 := by
-      simpa [Metric.mem_closedBall, dist_eq_norm] using hrK0 hxK
-    have hnorm_ge : (1 / 2 : ℝ) * ‖(ℓ : E)‖ ≤ ‖(x + (ℓ : E))‖ := by
-      have hsub : ‖(ℓ : E)‖ - ‖(x : E)‖ ≤ ‖(ℓ : E) + x‖ := by
-        simpa [add_comm] using norm_sub_norm_le (ℓ : E) (-x)
-      simpa [add_comm] using (by nlinarith : (1 / 2 : ℝ) * ‖(ℓ : E)‖ ≤ ‖(ℓ : E) + x‖)
-    have hpow_pos : 0 < ‖(x + (ℓ : E))‖ ^ k :=
-      pow_pos ((by positivity : 0 < (1 / 2 : ℝ) * ‖(ℓ : E)‖).trans_le hnorm_ge) _
-    have hinv : (‖(x + (ℓ : E))‖ ^ k)⁻¹ ≤ (2 ^ k : ℝ) * (‖(ℓ : E)‖⁻¹ ^ k) := by
-      simpa [one_div, mul_pow, inv_pow, mul_inv_rev, mul_comm] using
-        one_div_le_one_div_of_le (pow_pos (mul_pos (by positivity) hnorm_pos) _)
-          (pow_le_pow_left₀ (by positivity) hnorm_ge k)
-    calc ‖(translate (d := d) f ℓ) (⟨x, hxK⟩ : K)‖
-        = ‖f (x + (ℓ : E))‖ := by simp [translate]
-      _ ≤ C / (‖(x + (ℓ : E))‖ ^ k) := (le_div_iff₀' hpow_pos).2 (hC (x + (ℓ : E)))
-      _ ≤ (C * (2 ^ k : ℝ)) * (‖(ℓ : E)‖⁻¹ ^ k) := by
-        simpa [div_eq_mul_inv, mul_assoc] using mul_le_mul_of_nonneg_left hinv hCpos.le
-  refine Summable.of_norm_bounded_eventually
-    (((by simpa [k] using ZLattice.summable_norm_pow_inv (L := Λ) (n := k) (Nat.lt_succ_self _)
-        : Summable (fun ℓ : Λ => (‖(ℓ : E)‖⁻¹ ^ k : ℝ))).mul_left (C * (2 ^ k : ℝ)))) ?_
-  filter_upwards [h_event] with ℓ hℓ
-  simpa [Real.norm_of_nonneg (by positivity)] using hℓ
+  have hsum : Summable fun ℓ : Λ => ‖(ℓ : E)‖⁻¹ ^ k := by
+    simpa [k] using ZLattice.summable_norm_pow_inv (L := Λ) k (Nat.lt_succ_self _)
+  refine (hsum.mul_left (C * 2 ^ k)).of_norm_bounded_eventually ?_
+  filter_upwards [(finite_norm_le_lattice (d := d) (max (2 * r) 1)).eventually_cofinite_notMem]
+    with ℓ hℓ
+  have hRlt : max (2 * r) 1 < ‖(ℓ : E)‖ := lt_of_not_ge (by simpa using hℓ)
+  have hnorm_pos : 0 < ‖(ℓ : E)‖ := one_pos.trans_le ((le_max_right _ _).trans hRlt.le)
+  rw [norm_norm]
+  refine (ContinuousMap.norm_le _ (by positivity)).2 fun ⟨x, hxK⟩ => ?_
+  have hxr : ‖x‖ ≤ r := by simpa using hrK hxK
+  have hge : 1 / 2 * ‖(ℓ : E)‖ ≤ ‖x + (ℓ : E)‖ :=
+    half_norm_le_norm_add hxr ((le_max_left _ _).trans_lt hRlt)
+  have hpos : 0 < ‖x + (ℓ : E)‖ := (by positivity : (0 : ℝ) < 1 / 2 * ‖(ℓ : E)‖).trans_le hge
+  have hinv : ‖x + (ℓ : E)‖⁻¹ ≤ 2 * ‖(ℓ : E)‖⁻¹ := by
+    have h := inv_anti₀ (by positivity) hge
+    rwa [mul_inv, one_div, inv_inv] at h
+  calc ‖(translate (d := d) f ℓ) (⟨x, hxK⟩ : K)‖
+      = ‖f (x + (ℓ : E))‖ := rfl
+    _ ≤ C / ‖x + (ℓ : E)‖ ^ k := (le_div_iff₀' (pow_pos hpos k)).2 (hC _)
+    _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
+    _ ≤ C * (2 * ‖(ℓ : E)‖⁻¹) ^ k := by gcongr
+    _ = C * 2 ^ k * ‖(ℓ : E)‖⁻¹ ^ k := by rw [mul_pow, mul_assoc]
 
-/-- Periodization of a Schwartz function along the standard lattice. -/
-@[expose] public noncomputable def periodized : C(E, ℂ) :=
-  ∑' ℓ : Λ, translate (d := d) f ℓ
-
-public lemma periodized_apply (x : E) :
-    periodized (d := d) f x = ∑' ℓ : Λ, f (x + (ℓ : E)) := by
-  simpa [periodized, translate_apply] using
-    (ContinuousMap.tsum_apply (ContinuousMap.summable_of_locally_summable_norm
-      (summable_norm_translate_restrict (d := d) f)) x).symm
-
-/-- The quotient map `E = ℝ^d → (ℝ/ℤ)^d`, bundled as a continuous map. -/
+/-- The quotient map `coeFunE`, bundled as a continuous map. This packaging is what the
+`IsQuotientMap.lift`/`FactorsThrough` API consumes when descending periodic maps to the torus. -/
 @[expose] public noncomputable def coeFunEC : C(E, UnitAddTorus (Fin d)) :=
   ⟨coeFunE (d := d), continuous_coeFunE⟩
 
-/-- The periodization is invariant under lattice translates, so it factors through the torus. -/
-public lemma periodized_factorsThrough :
-    Function.FactorsThrough (periodized (d := d) f) (coeFunEC (d := d)) := fun x y hxy => by
-  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq (d := d) (x := x) (y := y)
-    (by simpa [coeFunEC] using hxy)
-  simpa [show x = y + intVec (d := d) n by
-    simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
-      congrArg (fun t => t + y) hn] using
-    show periodized (d := d) f (y + (⟨_, intVec_mem_standardLattice (d := d) n⟩ : Λ)) =
-        periodized (d := d) f y by
-      simpa [periodized_apply (d := d) f, add_assoc] using
-        (Equiv.addLeft (⟨_, intVec_mem_standardLattice (d := d) n⟩ : Λ)).tsum_eq
-          fun ℓ => f (y + (ℓ : E))
+section Periodization
 
-/-- Descend the periodization to the torus `(ℝ/ℤ)^d` via the quotient. -/
+/-- The **periodization** of a Schwartz function `f` along the standard lattice `ℤ^d`, as a
+continuous map `x ↦ ∑' n : ℤ^d, f (x + n)`. It is `ℤ^d`-periodic (`periodization_add_lattice`), so
+it descends to the torus `(ℝ/ℤ)^d` (`descended`); its torus Fourier coefficients are the values of
+`𝓕 f` on `ℤ^d`, which is the content of Poisson summation. -/
+@[expose] public noncomputable def periodization : C(E, ℂ) :=
+  ∑' ℓ : Λ, translate (d := d) f ℓ
+
+public lemma periodization_apply (x : E) :
+    periodization (d := d) f x = ∑' ℓ : Λ, f (x + (ℓ : E)) := by
+  simpa [periodization, translate_apply] using
+    (ContinuousMap.tsum_apply (ContinuousMap.summable_of_locally_summable_norm
+      (summable_norm_translate_restrict (d := d) f)) x).symm
+
+/-- The periodization is invariant under translation by a lattice vector. -/
+public lemma periodization_add_lattice (x : E) (ℓ : Λ) :
+    periodization (d := d) f (x + (ℓ : E)) = periodization (d := d) f x := by
+  rw [periodization_apply, periodization_apply]
+  simpa [add_assoc] using (Equiv.addLeft ℓ).tsum_eq fun m : Λ ↦ f (x + (m : E))
+
+/-- The periodization factors through the quotient `(ℝ/ℤ)^d`. -/
+public lemma periodization_factorsThrough :
+    Function.FactorsThrough (periodization (d := d) f) (coeFunEC (d := d)) := by
+  intro x y hxy
+  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq (d := d) (by simpa [coeFunEC] using hxy)
+  have hx : x = y + intVec (d := d) n := by rw [← hn]; abel
+  rw [hx]
+  exact periodization_add_lattice (d := d) f y ⟨_, intVec_mem_standardLattice (d := d) n⟩
+
+end Periodization
+
+/-- The quotient map `coeFunE : E → (ℝ/ℤ)^d` presents the torus as an open quotient of `E`. -/
+public theorem isOpenQuotientMap_coeFunE : IsOpenQuotientMap (coeFunE (d := d)) := by
+  simpa [coeFunE] using (UnitAddTorus.isOpenQuotientMap_coeFun d).comp
+    (PiLp.homeomorph (p := (2 : ENNReal)) (β := fun _ : Fin d ↦ ℝ)).isOpenQuotientMap
+
+/-- Descend the periodization to a continuous function on the torus `(ℝ/ℤ)^d`. This bridges to the
+torus Fourier theory: the Fourier coefficients of `descended f` are the values of `𝓕 f` on the
+lattice. -/
 @[expose] public noncomputable def descended : C(UnitAddTorus (Fin d), ℂ) :=
-  Topology.IsQuotientMap.lift (hf := (show IsOpenQuotientMap (coeFunE (d := d)) by
-      simpa [coeFunE] using IsOpenQuotientMap.comp (UnitAddTorus.isOpenQuotientMap_coeFun d)
-        (PiLp.homeomorph (p := (2 : ENNReal))
-          (β := fun _ : Fin d ↦ ℝ)).isOpenQuotientMap).isQuotientMap)
-    (g := periodized (d := d) f) (periodized_factorsThrough (d := d) (f := f))
+  isOpenQuotientMap_coeFunE.isQuotientMap.lift (periodization (d := d) f)
+    (periodization_factorsThrough (d := d) (f := f))
 
-/-- Compatibility of `descended` with `coeFunE`: pulling back gives `periodized`. -/
+/-- Compatibility of `descended` with `coeFunE`: pulling back along the quotient gives back the
+periodization. -/
 public lemma descended_comp (x : E) :
-    descended (d := d) f (coeFunE (d := d) x) = periodized (d := d) f x :=
+    descended (d := d) f (coeFunE (d := d) x) = periodization (d := d) f x :=
   congrArg (fun g : C(E, ℂ) => g x)
-    (by simp [descended] : (descended (d := d) f).comp (coeFunEC (d := d)) = periodized (d := d) f)
+    (by simp [descended] :
+      (descended (d := d) f).comp (coeFunEC (d := d)) = periodization (d := d) f)
 
 public lemma mFourier_neg_apply_coeFunE (n : Fin d → ℤ) (x : E) :
     UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) =
       (𝐞 (-(inner ℝ x (intVec (d := d) n))) : ℂ) := by
-  have hinner : inner ℝ x (intVec (d := d) n) = ∑ i, (x.ofLp i : ℝ) * (n i : ℝ) := by
-    simp only [intVec, PiLp.inner_apply]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    rw [show inner ℝ (x.ofLp i : ℝ) ((n i : ℝ)) = (x.ofLp i : ℝ) * (n i : ℝ) from
-      (RCLike.inner_apply' (x.ofLp i : ℝ) (n i : ℝ)).trans (by simp)]
+  have hinner : inner ℝ x (intVec (d := d) n) = ∑ i, (n i : ℝ) * (x.ofLp i : ℝ) := by
+    simp [intVec, PiLp.inner_apply]
   rw [hinner]
-  simp [coeFunE, UnitAddTorus.mFourier_apply_coeFun_ofLp,
-    Real.fourierChar_apply, Finset.sum_neg_distrib,
-    mul_assoc, mul_comm]
-
-@[simp] lemma intVec_neg (n : Fin d → ℤ) :
-    intVec (d := d) (-n) = -intVec (d := d) n := by ext i; simp [intVec_apply]
+  simp [coeFunE, UnitAddTorus.mFourier_apply_coeFun_ofLp, Real.fourierChar_apply,
+    Finset.sum_neg_distrib, mul_assoc, mul_comm]
 
 public lemma mFourier_apply_coeFunE_exp (n : Fin d → ℤ) (x : E) :
     UnitAddTorus.mFourier n (coeFunE (d := d) x) =
       Complex.exp (2 * Real.pi * Complex.I * ⟪x, intVec (d := d) n⟫_[ℝ]) := by
   have h := mFourier_neg_apply_coeFunE (d := d) (n := -n) (x := x)
   simp only [neg_neg, intVec_neg, inner_neg_right] at h
-  rw [h]
-  rw [show ⟪x, intVec n⟫_[ℝ] = inner ℝ x (intVec n) from RCLike.inner_eq_wInner_one x _ |>.symm]
+  rw [h, ← RCLike.inner_eq_wInner_one]
   simp [Real.fourierChar_apply, mul_assoc, mul_comm]
 
 public lemma mFourier_neg_apply_coeFunE_add_standardLattice (n : Fin d → ℤ) (ℓ : Λ) (x : E) :
     UnitAddTorus.mFourier (-n) (coeFunE (d := d) (x + (ℓ : E))) =
-      UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) :=
-  let ⟨m, hm⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (x := (ℓ : E)) ℓ.property
-  by simp [hm]
+      UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) := by
+  obtain ⟨m, hm⟩ := exists_intVec_eq_of_mem_standardLattice (d := d) (ℓ : E) ℓ.property
+  rw [hm, coeFunE_add_intVec]
 
 public lemma iocCube_subset_closedBall :
     iocCube (d := d) ⊆ Metric.closedBall (0 : E) (Real.sqrt d) := fun x hx => by
-  simpa [Metric.mem_closedBall, dist_eq_norm, EuclideanSpace.norm_eq] using
-    Real.sqrt_le_sqrt (show (∑ i : Fin d, ‖x i‖ ^ 2) ≤ (d : ℝ) by
-      simpa using (Finset.sum_le_sum fun i _ => show ‖x i‖ ^ 2 ≤ (1 : ℝ) by
-        nlinarith [norm_nonneg (x i), show ‖x i‖ ≤ (1 : ℝ) by
-          simpa [Real.norm_eq_abs, abs_of_nonneg (hx i).1.le] using (hx i).2]).trans_eq (by simp))
+  rw [Metric.mem_closedBall, dist_eq_norm, sub_zero, EuclideanSpace.norm_eq]
+  refine Real.sqrt_le_sqrt ?_
+  calc ∑ i : Fin d, ‖x i‖ ^ 2 ≤ ∑ _i : Fin d, (1 : ℝ) := by
+        refine Finset.sum_le_sum fun i _ => pow_le_one₀ (norm_nonneg _) ?_
+        rw [Real.norm_eq_abs, abs_of_pos (hx i).1]; exact (hx i).2
+    _ = d := by simp
 
 public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube (d := d)) < ⊤ :=
   ((Metric.isBounded_closedBall (x := (0 : E)) (r := Real.sqrt d)).subset
     (iocCube_subset_closedBall (d := d))).measure_lt_top
 
+/-- The closed ball of radius `√d`, packaged as `Compacts E`; it contains the fundamental cube
+`iocCube`. Kept as a named definition: it is the single compact on which the Schwartz-decay
+summability `summable_norm_translate_restrict` is instantiated to bound the cube integrals. -/
+def sqrtdBall : TopologicalSpace.Compacts E :=
+  ⟨Metric.closedBall (0 : E) (Real.sqrt d), isCompact_closedBall (0 : E) (Real.sqrt d)⟩
+
+/-- On `iocCube`, the integrand `mFourier (-n) (coeFunE ·) * f (· + ℓ)` is bounded by the sup norm
+of the translate `f (· + ℓ)` restricted to `sqrtdBall`. -/
+lemma norm_mFourier_mul_translate_le (n : Fin d → ℤ) (ℓ : Λ) {x : E}
+    (hx : x ∈ iocCube (d := d)) :
+    ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖ ≤
+      ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+  rw [norm_mul]
+  calc ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x)‖ * ‖f (x + (ℓ : E))‖
+      ≤ 1 * ‖f (x + (ℓ : E))‖ := by
+        gcongr
+        simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
+          ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) _
+    _ = ‖f (x + (ℓ : E))‖ := one_mul _
+    _ ≤ ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+        simpa [translate_apply, ContinuousMap.restrict_apply] using
+          ContinuousMap.norm_coe_le_norm ((translate (d := d) f ℓ).restrict (sqrtdBall (d := d)))
+            ⟨x, iocCube_subset_closedBall (d := d) hx⟩
+
 public lemma integrableOn_mFourier_mul_translate_iocCube (n : Fin d → ℤ) (ℓ : Λ) :
     IntegrableOn
         (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
-        (iocCube (d := d)) (volume : Measure E) := by
-  let K : TopologicalSpace.Compacts E :=
-    ⟨Metric.closedBall (0 : E) (Real.sqrt d), isCompact_closedBall (0 : E) (Real.sqrt d)⟩
-  refine Measure.integrableOn_of_bounded (μ := (volume : Measure E))
-    (s := iocCube (d := d)) (s_finite := (volume_iocCube_lt_top (d := d)).ne)
-    (M := ‖(translate (d := d) f ℓ).restrict K‖)
+        (iocCube (d := d)) (volume : Measure E) :=
+  Measure.integrableOn_of_bounded (volume_iocCube_lt_top (d := d)).ne
     (((UnitAddTorus.mFourier (-n)).continuous.comp (continuous_coeFunE (d := d))).mul
         (f.continuous.comp (continuous_id.add continuous_const))).aestronglyMeasurable
-    (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x hx => ?_)
-  calc ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖
-      ≤ 1 * ‖f (x + (ℓ : E))‖ := by
-        rw [norm_mul]; gcongr
-        simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
-          ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) _
-    _ ≤ ‖(translate (d := d) f ℓ).restrict K‖ := by
-      simpa [translate_apply, ContinuousMap.restrict_apply] using
-        ContinuousMap.norm_coe_le_norm ((translate (d := d) f ℓ).restrict K)
-          ⟨x, iocCube_subset_closedBall (d := d) hx⟩
+    (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun _ hx =>
+      norm_mFourier_mul_translate_le (d := d) f n ℓ hx)
 
 section StandardPoissonSummation
 
 open UnitAddTorus PoissonSummation.Standard
 
-noncomputable def ball : TopologicalSpace.Compacts E :=
-  ⟨Metric.closedBall (0 : E) (Real.sqrt d), isCompact_closedBall (0 : E) (Real.sqrt d)⟩
-
 lemma summable_integral_norm_mFourier_mul_translate_iocCube (n : Fin d → ℤ) :
-    Summable
-        (fun ℓ : Λ =>
-          ∫ x in iocCube (d := d),
-            ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
-                f (x + (ℓ : E))‖ ∂(volume : Measure E)) := by
-  let s : Set E := iocCube (d := d); let μ : Measure E := (volume : Measure E).restrict s
-  haveI : IsFiniteMeasure μ := ⟨by simpa [μ, s] using volume_iocCube_lt_top (d := d)⟩
-  have hsum_norm : Summable (fun ℓ : Λ =>
-      μ.real Set.univ * ‖(translate (d := d) f ℓ).restrict (ball (d := d))‖) := by
-    simpa [mul_assoc, mul_comm, mul_left_comm] using
-      (summable_norm_translate_restrict (d := d) f (ball (d := d))).mul_left (μ.real Set.univ)
-  refine Summable.of_nonneg_of_le (fun _ => by positivity) (fun ℓ => ?_) hsum_norm
-  simpa [μ, s, MeasureTheory.integral_const (μ := μ), smul_eq_mul, mul_comm, mul_left_comm,
-    mul_assoc] using integral_mono_of_nonneg (ae_of_all _ fun _ => by positivity)
-      (integrable_const ‖(translate (d := d) f ℓ).restrict (ball (d := d))‖)
-      (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x hx => by
-        have hmFourier : ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x)‖ ≤ 1 := by
-          simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
-            ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) (coeFunE (d := d) x)
-        simpa using (mul_le_mul hmFourier
-          (by simpa [translate_apply, ContinuousMap.restrict_apply] using
-              ContinuousMap.norm_coe_le_norm ((translate (d := d) f ℓ).restrict (ball (d := d)))
-                ⟨x, iocCube_subset_closedBall (d := d) hx⟩ :
-            ‖f (x + (ℓ : E))‖ ≤ ‖(translate (d := d) f ℓ).restrict (ball (d := d))‖)
-          (norm_nonneg _) (by norm_num)).trans (one_mul _).le)
+    Summable (fun ℓ : Λ => ∫ x in iocCube (d := d),
+        ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖
+        ∂(volume : Measure E)) := by
+  -- `μ` is the (finite) restriction of Lebesgue measure to the fundamental cube.
+  set μ : Measure E := (volume : Measure E).restrict (iocCube (d := d)) with hμ
+  have : IsFiniteMeasure μ := ⟨by simpa [hμ] using volume_iocCube_lt_top (d := d)⟩
+  refine ((summable_norm_translate_restrict (d := d) f (sqrtdBall (d := d))).mul_left
+    (μ.real Set.univ)).of_nonneg_of_le (fun _ => by positivity) fun ℓ => ?_
+  calc ∫ x, ‖UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))‖ ∂μ
+      ≤ ∫ _, ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ ∂μ :=
+        integral_mono_of_nonneg (ae_of_all _ fun _ => norm_nonneg _) (integrable_const _)
+          (ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x hx =>
+            norm_mFourier_mul_translate_le (d := d) f n ℓ hx)
+    _ = μ.real Set.univ * ‖(translate (d := d) f ℓ).restrict (sqrtdBall (d := d))‖ := by
+        rw [integral_const, smul_eq_mul]
 
 /-- The `n`-th torus Fourier coefficient of `descended f` is the integral over the unit cube
 of `mFourier(-n)(coeFunE x)` times the periodization `∑' ℓ, f (x + ℓ)`. -/
@@ -566,18 +503,17 @@ private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
   calc
     UnitAddTorus.mFourierCoeff (descended (d := d) f) n
         = ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • descended (d := d) f y := by
-            simp only [UnitAddTorus.mFourierCoeff, smul_eq_mul]
-            haveI : Fact (0 < (1 : ℝ)) := ⟨one_pos⟩
-            simp [show (@volume (UnitAddTorus (Fin d))
+            have hvol : (@volume (UnitAddTorus (Fin d))
                   (@MeasureSpace.pi (Fin d) (Fin.fintype d) (fun _ => UnitAddCircle)
                     (fun _ => instMeasureSpaceUnitAddCircle))) =
-                (@volume (UnitAddTorus (Fin d))
+                @volume (UnitAddTorus (Fin d))
                   (@MeasureSpace.pi (Fin d) (Fin.fintype d) (fun _ => UnitAddCircle)
-                    (fun _ => AddCircle.measureSpace (1 : ℝ)))) from
+                    (fun _ => AddCircle.measureSpace (1 : ℝ))) :=
               congrArg Measure.pi (funext fun _ => by
                 change (AddCircle.haarAddCircle (T := (1 : ℝ)) : Measure UnitAddCircle) =
-                  (@volume UnitAddCircle (AddCircle.measureSpace (1 : ℝ)))
-                simp [UnitAddCircle, AddCircle.volume_eq_smul_haarAddCircle])]
+                  @volume UnitAddCircle (AddCircle.measureSpace (1 : ℝ))
+                simp [UnitAddCircle, AddCircle.volume_eq_smul_haarAddCircle])
+            simp [UnitAddTorus.mFourierCoeff, smul_eq_mul, hvol]
     _ = ∫ x in iocCube (d := d),
           UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) •
             descended (d := d) f (coeFunE (d := d) x)
@@ -585,12 +521,12 @@ private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
     _ = _ :=
           integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube (d := d))
             fun _ _ => by simp [descended_comp (d := d) (f := f),
-              periodized_apply (d := d) (f := f), smul_eq_mul]
+              periodization_apply (d := d) (f := f), smul_eq_mul]
 
 /-- The integral over the unit cube of `mFourier(-n)(coeFunE x)` times the periodization of `f`
 equals the integral of `mFourier(-n)(coeFunE x) * f x` over the whole space, by swapping the
 integral with the lattice sum and applying the fundamental-domain property of `iocCube`. -/
-private lemma integral_iocCube_mFourier_periodized_eq_integral (n : Fin d → ℤ) :
+private lemma integral_iocCube_mFourier_periodization_eq_integral (n : Fin d → ℤ) :
     (∫ x in iocCube (d := d),
         UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
           (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
@@ -613,17 +549,16 @@ private lemma integral_iocCube_mFourier_periodized_eq_integral (n : Fin d → �
           ∫ x in iocCube (d := d),
             UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
               f (x + (ℓ : E)) ∂(volume : Measure E) := by
-    let s : Set E := iocCube (d := d)
-    simpa [s, tsum_mul_left, mul_assoc] using
+    simpa [tsum_mul_left, mul_assoc] using
       (MeasureTheory.integral_tsum_of_summable_integral_norm
-          (μ := (volume : Measure E).restrict s)
+          (μ := (volume : Measure E).restrict (iocCube (d := d)))
           (F := fun ℓ : Λ => fun x : E =>
             UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
           (fun ℓ => by
-            simpa [IntegrableOn, s] using
+            simpa [IntegrableOn] using
               (integrableOn_mFourier_mul_translate_iocCube (d := d) (f := f) n ℓ))
-          (by simpa [s] using
-            (summable_integral_norm_mFourier_mul_translate_iocCube (d := d) (f := f) n))).symm
+          (summable_integral_norm_mFourier_mul_translate_iocCube (d := d) (f := f) n)).symm
+  -- `g` is the full integrand, abbreviated for the fundamental-domain unfolding below.
   let g : E → ℂ := fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x
   have hterm : ∀ ℓ : Λ,
       (∫ x in iocCube (d := d), g (ℓ +ᵥ x) ∂(volume : Measure E)) =
@@ -633,8 +568,6 @@ private lemma integral_iocCube_mFourier_periodized_eq_integral (n : Fin d → �
     integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x _ => by
       simp [g, Submodule.vadd_def, vadd_eq_add, add_comm,
         mFourier_neg_apply_coeFunE_add_standardLattice (d := d) (n := n) (ℓ := ℓ) (x := x)]
-  haveI : Countable (SchwartzMap.standardLattice d).toAddSubgroup :=
-    inferInstanceAs (Countable (SchwartzMap.standardLattice d))
   rw [hsum_int]
   simpa [g, hterm] using
     ((isAddFundamentalDomain_iocCube (d := d)).integral_eq_tsum'' g hint).symm
@@ -643,7 +576,7 @@ lemma mFourierCoeff_descended (n : Fin d → ℤ) :
     UnitAddTorus.mFourierCoeff (descended (d := d) f) n =
       𝓕 (fun x : E => f x) (intVec (d := d) n) := by
   rw [mFourierCoeff_descended_eq_iocCube_integral (d := d) (f := f) (n := n),
-      integral_iocCube_mFourier_periodized_eq_integral (d := d) (f := f) (n := n)]
+      integral_iocCube_mFourier_periodization_eq_integral (d := d) (f := f) (n := n)]
   simp [Real.fourier_eq, Circle.smul_def, smul_eq_mul,
     mFourier_neg_apply_coeFunE (d := d) (n := n)]
 
@@ -651,10 +584,11 @@ lemma summable_mFourierCoeff_descended :
     Summable (UnitAddTorus.mFourierCoeff (descended (d := d) f)) := by
   have hsum_norm : Summable (fun n : Fin d → ℤ =>
       ‖𝓕 (fun x : E => f x) (intVec (d := d) n)‖) := by
+    -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable.
     let k : ℕ := d + 1
-    have hk : Module.finrank ℤ Λ < k := by
-      simp [show Module.finrank ℤ Λ = d from by
-        simpa using (ZLattice.rank (K := ℝ) (L := Λ)).trans (by simp), k]
+    have hrank : Module.finrank ℤ Λ = d := by
+      simpa using (ZLattice.rank (K := ℝ) (L := Λ)).trans (by simp)
+    have hk : Module.finrank ℤ Λ < k := by simp [hrank, k]
     obtain ⟨C, _, hC⟩ := (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).decay k 0
     have hC' : ∀ x : E, ‖x‖ ^ k * ‖𝓕 (fun y : E => f y) x‖ ≤ C := by
       simpa [FourierTransform.fourierCLE_apply, fourier_coe, norm_iteratedFDeriv_zero] using hC
@@ -672,13 +606,9 @@ lemma summable_mFourierCoeff_descended :
 
 /-- Poisson summation for Schwartz functions over the standard lattice `ℤ^d`. -/
 public theorem poissonSummation_standard (v : E) :
-    (∑' ℓ : Λ, f (v + (ℓ : E))) =
-      ∑' n : Fin d → ℤ,
-        (𝓕 (fun x : E => f x) (intVec (d := d) n)) *
-          Complex.exp
-            (2 * Real.pi * Complex.I *
-              ⟪v, intVec (d := d) n⟫_[ℝ]) := by
-  simpa [descended_comp (d := d) (f := f) v, periodized_apply (d := d) (f := f), smul_eq_mul,
+    (∑' ℓ : Λ, f (v + (ℓ : E))) = ∑' n : Fin d → ℤ, 𝓕 (fun x : E => f x) (intVec (d := d) n) *
+        Complex.exp (2 * Real.pi * Complex.I * ⟪v, intVec (d := d) n⟫_[ℝ]) := by
+  simpa [descended_comp (d := d) (f := f) v, periodization_apply (d := d) (f := f), smul_eq_mul,
     mFourierCoeff_descended (d := d) (f := f), mFourier_apply_coeFunE_exp (d := d), mul_assoc,
     mul_left_comm, mul_comm] using
     (UnitAddTorus.hasSum_mFourier_series_apply_of_summable
@@ -692,82 +622,87 @@ end SchwartzMap.PoissonSummation.Standard
 
 namespace SchwartzMap
 
+open SchwartzMap.PoissonSummation.Standard
+
 variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
 
-/-- The dual `ℤ`-lattice with respect to the Euclidean inner product. -/
+/-- The dual `ℤ`-lattice with respect to the Euclidean inner product. Kept as a named abbreviation:
+it is the index set of the spectral side of Poisson summation and is part of this file's public
+API (used downstream in the linear-programming bound). -/
 public noncomputable abbrev dualLattice (L : Submodule ℤ E) : Submodule ℤ E :=
   LinearMap.BilinForm.dualSubmodule (B := (innerₗ E : LinearMap.BilinForm ℝ E)) L
 
+/-- A `Fin d`-indexed integral basis of the `ℤ`-lattice `L` (Mathlib's `chooseBasis` reindexed
+along `finrank ℤ L = d`). Kept as a named definition: a fixed integral frame for `L` whose
+determinant against `stdBasis` computes the covolume. -/
 noncomputable def zBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Basis (Fin d) ℤ L :=
-  haveI : Module.Finite ℤ L := ZLattice.module_finite ℝ L
   (Module.Free.chooseBasis ℤ L).reindex <| Fintype.equivOfCardEq <| by
     simpa [(ZLattice.rank (K := ℝ) (L := L)).trans (by simp : _ = d)] using
       (Module.finrank_eq_card_chooseBasisIndex (R := ℤ) (M := L)).symm
 
+/-- The `ℝ`-basis of `E` spanned by `zBasis L` (Mathlib's `Basis.ofZLatticeBasis`). Kept as a named
+definition: the real frame realizing `L`, namely the image of `stdBasis` under `latticeEquiv L`. -/
 noncomputable def rBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Basis (Fin d) ℝ E := (zBasis (d := d) L).ofZLatticeBasis ℝ L
 
+/-- The standard basis of `E = ℝ^d` as an `ℝ`-basis, i.e. `(EuclideanSpace.basisFun _ _).toBasis`.
+Kept as a named definition: the orthonormal reference frame (and `ℤ`-basis of the standard lattice)
+against which the lattice determinant and covolume are measured. -/
 noncomputable def stdBasis : Basis (Fin d) ℝ E := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis
 
-noncomputable def A (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] : E ≃ₗ[ℝ] E :=
-  (stdBasis (d := d)).equiv (rBasis (d := d) L) (Equiv.refl (Fin d))
+/-- The `ℝ`-linear automorphism of `E` sending the standard basis to `rBasis L`, hence the standard
+lattice `ℤ^d` onto `L`. Kept as a named definition: it is the change-of-variables map underlying
+the reduction of lattice Poisson summation to the standard-lattice case, used throughout this
+section and reused via its adjoints `Bₗ`/`Aadjₗ`. -/
+noncomputable def latticeEquiv (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
+    E ≃ₗ[ℝ] E := (stdBasis (d := d)).equiv (rBasis (d := d) L) (Equiv.refl (Fin d))
 
-@[simp] lemma A_apply_stdBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L]
-    (i : Fin d) : (A (d := d) L) ((stdBasis (d := d)) i) = (rBasis (d := d) L) i := by
-  simpa [A, stdBasis, rBasis] using Basis.equiv_apply
-    (b := stdBasis (d := d)) (b' := rBasis (d := d) L) (e := Equiv.refl _) (i := i)
+@[simp] lemma latticeEquiv_apply_stdBasis (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L]
+    (i : Fin d) : latticeEquiv (d := d) L ((stdBasis (d := d)) i) = (rBasis (d := d) L) i :=
+  Basis.equiv_apply (b := stdBasis (d := d)) (b' := rBasis (d := d) L) (e := Equiv.refl _) (i := i)
 
 lemma map_standardLattice_eq (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
-    Submodule.map ((A (d := d) L).toLinearMap.restrictScalars ℤ)
-        (SchwartzMap.standardLattice d) = L := calc
-    Submodule.map ((A (d := d) L).toLinearMap.restrictScalars ℤ) (SchwartzMap.standardLattice d) =
-        Submodule.span ℤ ((fun a : E => (A (d := d) L) a) '' Set.range (stdBasis (d := d))) := by
-          simp [SchwartzMap.standardLattice, stdBasis, Submodule.map_span]
-    _ = Submodule.span ℤ (Set.range (rBasis (d := d) L)) := by
-        rw [show (fun a : E => (A (d := d) L) a) '' (Set.range (stdBasis (d := d))) =
-            Set.range (rBasis (d := d) L) from by
-          simpa [show (fun a : E => (A (d := d) L) a) ∘ stdBasis (d := d) = rBasis (d := d) L from
-            by funext i; simp [Function.comp]] using
-            (Set.range_comp (g := fun a : E => (A (d := d) L) a) (f := stdBasis (d := d))).symm]
-    _ = L := by simpa [rBasis] using
-        Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis (d := d) L)
+    Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
+        (SchwartzMap.standardLattice d) = L := by
+  have hrange : (fun a : E => latticeEquiv (d := d) L a) '' Set.range (stdBasis (d := d)) =
+      Set.range (rBasis (d := d) L) := by
+    rw [← Set.range_comp]; simp [Function.comp_def]
+  calc Submodule.map ((latticeEquiv (d := d) L).toLinearMap.restrictScalars ℤ)
+          (SchwartzMap.standardLattice d)
+      = Submodule.span ℤ ((fun a : E => latticeEquiv (d := d) L a) '' Set.range (stdBasis (d := d)))
+        := by simp [SchwartzMap.standardLattice, stdBasis, Submodule.map_span]
+    _ = Submodule.span ℤ (Set.range (rBasis (d := d) L)) := by rw [hrange]
+    _ = L := by
+        simpa [rBasis] using Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis L)
+
+/-- The standard fundamental domain in `E = ℝ^d` (the unit cube of the orthonormal standard
+basis) has volume `1`. -/
+private lemma volume_real_fundamentalDomain_basisFun :
+    (volume : Measure E).real
+      (ZSpan.fundamentalDomain ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) = 1 := by
+  rw [measureReal_def, measure_congr (ZSpan.fundamentalDomain_ae_parallelepiped
+    (μ := (volume : Measure E)) ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis))]
+  simp [(EuclideanSpace.basisFun (Fin d) ℝ).volume_parallelepiped]
 
 section CovolumeDet
 
 variable (L : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology L] [IsZLattice ℝ L]
 
-lemma covolume_eq_abs_det_A :
-    ZLattice.covolume L =
-      abs ((LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((A L).toLinearMap)) := by
-  have hvol : (volume : Measure E).real
-      (ZSpan.fundamentalDomain ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) = 1 := by
-    let f : E ≃L[ℝ] (Fin d → ℝ) := EuclideanSpace.equiv (Fin d) ℝ
-    simpa [show f ⁻¹' (ZSpan.fundamentalDomain (Pi.basisFun ℝ (Fin d))) =
-        ZSpan.fundamentalDomain ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis) by
-      rw [show ZSpan.fundamentalDomain (Pi.basisFun ℝ (Fin d)) =
-          f.toLinearEquiv '' ZSpan.fundamentalDomain ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)
-        from by simpa [show ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis).map f.toLinearEquiv =
-            Pi.basisFun ℝ (Fin d) from rfl] using
-          (ZSpan.map_fundamentalDomain
-            (b := (EuclideanSpace.basisFun (Fin d) ℝ).toBasis) f.toLinearEquiv).symm]
-      exact Set.preimage_image_eq _ f.injective, ZSpan.volume_real_fundamentalDomain,
-      show (Matrix.of (Pi.basisFun ℝ (Fin d)) : Matrix (Fin d) (Fin d) ℝ) = 1 by
-        ext; simp [Matrix.of_apply, Matrix.one_apply, Pi.basisFun_apply, Pi.single_apply, eq_comm]]
-      using (show MeasurePreserving (fun x : E => (f x)) volume volume by
-        simpa [EuclideanSpace.equiv, PiLp.coe_continuousLinearEquiv] using
-          PiLp.volume_preserving_ofLp (ι := Fin d)).measureReal_preimage
-      (ZSpan.fundamentalDomain_measurableSet (b := (Pi.basisFun ℝ (Fin d)))).nullMeasurableSet
+/-- The covolume of `L` equals `|det (latticeEquiv L)|`: the map carrying the standard lattice
+onto `L` scales the unit-covolume standard lattice by exactly its determinant. -/
+lemma covolume_eq_abs_det_latticeEquiv :
+    ZLattice.covolume L = |(LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((latticeEquiv L).toLinearMap)| := by
   have hr : rBasis (d := d) L = fun i : Fin d => (zBasis (d := d) L i : E) :=
     funext fun i => by simp [rBasis]
   have hcovol : ZLattice.covolume L =
       |(stdBasis (d := d)).det (fun i : Fin d => (zBasis (d := d) L i : E))| := by
-    simpa [stdBasis, hvol] using
+    simpa [stdBasis, volume_real_fundamentalDomain_basisFun] using
       ZLattice.covolume_eq_det_mul_measureReal (L := L) (b := zBasis (d := d) L)
         (b₀ := stdBasis (d := d)) (μ := (volume : Measure E))
-  rw [hcovol, ← hr]; simp [A, stdBasis]
+  rw [hcovol, ← hr]; simp [latticeEquiv, stdBasis]
 
 end CovolumeDet
 
@@ -775,99 +710,110 @@ section PoissonSummationLattices
 
 variable (L : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology L] [IsZLattice ℝ L]
 
-noncomputable def Aₗ : E ≃ₗ[ℝ] E := A L
-noncomputable def Bₗ : E →ₗ[ℝ] E := (Aₗ L).symm.toLinearMap.adjoint
-noncomputable def Aadjₗ : E →ₗ[ℝ] E := (Aₗ L).toLinearMap.adjoint
+/-- The adjoint of `(latticeEquiv L)⁻¹`; it carries the standard lattice onto the dual lattice
+`L*`, and is the engine of the change of variables on the spectral side of Poisson summation. -/
+noncomputable def Bₗ : E →ₗ[ℝ] E := (latticeEquiv L).symm.toLinearMap.adjoint
 
+/-- The adjoint of `latticeEquiv L`. Kept as a named definition: it is the two-sided inverse of
+`Bₗ L`, supplying `adjointSymmEquiv` with its inverse map. -/
+noncomputable def Aadjₗ : E →ₗ[ℝ] E := (latticeEquiv L).toLinearMap.adjoint
+
+/-- `latticeEquiv L` restricted to a `ℤ`-linear equivalence from the standard lattice `ℤ^d` onto
+`L`. Kept as a named definition: it transports lattice sums between `ℤ^d` and `L`. -/
 noncomputable def equivStandardLattice : SchwartzMap.standardLattice d ≃ₗ[ℤ] L :=
-  (LinearEquiv.restrictScalars ℤ (Aₗ L)).ofSubmodules (SchwartzMap.standardLattice d) L
+  (LinearEquiv.restrictScalars ℤ (latticeEquiv L)).ofSubmodules (SchwartzMap.standardLattice d) L
     (by simpa [LinearEquiv.restrictScalars_apply] using map_standardLattice_eq (d := d) L)
 
 @[simp] lemma equivStandardLattice_apply (x : SchwartzMap.standardLattice d) :
-    ((equivStandardLattice (d := d) L x : L) : E) = (Aₗ L) x := by simp [equivStandardLattice]
+    ((equivStandardLattice (d := d) L x : L) : E) = (latticeEquiv L) x := by
+  simp [equivStandardLattice]
 
-lemma Bₗ_comp_Aadjₗ : (Bₗ L ∘ₗ Aadjₗ L) = (LinearMap.id : E →ₗ[ℝ] E) := by
+lemma Bₗ_comp_Aadjₗ : Bₗ L ∘ₗ Aadjₗ L = (LinearMap.id : E →ₗ[ℝ] E) := by
   simp [Bₗ, Aadjₗ, ← LinearMap.adjoint_comp,
-    show (Aₗ L).toLinearMap ∘ₗ (Aₗ L).symm.toLinearMap = LinearMap.id from by ext x; simp]
+    show (latticeEquiv L).toLinearMap ∘ₗ (latticeEquiv L).symm.toLinearMap = LinearMap.id from by
+      ext x; simp]
 
+lemma Aadjₗ_comp_Bₗ : Aadjₗ L ∘ₗ Bₗ L = (LinearMap.id : E →ₗ[ℝ] E) := by
+  simp [Bₗ, Aadjₗ, ← LinearMap.adjoint_comp,
+    show (latticeEquiv L).symm.toLinearMap ∘ₗ (latticeEquiv L).toLinearMap = LinearMap.id from by
+      ext x; simp]
+
+/-- `Bₗ L` as a linear automorphism of `E`, with inverse `Aadjₗ L`. Kept as a named definition: it
+realizes the standard-lattice-to-dual-lattice transport as an equivalence, so its `tsum_eq`
+reindexes the spectral sum. -/
 noncomputable def adjointSymmEquiv : E ≃ₗ[ℝ] E where
   toLinearMap := Bₗ L
   invFun := Aadjₗ L
-  left_inv x := by
-    simpa using congrArg (fun f : E →ₗ[ℝ] E => f x) (show Aadjₗ L ∘ₗ Bₗ L = LinearMap.id by
-      simp [Bₗ, Aadjₗ, ← LinearMap.adjoint_comp,
-        show (Aₗ L).symm.toLinearMap ∘ₗ (Aₗ L).toLinearMap = LinearMap.id from by ext x; simp])
-  right_inv x := by simpa using congrArg (fun f : E →ₗ[ℝ] E => f x) (Bₗ_comp_Aadjₗ L)
+  left_inv x := by simpa using DFunLike.congr_fun (Aadjₗ_comp_Bₗ L) x
+  right_inv x := by simpa using DFunLike.congr_fun (Bₗ_comp_Aadjₗ L) x
 
 lemma map_standardLattice_adjointSymm_eq_dualSubmodule :
     Submodule.map ((Bₗ L).restrictScalars ℤ) (standardLattice d) = dualLattice (d := d) L := by
-  ext x
+  have hmapL : Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
+      (standardLattice d) = L := map_standardLattice_eq (d := d) L
   have hdualStd : dualLattice (d := d) (standardLattice d) = standardLattice d := by
     simpa [dualLattice] using PoissonSummation.Standard.dualSubmodule_standardLattice_eq (d := d)
+  have hBA (y w : E) : inner ℝ ((Bₗ L) y) ((latticeEquiv L) w) = inner ℝ y w := by
+    simpa [Bₗ] using LinearMap.adjoint_inner_left ((latticeEquiv L).symm.toLinearMap)
+      ((latticeEquiv L) w) y
+  have hAadj (p w : E) : inner ℝ ((Aadjₗ L) p) w = inner ℝ p ((latticeEquiv L) w) := by
+    simpa [Aadjₗ] using LinearMap.adjoint_inner_left ((latticeEquiv L).toLinearMap) w p
+  ext x
   refine ⟨?_, fun hx => ⟨(Aadjₗ L) x, ?_, ?_⟩⟩
   · rintro ⟨y, hy, rfl⟩ z hz
-    obtain ⟨w, hw, rfl⟩ : (z : E) ∈
-        Submodule.map ((Aₗ L).toLinearMap.restrictScalars ℤ) (standardLattice d) := by
-      simpa [Aₗ, map_standardLattice_eq (d := d) L] using hz
-    simpa [dualLattice, innerₗ_apply_apply,
-      show inner ℝ ((Bₗ L) y) ((Aₗ L) w) = inner ℝ y w from by
-        simpa [Bₗ, Aₗ] using LinearMap.adjoint_inner_left
-          ((Aₗ L).symm.toLinearMap) ((Aₗ L) w) y] using
+    obtain ⟨w, hw, rfl⟩ : (z : E) ∈ Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
+        (standardLattice d) := by rw [hmapL]; exact hz
+    simpa [dualLattice, innerₗ_apply_apply, hBA] using
       (by simpa [hdualStd] using hy : y ∈ dualLattice (d := d) (standardLattice d)) w hw
   · suffices hydual : (Aadjₗ L) x ∈ dualLattice (d := d) (standardLattice d) by
       simpa [hdualStd] using hydual
     intro w hw
-    have hwL : (Aₗ L) w ∈ L := by
-      have : (Aₗ L) w ∈ Submodule.map ((Aₗ L).toLinearMap.restrictScalars ℤ)
-          (standardLattice d) := ⟨w, hw, rfl⟩
-      simpa [Aₗ, map_standardLattice_eq (d := d) L] using this
-    simpa [dualLattice, innerₗ_apply_apply,
-      show inner ℝ ((Aadjₗ L) x) w = inner ℝ x ((Aₗ L) w) from by
-        simpa [Aadjₗ, Aₗ] using LinearMap.adjoint_inner_left ((Aₗ L).toLinearMap) w x] using
-      hx ((Aₗ L) w) hwL
-  · simpa using congrArg (fun f : E →ₗ[ℝ] E => f x) (Bₗ_comp_Aadjₗ L)
+    have hwL : (latticeEquiv L) w ∈ L := by
+      have hmem : (latticeEquiv L) w ∈ Submodule.map
+        ((latticeEquiv L).toLinearMap.restrictScalars ℤ) (standardLattice d) := ⟨w, hw, rfl⟩
+      rwa [hmapL] at hmem
+    simpa [dualLattice, innerₗ_apply_apply, hAadj] using hx ((latticeEquiv L) w) hwL
+  · simpa using DFunLike.congr_fun (Bₗ_comp_Aadjₗ L) x
 
-/-- LHS rewrite for `poissonSummation_lattice`: pull back the lattice sum along `A`. -/
+/-- LHS rewrite for `poissonSummation_lattice`: pull back the lattice sum along `latticeEquiv`. -/
 private lemma poissonSummation_lattice_lhs (f : SchwartzMap E ℂ) (v : E) :
-    (∑' ℓ : SchwartzMap.standardLattice d, f (v + (Aₗ L) (ℓ : E))) =
+    (∑' ℓ : SchwartzMap.standardLattice d, f (v + (latticeEquiv L) (ℓ : E))) =
       ∑' ℓ : L, f (v + (ℓ : E)) := by
   simpa [equivStandardLattice_apply] using
     (equivStandardLattice (d := d) L).toEquiv.tsum_eq (f := fun ℓ : L => f (v + (ℓ : E)))
 
-/-- Inner-product rewrite for exponentials: `⟪A.symm v, w⟫ = ⟪v, B w⟫`. -/
+/-- Inner-product rewrite for exponentials: `⟪(latticeEquiv L).symm v, w⟫ = ⟪v, Bₗ L w⟫`. -/
 private lemma poissonSummation_lattice_inner_swap (v w : E) :
-    ⟪(Aₗ L).symm v, w⟫_[ℝ] = ⟪v, (Bₗ L) w⟫_[ℝ] := by
-  rw [show ⟪(Aₗ L).symm v, w⟫_[ℝ] = inner ℝ ((Aₗ L).symm v) w from
-      (RCLike.inner_eq_wInner_one _ _).symm,
-    show ⟪v, (Bₗ L) w⟫_[ℝ] = inner ℝ v ((Bₗ L) w) from
-      (RCLike.inner_eq_wInner_one _ _).symm]
-  simpa [Bₗ] using
-    (LinearMap.adjoint_inner_right (((Aₗ L).symm : E ≃ₗ[ℝ] E).toLinearMap) v w).symm
+    ⟪(latticeEquiv L).symm v, w⟫_[ℝ] = ⟪v, (Bₗ L) w⟫_[ℝ] := by
+  simp only [← RCLike.inner_eq_wInner_one]
+  simpa [Bₗ] using (LinearMap.adjoint_inner_right ((latticeEquiv L).symm.toLinearMap) v w).symm
 
 /-- RHS rewrite for `poissonSummation_lattice`: descend the standard-lattice dual sum
-to the dual lattice `L*` along `B = (A.symm).adjoint`. -/
+to the dual lattice `L*` along `Bₗ = (latticeEquiv L).symm.adjoint`. -/
 private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
     (∑' n : Fin d → ℤ,
-        (𝓕 (fun x : E => f ((Aₗ L) x))
-          (SchwartzMap.PoissonSummation.Standard.intVec (d := d) n)) *
+        (𝓕 (fun x : E => f ((latticeEquiv L) x))
+          (intVec (d := d) n)) *
           Complex.exp (2 * π * Complex.I *
-            ⟪(Aₗ L).symm v, SchwartzMap.PoissonSummation.Standard.intVec (d := d) n⟫_[ℝ])) =
+            ⟪(latticeEquiv L).symm v, intVec (d := d) n⟫_[ℝ])) =
       (1 / ZLattice.covolume L) *
         ∑' m : dualLattice (d := d) L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
+  -- Abbreviations: the dual-lattice summand `F`, the determinant `detA` of the change of
+  -- variables and its reciprocal `cC = |detA|⁻¹`, and the integer-vector embedding `iv`.
   let F : dualLattice (d := d) L → ℂ :=
     fun m => (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ])
-  let detA : ℝ := (LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((Aₗ L) : E →ₗ[ℝ] E)
+  let detA : ℝ := (LinearMap.det : (E →ₗ[ℝ] E) →* ℝ) ((latticeEquiv L) : E →ₗ[ℝ] E)
   let cC : ℂ := ((abs detA)⁻¹ : ℝ)
-  let iv : (Fin d → ℤ) → E := SchwartzMap.PoissonSummation.Standard.intVec (d := d)
-  have hfourier (w : E) : 𝓕 (fun x : E => f ((Aₗ L) x)) w =
+  let iv : (Fin d → ℤ) → E := intVec (d := d)
+  have hfourier (w : E) : 𝓕 (fun x : E => f ((latticeEquiv L) x)) w =
       cC * 𝓕 (fun x : E => f x) ((Bₗ L) w) := by
     simpa [Bₗ, detA, cC, Complex.real_smul] using
       SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv
-        (A := Aₗ L) (f := fun x : E => f x) w
-  rw [show (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((Aₗ L) x)) (iv n)) *
-            Complex.exp (2 * π * Complex.I * ⟪(Aₗ L).symm v, iv n⟫_[ℝ])) =
-        cC * ∑' m : dualLattice (d := d) L, F m from by
+        (A := latticeEquiv L) (f := fun x : E => f x) w
+  have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (iv n)) *
+        Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, iv n⟫_[ℝ])) =
+      cC * ∑' m : dualLattice (d := d) L, F m := by
     rw [← (PoissonSummation.Standard.equivIntVec.trans
       ((LinearEquiv.restrictScalars ℤ (adjointSymmEquiv L)).ofSubmodules _ _ <| by
           simpa [LinearEquiv.restrictScalars_apply] using
@@ -876,9 +822,10 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
     exact tsum_congr fun n ↦ by
       simpa [F, mul_assoc, poissonSummation_lattice_inner_swap (L := L) v (w := iv n)] using
         congrArg (· * Complex.exp (2 * π * Complex.I * ⟪v, (Bₗ L) (iv n)⟫_[ℝ]))
-          (hfourier (w := iv n))]
+          (hfourier (w := iv n))
+  rw [hreindex]
   simp [F, cC, show ZLattice.covolume L = abs detA from by
-    simpa [Aₗ, detA] using covolume_eq_abs_det_A (d := d) (L := L), one_div]
+    simpa [latticeEquiv, detA] using covolume_eq_abs_det_latticeEquiv (d := d) (L := L), one_div]
 
 /-- Poisson summation over a full-rank `ℤ`-lattice `L`. -/
 public theorem poissonSummation_lattice (f : SchwartzMap E ℂ) (v : E) :
@@ -886,24 +833,29 @@ public theorem poissonSummation_lattice (f : SchwartzMap E ℂ) (v : E) :
       (1 / ZLattice.covolume L) *
         ∑' m : dualLattice (d := d) L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
-  let A : E ≃ₗ[ℝ] E := Aₗ L
+  -- `A` is the change of variables `ℤ^d → L`; `g = f ∘ A` is again Schwartz.
+  -- The local instance short-circuits a `ContinuousSMul ℝ E` search that otherwise loops on
+  -- `EuclideanSpace`'s `PiLp` structure inside `LinearEquiv.toContinuousLinearEquiv`.
+  have : ContinuousSMul ℝ E := inferInstance
+  let A : E ≃ₗ[ℝ] E := latticeEquiv L
   let g : SchwartzMap E ℂ :=
     SchwartzMap.compCLMOfContinuousLinearEquiv ℂ A.toContinuousLinearEquiv f
   have hlhs : (∑' ℓ : SchwartzMap.standardLattice d, g (A.symm v + (ℓ : E))) =
       ∑' ℓ : L, f (v + (ℓ : E)) := by
-    rw [tsum_congr (fun ℓ : SchwartzMap.standardLattice d => by simp [g, map_add] :
-      ∀ ℓ : SchwartzMap.standardLattice d, g (A.symm v + (ℓ : E)) = f (v + A (ℓ : E)))]
+    have hg : ∀ ℓ : SchwartzMap.standardLattice d,
+        g (A.symm v + (ℓ : E)) = f (v + A (ℓ : E)) := fun ℓ => by simp [g, map_add]
+    rw [tsum_congr hg]
     exact poissonSummation_lattice_lhs (L := L) f v
   have hrhs : (∑' n : Fin d → ℤ,
-        (𝓕 (fun x : E => g x) (SchwartzMap.PoissonSummation.Standard.intVec (d := d) n)) *
+        (𝓕 (fun x : E => g x) (intVec (d := d) n)) *
           Complex.exp (2 * π * Complex.I *
-            ⟪A.symm v, SchwartzMap.PoissonSummation.Standard.intVec (d := d) n⟫_[ℝ])) =
+            ⟪A.symm v, intVec (d := d) n⟫_[ℝ])) =
       (1 / ZLattice.covolume L) *
         ∑' m : dualLattice (d := d) L,
           (𝓕 (fun x : E => f x) m) * Complex.exp (2 * π * Complex.I * ⟪v, m⟫_[ℝ]) := by
     simpa [g, A] using poissonSummation_lattice_rhs (L := L) f v
   simpa [hlhs, hrhs] using
-    SchwartzMap.PoissonSummation.Standard.poissonSummation_standard
+    poissonSummation_standard
       (d := d) (f := g) (v := A.symm v)
 
 end SchwartzMap.PoissonSummationLattices

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -166,10 +166,9 @@ public lemma dualSubmodule_standardLattice_eq :
   constructor
   · intro hx
     have hcoord : ∀ i : Fin d, ∃ n : ℤ, (n : ℝ) = x i := fun i ↦ by
-      have hmem : x i ∈ (1 : Submodule ℤ ℝ) := by
+      obtain ⟨n, hn⟩ := Submodule.mem_one.mp (show x i ∈ (1 : Submodule ℤ ℝ) by
         simpa [innerₗ_apply_apply, EuclideanSpace.inner_single_right] using
-          hx (EuclideanSpace.basisFun (Fin d) ℝ i) (Submodule.subset_span ⟨i, by simp⟩)
-      obtain ⟨n, hn⟩ := Submodule.mem_one.mp hmem
+          hx (EuclideanSpace.basisFun (Fin d) ℝ i) (Submodule.subset_span ⟨i, by simp⟩))
       exact ⟨n, by simpa using hn⟩
     choose n hn using hcoord
     have hx_eq : x = intVec (d := d) n := by ext i; simp [hn i]
@@ -531,41 +530,48 @@ private lemma mFourierCoeff_descended_eq_iocCube_integral (n : Fin d → ℤ) :
             fun _ _ => by simp [descended_comp (d := d) (f := f),
               periodization_apply (d := d) (f := f), smul_eq_mul]
 
+/-- The integrand `mFourier(-n)(coeFunE x) * f x` is integrable over `E`: it is `f` (integrable,
+being Schwartz) scaled by the factor `mFourier(-n) ∘ coeFunE`, which has norm `≤ 1`. -/
+lemma integrable_mFourier_mul (n : Fin d → ℤ) :
+    Integrable (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x)
+      (volume : Measure E) := by
+  simpa using Integrable.bdd_mul (μ := (volume : Measure E))
+    (SchwartzMap.integrable (μ := (volume : Measure E)) f)
+    (((UnitAddTorus.mFourier (-n)).continuous.comp
+      (continuous_coeFunE (d := d))).aestronglyMeasurable)
+    (ae_of_all _ fun x => by
+      simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
+        (ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) (coeFunE (d := d) x)))
+
+/-- Interchange of the cube-integral and the lattice sum: the cube-integral of
+`mFourier(-n)(coeFunE ·)` against the periodization is the lattice sum of the cube-integrals of the
+individual translates (`integral_tsum_of_summable_integral_norm`). -/
+lemma integral_iocCube_periodization_eq_tsum (n : Fin d → ℤ) :
+    (∫ x in iocCube (d := d),
+        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
+          (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
+      ∑' ℓ : Λ, ∫ x in iocCube (d := d),
+        UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E))
+          ∂(volume : Measure E) := by
+  simpa [tsum_mul_left, mul_assoc] using
+    (MeasureTheory.integral_tsum_of_summable_integral_norm
+        (μ := (volume : Measure E).restrict (iocCube (d := d)))
+        (F := fun ℓ : Λ => fun x : E =>
+          UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
+        (fun ℓ => by
+          simpa [IntegrableOn] using
+            (integrableOn_mFourier_mul_translate_iocCube (d := d) (f := f) n ℓ))
+        (summable_integral_norm_mFourier_mul_translate_iocCube (d := d) (f := f) n)).symm
+
 /-- The integral over the unit cube of `mFourier(-n)(coeFunE x)` times the periodization of `f`
 equals the integral of `mFourier(-n)(coeFunE x) * f x` over the whole space, by swapping the
-integral with the lattice sum and applying the fundamental-domain property of `iocCube`. -/
+integral with the lattice sum (`integral_iocCube_periodization_eq_tsum`) and applying the
+fundamental-domain property of `iocCube`. -/
 private lemma integral_iocCube_mFourier_periodization_eq_integral (n : Fin d → ℤ) :
     (∫ x in iocCube (d := d),
         UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
           (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
       ∫ x : E, UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x ∂(volume : Measure E) := by
-  have hint : Integrable
-      (fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x)
-      (volume : Measure E) := by
-    simpa using Integrable.bdd_mul (μ := (volume : Measure E))
-      (SchwartzMap.integrable (μ := (volume : Measure E)) f)
-      (((UnitAddTorus.mFourier (-n)).continuous.comp
-        (continuous_coeFunE (d := d))).aestronglyMeasurable)
-      (ae_of_all _ fun x => by
-        simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
-          (ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) (coeFunE (d := d) x)))
-  have hsum_int :
-      (∫ x in iocCube (d := d),
-            UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
-              (∑' ℓ : Λ, f (x + (ℓ : E))) ∂(volume : Measure E)) =
-        ∑' ℓ : Λ,
-          ∫ x in iocCube (d := d),
-            UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) *
-              f (x + (ℓ : E)) ∂(volume : Measure E) := by
-    simpa [tsum_mul_left, mul_assoc] using
-      (MeasureTheory.integral_tsum_of_summable_integral_norm
-          (μ := (volume : Measure E).restrict (iocCube (d := d)))
-          (F := fun ℓ : Λ => fun x : E =>
-            UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f (x + (ℓ : E)))
-          (fun ℓ => by
-            simpa [IntegrableOn] using
-              (integrableOn_mFourier_mul_translate_iocCube (d := d) (f := f) n ℓ))
-          (summable_integral_norm_mFourier_mul_translate_iocCube (d := d) (f := f) n)).symm
   -- `g` is the full integrand, abbreviated for the fundamental-domain unfolding below.
   let g : E → ℂ := fun x : E => UnitAddTorus.mFourier (-n) (coeFunE (d := d) x) * f x
   have hterm : ∀ ℓ : Λ,
@@ -576,9 +582,10 @@ private lemma integral_iocCube_mFourier_periodization_eq_integral (n : Fin d →
     integral_congr_ae <| ae_restrict_of_forall_mem (measurableSet_iocCube (d := d)) fun x _ => by
       simp [g, Submodule.vadd_def, vadd_eq_add, add_comm,
         mFourier_neg_apply_coeFunE_add_standardLattice (d := d) (n := n) (ℓ := ℓ) (x := x)]
-  rw [hsum_int]
+  rw [integral_iocCube_periodization_eq_tsum (d := d) (f := f) n]
   simpa [g, hterm] using
-    ((isAddFundamentalDomain_iocCube (d := d)).integral_eq_tsum'' g hint).symm
+    ((isAddFundamentalDomain_iocCube (d := d)).integral_eq_tsum'' g
+      (integrable_mFourier_mul (d := d) (f := f) n)).symm
 
 lemma mFourierCoeff_descended (n : Fin d → ℤ) :
     UnitAddTorus.mFourierCoeff (descended (d := d) f) n =
@@ -588,29 +595,36 @@ lemma mFourierCoeff_descended (n : Fin d → ℤ) :
   simp [Real.fourier_eq, Circle.smul_def, smul_eq_mul,
     mFourier_neg_apply_coeFunE (d := d) (n := n)]
 
+/-- Schwartz–Fourier decay over the lattice: `𝓕 f` is summable in norm over `Λ = ℤ^d`. The decay
+order `d + 1` exceeds the lattice rank, so `‖·‖⁻¹ ^ (d + 1)` is summable and dominates `𝓕 f`. -/
+lemma summable_norm_fourier_lattice :
+    Summable (fun ℓ : Λ => ‖𝓕 (fun y : E => f y) (ℓ : E)‖) := by
+  have hrank : Module.finrank ℤ Λ = d := by
+    simpa using (ZLattice.rank (K := ℝ) (L := Λ)).trans (by simp)
+  have hk : Module.finrank ℤ Λ < d + 1 := by omega
+  obtain ⟨C, _, hC⟩ := (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).decay (d + 1) 0
+  have hC' : ∀ x : E, ‖x‖ ^ (d + 1) * ‖𝓕 (fun y : E => f y) x‖ ≤ C := by
+    simpa [FourierTransform.fourierCLE_apply, fourier_coe, norm_iteratedFDeriv_zero] using hC
+  refine Summable.of_norm_bounded_eventually
+    ((by simpa using ZLattice.summable_norm_pow_inv (L := Λ) (n := d + 1) hk :
+      Summable (fun ℓ : Λ => (‖(ℓ : E)‖⁻¹ ^ (d + 1) : ℝ))).mul_left C) ?_
+  filter_upwards [(finite_norm_le_lattice (d := d) 1).compl_mem_cofinite] with ℓ hℓ
+  simpa [Real.norm_of_nonneg (norm_nonneg _), div_eq_mul_inv, inv_pow, one_div] using
+    (le_div_iff₀' (pow_pos (lt_trans (by positivity)
+      (lt_of_not_ge (by simpa using hℓ) : (1 : ℝ) < ‖(ℓ : E)‖)) _)).2 (hC' (ℓ : E))
+
+/-- The Fourier-decay summability of `summable_norm_fourier_lattice`, reindexed over `ℤ^d` along
+`equivIntVec`. -/
+lemma summable_norm_fourier_intVec :
+    Summable (fun n : Fin d → ℤ => ‖𝓕 (fun x : E => f x) (intVec (d := d) n)‖) := by
+  simpa [equivIntVec] using (summable_norm_fourier_lattice (d := d) (f := f)).comp_injective
+    (equivIntVec (d := d)).injective
+
 lemma summable_mFourierCoeff_descended :
-    Summable (UnitAddTorus.mFourierCoeff (descended (d := d) f)) := by
-  have hsum_norm : Summable (fun n : Fin d → ℤ =>
-      ‖𝓕 (fun x : E => f x) (intVec (d := d) n)‖) := by
-    -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable.
-    let k : ℕ := d + 1
-    have hrank : Module.finrank ℤ Λ = d := by
-      simpa using (ZLattice.rank (K := ℝ) (L := Λ)).trans (by simp)
-    have hk : Module.finrank ℤ Λ < k := by simp [hrank, k]
-    obtain ⟨C, _, hC⟩ := (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).decay k 0
-    have hC' : ∀ x : E, ‖x‖ ^ k * ‖𝓕 (fun y : E => f y) x‖ ≤ C := by
-      simpa [FourierTransform.fourierCLE_apply, fourier_coe, norm_iteratedFDeriv_zero] using hC
-    have hsum_lattice : Summable (fun ℓ : Λ => ‖𝓕 (fun y : E => f y) (ℓ : E)‖) := by
-      refine Summable.of_norm_bounded_eventually
-        ((by simpa [k] using ZLattice.summable_norm_pow_inv (L := Λ) (n := k) hk :
-          Summable (fun ℓ : Λ => (‖(ℓ : E)‖⁻¹ ^ k : ℝ))).mul_left C) ?_
-      filter_upwards [(finite_norm_le_lattice (d := d) 1).compl_mem_cofinite] with ℓ hℓ
-      simpa [Real.norm_of_nonneg (norm_nonneg _), div_eq_mul_inv, inv_pow, one_div] using
-        (le_div_iff₀' (pow_pos (lt_trans (by positivity)
-          (lt_of_not_ge (by simpa using hℓ) : (1 : ℝ) < ‖(ℓ : E)‖)) _)).2 (hC' (ℓ : E))
-    simpa [equivIntVec] using
-      hsum_lattice.comp_injective (equivIntVec (d := d)).injective
-  exact Summable.of_norm (by simpa [mFourierCoeff_descended (d := d) (f := f)] using hsum_norm)
+    Summable (UnitAddTorus.mFourierCoeff (descended (d := d) f)) :=
+  Summable.of_norm <| by
+    simpa [mFourierCoeff_descended (d := d) (f := f)] using
+      summable_norm_fourier_intVec (d := d) (f := f)
 
 /-- Poisson summation for Schwartz functions over the standard lattice `ℤ^d`. -/
 public theorem poissonSummation_standard (v : E) :

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -4,8 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib
-public import SpherePacking.ForMathlib.DualLattice
+public import Mathlib.Algebra.Module.ZLattice.Covolume
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import Mathlib.Analysis.RCLike.Inner
+public import Mathlib.Data.Real.Hom
+public import Mathlib.Data.Real.StarOrdered
+public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
+public import Mathlib.Topology.Separation.CompletelyRegular
+
 public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.SchwartzLatticeSummable
 public import SpherePacking.ForMathlib.UnitAddTorusQuotient

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -32,28 +32,25 @@ open MeasureTheory
 namespace SchwartzMap
 
 variable {d : ℕ}
-variable (Λ : Submodule ℤ (EuclideanSpace ℝ (Fin d))) [DiscreteTopology Λ] [IsZLattice ℝ Λ]
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
 
-section StandardLattice
-
-/-- The standard `ℤ`-lattice in `E = ℝ^d`, i.e. the span of the standard basis over `ℤ`. Kept as a
-named definition: it is the base lattice to which every full-rank lattice is reduced, and the
-domain of all the periodization/descent machinery. -/
-@[expose] public def standardLattice (d : ℕ) :
-    Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
-  Submodule.span ℤ (Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis))
-
-namespace standardLattice
-
-public instance instDiscreteTopology : DiscreteTopology (standardLattice d) :=
-  inferInstanceAs <| DiscreteTopology (Submodule.span ℤ (Set.range _))
-
-public instance instIsZLattice : IsZLattice ℝ (standardLattice d) :=
-  inferInstanceAs <| IsZLattice ℝ (Submodule.span ℤ (Set.range _))
-
-end StandardLattice.standardLattice
+/- The standard `ℤ`-lattice `ℤ^d ⊆ ℝ^d`, its dual for the Euclidean inner product, the
+fundamental cube `(0,1]^d`, and the `√d`-ball are *notation*, not definitions (following this
+project's pattern for such spellings, cf. `ℝ⁸` and the cube machinery in
+`ForMathlib/CoordCube.lean`): they elaborate literally to `Submodule.span`/`dualSubmodule`/
+set-builder/`Compacts.mk` terms, so Mathlib's lemmas and instances (`ZSpan`,
+`instDiscreteTopology_dualSubmodule_innerₗ`, …) apply to them directly and there is nothing to
+unfold. The right-hand sides are written projection-free for the notation precheck. -/
+local notation:max "standardLattice " d:max =>
+  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+local notation "iocCube" =>
+  {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
+local notation "sqrtdBall" =>
+  TopologicalSpace.Compacts.mk (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
+    (isCompact_closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
+local notation:max "dualLattice " L:max =>
+  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
 
 namespace PoissonSummation
 
@@ -74,30 +71,25 @@ sums and Fourier coefficients. -/
 
 /-- Every integer vector lies in the standard lattice. -/
 public lemma intVec_mem_standardLattice (k : Fin d → ℤ) :
-    intVec k ∈ SchwartzMap.standardLattice d :=
+    intVec k ∈ standardLattice d :=
   (Module.Basis.mem_span_iff_repr_mem ℤ _ _).2 fun i ↦ ⟨k i, rfl⟩
 
 open TopologicalSpace UnitAddTorus
 
-/-- The half-open cube `(0,1]^d`. Kept as a named definition: it is the explicit fundamental domain
-for `ℤ^d` (`isAddFundamentalDomain_iocCube`) over which every torus integral is unfolded. -/
-public def iocCube : Set E := {x | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
-
 /-- The half-open cube `(0,1]^d` is measurable. -/
-public lemma measurableSet_iocCube : MeasurableSet (iocCube (d := d)) := by
-  unfold iocCube
+public lemma measurableSet_iocCube : MeasurableSet (iocCube) := by
   measurability
 
 /-- Every element of the standard lattice comes from an integer vector via `intVec`. -/
 public lemma exists_intVec_eq_of_mem_standardLattice (x : E)
-    (hx : x ∈ SchwartzMap.standardLattice d) : ∃ n : Fin d → ℤ, x = intVec n := by
+    (hx : x ∈ standardLattice d) : ∃ n : Fin d → ℤ, x = intVec n := by
   choose n hn using ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis.mem_span_iff_repr_mem ℤ x).1 hx
   exact ⟨n, PiLp.ext fun i => (hn i).symm⟩
 
 /-- The dual of the standard lattice (for the Euclidean inner product) is the standard lattice. -/
 public lemma dualSubmodule_standardLattice_eq :
     LinearMap.BilinForm.dualSubmodule (B := (innerₗ E : LinearMap.BilinForm ℝ E))
-        (SchwartzMap.standardLattice d) = SchwartzMap.standardLattice d := by
+        (standardLattice d) = standardLattice d := by
   ext x
   constructor
   · intro hx
@@ -145,7 +137,7 @@ public theorem exists_intVec_eq_sub_of_coeFunE_eq {x y : E}
 
 /-- The cube `iocCube` is a fundamental domain for translation by the standard lattice. -/
 public theorem isAddFundamentalDomain_iocCube :
-    MeasureTheory.IsAddFundamentalDomain (SchwartzMap.standardLattice d)
+    MeasureTheory.IsAddFundamentalDomain (standardLattice d)
       (iocCube) (volume : Measure E) := by
   refine MeasureTheory.IsAddFundamentalDomain.mk'
     (measurableSet_iocCube).nullMeasurableSet fun x ↦ ?_
@@ -173,7 +165,7 @@ public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) �
   have hmp : MeasurePreserving (⇑f) (volume : Measure (Fin d → ℝ)) (volume : Measure E) := by
     simpa [f] using PiLp.volume_preserving_toLp (ι := Fin d)
   have hpre : f ⁻¹' iocCube = Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1 := by
-    ext x; simp [f, iocCube]
+    ext x; simp [f]
   calc
     (∫ y : UnitAddTorus (Fin d), g y)
         = ∫ x, g (UnitAddTorus.coeFun (Fin d) x) ∂(volume : Measure (Fin d → ℝ)).restrict
@@ -193,7 +185,16 @@ namespace SchwartzMap.PoissonSummation.Standard
 variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
-local notation "Λ" => SchwartzMap.standardLattice d
+-- Re-declarations of the block-local notations from the top of the file (`local` scope ends with
+-- each namespace block).
+local notation:max "standardLattice " d:max =>
+  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+local notation "iocCube" =>
+  {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
+local notation "sqrtdBall" =>
+  TopologicalSpace.Compacts.mk (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
+    (isCompact_closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
+local notation "Λ" => standardLattice d
 
 /-- The canonical equivalence between integer vectors `Fin d → ℤ` and the standard lattice
 `Λ = ℤ^d ⊆ ℝ^d`. Kept as a named definition: it reindexes sums over the lattice as sums over
@@ -229,12 +230,7 @@ continuous maps. -/
 /-- Schwartz decay: sup norms of translates restricted to a compact `K` are summable. -/
 public lemma summable_norm_translate_restrict (K : TopologicalSpace.Compacts E) :
     Summable (fun ℓ : Λ => ‖(translate f ℓ).restrict K‖) :=
-  f.summable_norm_restrict_comp_addRight (SchwartzMap.standardLattice d) K
-
-/-- The quotient map `coeFunE`, bundled as a continuous map. This packaging is what the
-`IsQuotientMap.lift`/`FactorsThrough` API consumes when descending periodic maps to the torus. -/
-@[expose] public noncomputable def coeFunEC : C(E, UnitAddTorus (Fin d)) :=
-  ⟨coeFunE, continuous_coeFunE⟩
+  f.summable_norm_restrict_comp_addRight (standardLattice d) K
 
 section Periodization
 
@@ -259,9 +255,9 @@ public lemma periodization_add_lattice (x : E) (ℓ : Λ) :
 
 /-- The periodization factors through the quotient `(ℝ/ℤ)^d`. -/
 public lemma periodization_factorsThrough :
-    Function.FactorsThrough (periodization f) (coeFunEC) := by
+    Function.FactorsThrough (periodization f) (coeFunE) := by
   intro x y hxy
-  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq (by simpa [coeFunEC] using hxy)
+  obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq hxy
   have hx : x = y + intVec n := by rw [← hn]; abel
   rw [hx]
   exact periodization_add_lattice f y ⟨_, intVec_mem_standardLattice n⟩
@@ -286,7 +282,7 @@ public lemma descended_comp (x : E) :
     descended f (coeFunE x) = periodization f x :=
   congrArg (fun g : C(E, ℂ) => g x)
     (by simp [descended] :
-      (descended f).comp (coeFunEC) = periodization f)
+      (descended f).comp ⟨coeFunE, continuous_coeFunE⟩ = periodization f)
 
 public lemma mFourier_neg_apply_coeFunE (n : Fin d → ℤ) (x : E) :
     UnitAddTorus.mFourier (-n) (coeFunE x) =
@@ -324,18 +320,12 @@ public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube) < ⊤ :=
   ((Metric.isBounded_closedBall (x := (0 : E)) (r := Real.sqrt d)).subset
     (iocCube_subset_closedBall)).measure_lt_top
 
-/-- The closed ball of radius `√d`, packaged as `Compacts E`; it contains the fundamental cube
-`iocCube`. Kept as a named definition: it is the single compact on which the Schwartz-decay
-summability `summable_norm_translate_restrict` is instantiated to bound the cube integrals. -/
-def sqrtdBall : TopologicalSpace.Compacts E :=
-  ⟨Metric.closedBall (0 : E) (Real.sqrt d), isCompact_closedBall (0 : E) (Real.sqrt d)⟩
-
 /-- On `iocCube`, the integrand `mFourier (-n) (coeFunE ·) * f (· + ℓ)` is bounded by the sup norm
 of the translate `f (· + ℓ)` restricted to `sqrtdBall`. -/
 lemma norm_mFourier_mul_translate_le (n : Fin d → ℤ) (ℓ : Λ) {x : E}
     (hx : x ∈ iocCube) :
     ‖UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))‖ ≤
-      ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
+      ‖(translate f ℓ).restrict (sqrtdBall)‖ := by
   rw [norm_mul]
   calc ‖UnitAddTorus.mFourier (-n) (coeFunE x)‖ * ‖f (x + (ℓ : E))‖
       ≤ 1 * ‖f (x + (ℓ : E))‖ := by
@@ -343,9 +333,9 @@ lemma norm_mFourier_mul_translate_le (n : Fin d → ℤ) (ℓ : Λ) {x : E}
         simpa [UnitAddTorus.mFourier_norm (d := Fin d) (n := -n)] using
           ContinuousMap.norm_coe_le_norm (UnitAddTorus.mFourier (-n)) _
     _ = ‖f (x + (ℓ : E))‖ := one_mul _
-    _ ≤ ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
+    _ ≤ ‖(translate f ℓ).restrict (sqrtdBall)‖ := by
         simpa [translate_apply, ContinuousMap.restrict_apply] using
-          ContinuousMap.norm_coe_le_norm ((translate f ℓ).restrict (sqrtdBall (d := d)))
+          ContinuousMap.norm_coe_le_norm ((translate f ℓ).restrict (sqrtdBall))
             ⟨x, iocCube_subset_closedBall hx⟩
 
 public lemma integrableOn_mFourier_mul_translate_iocCube (n : Fin d → ℤ) (ℓ : Λ) :
@@ -372,11 +362,11 @@ lemma summable_integral_norm_mFourier_mul_translate_iocCube (n : Fin d → ℤ) 
   refine ((summable_norm_translate_restrict f (sqrtdBall)).mul_left
     (μ.real Set.univ)).of_nonneg_of_le (fun _ => by positivity) fun ℓ => ?_
   calc ∫ x, ‖UnitAddTorus.mFourier (-n) (coeFunE x) * f (x + (ℓ : E))‖ ∂μ
-      ≤ ∫ _, ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ ∂μ :=
+      ≤ ∫ _, ‖(translate f ℓ).restrict (sqrtdBall)‖ ∂μ :=
         integral_mono_of_nonneg (ae_of_all _ fun _ => norm_nonneg _) (integrable_const _)
           (ae_restrict_of_forall_mem (measurableSet_iocCube) fun x hx =>
             norm_mFourier_mul_translate_le f n ℓ hx)
-    _ = μ.real Set.univ * ‖(translate f ℓ).restrict (sqrtdBall (d := d))‖ := by
+    _ = μ.real Set.univ * ‖(translate f ℓ).restrict (sqrtdBall)‖ := by
         rw [integral_const, smul_eq_mul]
 
 /-- The ambient `volume` on `UnitAddCircle` is the probability measure `haarAddCircle` baked into
@@ -495,7 +485,7 @@ lemma summable_norm_fourier_lattice :
     Summable (fun ℓ : Λ => ‖𝓕 (fun y : E => f y) (ℓ : E)‖) := by
   simpa [FourierTransform.fourierCLE_apply, fourier_coe] using
     (FourierTransform.fourierCLE ℂ (SchwartzMap E ℂ) f).summable_norm_comp_add
-      (SchwartzMap.standardLattice d) 0
+      (standardLattice d) 0
 
 /-- The Fourier-decay summability of `summable_norm_fourier_lattice`, reindexed over `ℤ^d` along
 `equivIntVec`. -/
@@ -533,12 +523,13 @@ open SchwartzMap.PoissonSummation.Standard
 variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
-
-/-- The dual `ℤ`-lattice with respect to the Euclidean inner product. Kept as a named abbreviation:
-it is the index set of the spectral side of Poisson summation and is part of this file's public
-API (used downstream in the linear-programming bound). -/
-public noncomputable abbrev dualLattice (L : Submodule ℤ E) : Submodule ℤ E :=
-  LinearMap.BilinForm.dualSubmodule (B := (innerₗ E : LinearMap.BilinForm ℝ E)) L
+-- Re-declarations of the block-local notations from the top of the file (`local` scope ends with
+-- each namespace block). `dualLattice L` is the dual `ℤ`-lattice for the Euclidean inner product:
+-- the index set of the spectral side of Poisson summation.
+local notation:max "standardLattice " d:max =>
+  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+local notation:max "dualLattice " L:max =>
+  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
 
 /-- A `Fin d`-indexed integral basis of the `ℤ`-lattice `L` (Mathlib's `chooseBasis` reindexed
 along `finrank ℤ L = d`). Kept as a named definition: a fixed integral frame for `L` whose
@@ -576,16 +567,16 @@ lemma latticeEquiv_apply_basisFun (L : Submodule ℤ E) [DiscreteTopology L] [Is
 
 lemma map_standardLattice_eq (L : Submodule ℤ E) [DiscreteTopology L] [IsZLattice ℝ L] :
     Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
-        (SchwartzMap.standardLattice d) = L := by
+        (standardLattice d) = L := by
   have hrange : (fun a : E => latticeEquiv L a) ''
         Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis) =
       Set.range (rBasis L) := by
     rw [← Set.range_comp]; simp only [Function.comp_def, latticeEquiv_apply_basisFun]
   calc Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
-          (SchwartzMap.standardLattice d)
+          (standardLattice d)
       = Submodule.span ℤ ((fun a : E => latticeEquiv L a) ''
             Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) := by
-        simp [SchwartzMap.standardLattice, Submodule.map_span]
+        simp [Submodule.map_span]
     _ = Submodule.span ℤ (Set.range (rBasis L)) := by rw [hrange]
     _ = L := by
         simpa [rBasis] using Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis L)
@@ -646,11 +637,11 @@ lemma dualEquiv_symm_apply (x : E) :
 
 /-- `latticeEquiv L` restricted to a `ℤ`-linear equivalence from the standard lattice `ℤ^d` onto
 `L`. Kept as a named definition: it transports lattice sums between `ℤ^d` and `L`. -/
-noncomputable def equivStandardLattice : SchwartzMap.standardLattice d ≃ₗ[ℤ] L :=
-  (LinearEquiv.restrictScalars ℤ (latticeEquiv L)).ofSubmodules (SchwartzMap.standardLattice d) L
+noncomputable def equivStandardLattice : standardLattice d ≃ₗ[ℤ] L :=
+  (LinearEquiv.restrictScalars ℤ (latticeEquiv L)).ofSubmodules (standardLattice d) L
     (by simpa [LinearEquiv.restrictScalars_apply] using map_standardLattice_eq L)
 
-@[simp] lemma equivStandardLattice_apply (x : SchwartzMap.standardLattice d) :
+@[simp] lemma equivStandardLattice_apply (x : standardLattice d) :
     ((equivStandardLattice L x : L) : E) = (latticeEquiv L) x := by
   simp [equivStandardLattice]
 
@@ -661,8 +652,8 @@ lemma map_standardLattice_dualEquiv_eq :
       dualLattice L := by
   have hmapL : Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
       (standardLattice d) = L := map_standardLattice_eq L
-  have hdualStd : dualLattice (standardLattice d) = standardLattice d := by
-    simpa [dualLattice] using PoissonSummation.Standard.dualSubmodule_standardLattice_eq
+  have hdualStd : dualLattice (standardLattice d) = standardLattice d :=
+    PoissonSummation.Standard.dualSubmodule_standardLattice_eq
   have hBA (y w : E) : inner ℝ (dualEquiv L y) ((latticeEquiv L) w) = inner ℝ y w := by
     simpa [dualEquiv_apply] using LinearMap.adjoint_inner_left ((latticeEquiv L).symm.toLinearMap)
       ((latticeEquiv L) w) y
@@ -674,7 +665,7 @@ lemma map_standardLattice_dualEquiv_eq :
   · rintro ⟨y, hy, rfl⟩ z hz
     obtain ⟨w, hw, rfl⟩ : (z : E) ∈ Submodule.map ((latticeEquiv L).toLinearMap.restrictScalars ℤ)
         (standardLattice d) := by rw [hmapL]; exact hz
-    simpa [dualLattice, innerₗ_apply_apply, hBA] using
+    simpa [innerₗ_apply_apply, hBA] using
       (by simpa [hdualStd] using hy : y ∈ dualLattice (standardLattice d)) w hw
   · suffices hydual : (dualEquiv L).symm x ∈ dualLattice (standardLattice d) by
       simpa [hdualStd] using hydual
@@ -683,12 +674,12 @@ lemma map_standardLattice_dualEquiv_eq :
       have hmem : (latticeEquiv L) w ∈ Submodule.map
         ((latticeEquiv L).toLinearMap.restrictScalars ℤ) (standardLattice d) := ⟨w, hw, rfl⟩
       rwa [hmapL] at hmem
-    simpa [dualLattice, innerₗ_apply_apply, hAadj] using hx ((latticeEquiv L) w) hwL
+    simpa [innerₗ_apply_apply, hAadj] using hx ((latticeEquiv L) w) hwL
   · simp
 
 /-- LHS rewrite for `poissonSummation_lattice`: pull back the lattice sum along `latticeEquiv`. -/
 private lemma poissonSummation_lattice_lhs (f : SchwartzMap E ℂ) (v : E) :
-    (∑' ℓ : SchwartzMap.standardLattice d, f (v + (latticeEquiv L) (ℓ : E))) =
+    (∑' ℓ : standardLattice d, f (v + (latticeEquiv L) (ℓ : E))) =
       ∑' ℓ : L, f (v + (ℓ : E)) := by
   simpa [equivStandardLattice_apply] using
     (equivStandardLattice L).toEquiv.tsum_eq (f := fun ℓ : L => f (v + (ℓ : E)))
@@ -751,9 +742,9 @@ public theorem poissonSummation_lattice (f : SchwartzMap E ℂ) (v : E) :
   let A : E ≃ₗ[ℝ] E := latticeEquiv L
   let g : SchwartzMap E ℂ :=
     SchwartzMap.compCLMOfContinuousLinearEquiv ℂ A.toContinuousLinearEquiv f
-  have hlhs : (∑' ℓ : SchwartzMap.standardLattice d, g (A.symm v + (ℓ : E))) =
+  have hlhs : (∑' ℓ : standardLattice d, g (A.symm v + (ℓ : E))) =
       ∑' ℓ : L, f (v + (ℓ : E)) := by
-    have hg : ∀ ℓ : SchwartzMap.standardLattice d,
+    have hg : ∀ ℓ : standardLattice d,
         g (A.symm v + (ℓ : E)) = f (v + A (ℓ : E)) := fun ℓ => by simp [g, map_add]
     rw [tsum_congr hg]
     exact poissonSummation_lattice_lhs (L := L) f v

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -54,14 +54,6 @@ public instance instIsZLattice : IsZLattice ℝ (standardLattice d) :=
 
 end standardLattice
 
-/- The fundamental cube `(0,1]^d` is *notation*, not a definition (cf. the cube machinery in
-`ForMathlib/CoordCube.lean`): it elaborates literally to the set-builder, so membership is
-judgemental and there is nothing to unfold. The precheck is disabled because Mathlib's set-builder
-syntax has no `quot_precheck` support. -/
-set_option quotPrecheck false in
-local notation "iocCube" =>
-  {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
-
 namespace PoissonSummation
 
 namespace Standard
@@ -86,8 +78,16 @@ public lemma intVec_mem_standardLattice (k : Fin d → ℤ) :
 
 open TopologicalSpace UnitAddTorus
 
+/-- The half-open cube `(0,1]^d`, the explicit fundamental domain for `ℤ^d`
+(`isAddFundamentalDomain_iocCube`) over which every torus integral is unfolded. Deliberately a
+definition rather than an inline set-builder: the integral-bridge proofs below carry it through
+`simpa`, where `Set.mem_Ioc`/`Set.preimage_setOf_eq` would normalize a bare set-builder's body and
+detach the terms from the statements. The constant shields the spelling (cf. `standardLattice`). -/
+public def iocCube : Set E := {x | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
+
 /-- The half-open cube `(0,1]^d` is measurable. -/
-public lemma measurableSet_iocCube : MeasurableSet (iocCube) := by
+public lemma measurableSet_iocCube : MeasurableSet (iocCube (d := d)) := by
+  unfold iocCube
   measurability
 
 /-- Every element of the standard lattice comes from an integer vector via `intVec`. -/
@@ -175,7 +175,7 @@ public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) �
   have hmp : MeasurePreserving (⇑f) (volume : Measure (Fin d → ℝ)) (volume : Measure E) := by
     simpa [f] using PiLp.volume_preserving_toLp (ι := Fin d)
   have hpre : f ⁻¹' iocCube = Set.univ.pi fun _ : Fin d ↦ Set.Ioc (0 : ℝ) 1 := by
-    ext x; simp [f]
+    ext x; simp [f, iocCube]
   calc
     (∫ y : UnitAddTorus (Fin d), g y)
         = ∫ x, g (UnitAddTorus.coeFun (Fin d) x) ∂(volume : Measure (Fin d → ℝ)).restrict
@@ -195,11 +195,7 @@ namespace SchwartzMap.PoissonSummation.Standard
 variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
--- Re-declarations of the block-local notations from the top of the file (`local` scope ends with
--- each namespace block), plus the `√d`-ball as a `Compacts.mk` spelling.
-set_option quotPrecheck false in
-local notation "iocCube" =>
-  {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
+-- The `√d`-ball as an inline `Compacts.mk` spelling (notation, not a definition).
 local notation "sqrtdBall" =>
   TopologicalSpace.Compacts.mk (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
     (isCompact_closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
@@ -585,7 +581,7 @@ lemma map_standardLattice_eq (L : Submodule ℤ E) [DiscreteTopology L] [IsZLatt
           (standardLattice d)
       = Submodule.span ℤ ((fun a : E => latticeEquiv L a) ''
             Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis)) := by
-        simp [Submodule.map_span]
+        simp [SchwartzMap.standardLattice, Submodule.map_span]
     _ = Submodule.span ℤ (Set.range (rBasis L)) := by rw [hrange]
     _ = L := by
         simpa [rBasis] using Module.Basis.ofZLatticeBasis_span (K := ℝ) (L := L) (b := zBasis L)

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -16,14 +16,18 @@ public import SpherePacking.ForMathlib.FourierComp
 public import SpherePacking.ForMathlib.SchwartzLatticeSummable
 public import SpherePacking.ForMathlib.UnitAddTorusQuotient
 
+import SpherePacking.ForMathlib.CoordCube
+
 /-! # Poisson summation for Schwartz functions
 
-Three layers:
+Two layers:
 
-* `SchwartzMap.PoissonSummation.Standard` — periodization, descent to the torus, Schwartz decay
-  bounds, and Poisson summation over the standard `ℤ^d` lattice.
-* `SchwartzMap.PoissonSummationLattices` — Poisson summation over a full-rank `ℤ`-lattice
-  `L ⊆ ℝ^d`, obtained from the standard case via a linear equivalence sending `ℤ^d` to `L`.
+* namespace `SchwartzMap.PoissonSummation.Standard` — periodization, descent to the torus,
+  Schwartz decay bounds, and Poisson summation over the standard `ℤ^d` lattice
+  (`poissonSummation_standard`).
+* section `PoissonSummationLattices` (declarations in namespace `SchwartzMap`) — Poisson
+  summation over a full-rank `ℤ`-lattice `L ⊆ ℝ^d` (`SchwartzMap.poissonSummation_lattice`),
+  obtained from the standard case via a linear equivalence sending `ℤ^d` onto `L`.
 -/
 
 open scoped BigOperators FourierTransform Real
@@ -88,7 +92,7 @@ public def iocCube : Set E := {x | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
 /-- The half-open cube `(0,1]^d` is measurable. -/
 public lemma measurableSet_iocCube : MeasurableSet (iocCube (d := d)) := by
   unfold iocCube
-  measurability
+  exact EuclideanSpace.measurableSet_cube measurableSet_Ioc
 
 /-- Every element of the standard lattice comes from an integer vector via `intVec`. -/
 public lemma exists_intVec_eq_of_mem_standardLattice (x : E)
@@ -165,8 +169,10 @@ public theorem isAddFundamentalDomain_iocCube :
     have hℓ' : x + intVec n' ∈ iocCube := by rw [add_comm, ← hn']; exact hℓ
     exact Subtype.ext (hn'.trans (congrArg (intVec) (hmem_unique n' hℓ')))
 
-/-- Pull back Haar integration on `(ℝ/ℤ)^d` to `iocCube` in `E = ℝ^d`. -/
-public theorem integral_eq_integral_preimage_coeFunE (g : UnitAddTorus (Fin d) → ℂ)
+/-- Pull back Haar integration on `(ℝ/ℤ)^d` to `iocCube` in `E = ℝ^d`, for any
+Banach-space-valued integrand. -/
+public theorem integral_eq_integral_preimage_coeFunE {G : Type*} [NormedAddCommGroup G]
+    [NormedSpace ℝ G] (g : UnitAddTorus (Fin d) → G)
     (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus (Fin d)))) :
     (∫ y : UnitAddTorus (Fin d), g y) =
       ∫ x, g (coeFunE x) ∂(volume : Measure E).restrict (iocCube) := by
@@ -214,12 +220,15 @@ local notation "Λ" => SchwartzMap.standardLattice d
 
 variable (f : 𝓢(EuclideanSpace ℝ (Fin d), ℂ))
 
-public instance instMeasurableVAdd_standardLattice : MeasurableVAdd Λ E where
+/-- Translation of `E = ℝ^d` by any `ℤ`-submodule (not just the standard lattice) is
+measurable. -/
+public instance (Λ' : Submodule ℤ E) : MeasurableVAdd Λ' E where
   measurable_const_vadd _ := by simp only [Submodule.vadd_def, vadd_eq_add]; fun_prop
   measurable_vadd_const _ := by simp only [Submodule.vadd_def, vadd_eq_add]; fun_prop
 
-public instance instVAddInvariantMeasure_standardLattice :
-    MeasureTheory.VAddInvariantMeasure Λ E (volume : Measure E) where
+/-- Lebesgue measure on `E = ℝ^d` is invariant under translation by any `ℤ`-submodule. -/
+public instance (Λ' : Submodule ℤ E) :
+    MeasureTheory.VAddInvariantMeasure Λ' E (volume : Measure E) where
   measure_preimage_vadd _ _ _ := by
     simp [Submodule.vadd_def, vadd_eq_add, MeasureTheory.measure_preimage_add]
 
@@ -301,7 +310,7 @@ public lemma mFourier_neg_apply_coeFunE (n : Fin d → ℤ) (x : E) :
 
 public lemma mFourier_apply_coeFunE_exp (n : Fin d → ℤ) (x : E) :
     UnitAddTorus.mFourier n (coeFunE x) =
-      Complex.exp (2 * Real.pi * Complex.I * ⟪x, intVec n⟫_[ℝ]) := by
+      Complex.exp (2 * π * Complex.I * ⟪x, intVec n⟫_[ℝ]) := by
   have h := mFourier_neg_apply_coeFunE (n := -n) (x := x)
   simp only [neg_neg, intVec_neg, inner_neg_right] at h
   rw [h, ← RCLike.inner_eq_wInner_one]
@@ -322,9 +331,10 @@ public lemma iocCube_subset_closedBall :
         rw [Real.norm_eq_abs, abs_of_pos (hx i).1]; exact (hx i).2
     _ = d := by simp
 
-public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube) < ⊤ :=
-  ((Metric.isBounded_closedBall (x := (0 : E)) (r := Real.sqrt d)).subset
-    (iocCube_subset_closedBall)).measure_lt_top
+public lemma volume_iocCube_lt_top : (volume : Measure E) (iocCube) < ⊤ := by
+  unfold iocCube
+  rw [EuclideanSpace.volume_cube _ measurableSet_Ioc, Real.volume_Ioc]
+  exact (ENNReal.pow_ne_top ENNReal.ofReal_ne_top).lt_top
 
 /-- On `iocCube`, the integrand `mFourier (-n) (coeFunE ·) * f (· + ℓ)` is bounded by the sup norm
 of the translate `f (· + ℓ)` restricted to `sqrtdBall`. -/
@@ -383,7 +393,11 @@ private lemma volume_unitAddCircle_eq_haar :
 
 /-- `UnitAddTorus.mFourierCoeff g n` as an integral against the file's ambient `volume` on the
 torus. `mFourierCoeff` is defined using `haarAddCircle`; this bridges the resulting measure-space
-diamond to the ambient `volume`, which agrees by `volume_unitAddCircle_eq_haar`. -/
+diamond to the ambient `volume`, which agrees by `volume_unitAddCircle_eq_haar`. The `@`-explicit
+spelling in `hvol` pins the `MeasureSpace.pi` instance under which `mFourierCoeff`'s integral
+actually elaborates, so `congrArg Measure.pi` can rewrite the factor measures; TODO: drop the
+surgery once the `AddCircle.measureSpace`/`haarAddCircle` instance diamond is reconciled upstream
+(see the module docstring of `ForMathlib/UnitAddTorusQuotient.lean`). -/
 private lemma mFourierCoeff_eq_integral_volume (n : Fin d → ℤ) (g : UnitAddTorus (Fin d) → ℂ) :
     UnitAddTorus.mFourierCoeff g n =
       ∫ y : UnitAddTorus (Fin d), UnitAddTorus.mFourier (-n) y • g y := by
@@ -509,7 +523,7 @@ lemma summable_mFourierCoeff_descended :
 /-- Poisson summation for Schwartz functions over the standard lattice `ℤ^d`. -/
 public theorem poissonSummation_standard (v : E) :
     (∑' ℓ : Λ, f (v + (ℓ : E))) = ∑' n : Fin d → ℤ, 𝓕 (fun x : E => f x) (intVec n) *
-        Complex.exp (2 * Real.pi * Complex.I * ⟪v, intVec n⟫_[ℝ]) := by
+        Complex.exp (2 * π * Complex.I * ⟪v, intVec n⟫_[ℝ]) := by
   simpa [descended_comp (f := f) v, periodization_apply (f := f), smul_eq_mul,
     mFourierCoeff_descended (f := f), mFourier_apply_coeFunE_exp, mul_assoc,
     mul_left_comm, mul_comm] using
@@ -716,8 +730,7 @@ private lemma poissonSummation_lattice_rhs (f : SchwartzMap E ℂ) (v : E) :
   have hfourier (w : E) : 𝓕 (fun x : E => f ((latticeEquiv L) x)) w =
       cC * 𝓕 (fun x : E => f x) (dualEquiv L w) := by
     simpa [dualEquiv_apply, detA, cC, Complex.real_smul] using
-      SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv
-        (A := latticeEquiv L) (f := fun x : E => f x) w
+      Real.fourier_comp_linearEquiv (A := latticeEquiv L) (f := fun x : E => f x) w
   have hreindex : (∑' n : Fin d → ℤ, (𝓕 (fun x : E => f ((latticeEquiv L) x)) (intVec n)) *
         Complex.exp (2 * π * Complex.I * ⟪(latticeEquiv L).symm v, intVec n⟫_[ℝ])) =
       cC * ∑' m : dualLattice L, F m := by

--- a/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
+++ b/SpherePacking/CohnElkies/PoissonSummationGeneral.lean
@@ -35,22 +35,32 @@ variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
 
-/- The standard `ℤ`-lattice `ℤ^d ⊆ ℝ^d`, its dual for the Euclidean inner product, the
-fundamental cube `(0,1]^d`, and the `√d`-ball are *notation*, not definitions (following this
-project's pattern for such spellings, cf. `ℝ⁸` and the cube machinery in
-`ForMathlib/CoordCube.lean`): they elaborate literally to `Submodule.span`/`dualSubmodule`/
-set-builder/`Compacts.mk` terms, so Mathlib's lemmas and instances (`ZSpan`,
-`instDiscreteTopology_dualSubmodule_innerₗ`, …) apply to them directly and there is nothing to
-unfold. The right-hand sides are written projection-free for the notation precheck. -/
-local notation:max "standardLattice " d:max =>
-  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+/-- The standard `ℤ`-lattice in `E = ℝ^d`, the span of the standard basis over `ℤ`. Deliberately a
+definition rather than notation: its body's head is `(basisFun _ _).toBasis`, which the simp lemma
+`OrthonormalBasis.coe_toBasis` would otherwise normalize away inside goals, detaching them from
+statement spellings and from the `ZSpan` instance keys. The constant shields that spelling (and
+carries the two instances below). -/
+@[expose] public def standardLattice (d : ℕ) :
+    Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
+  Submodule.span ℤ (Set.range ((EuclideanSpace.basisFun (Fin d) ℝ).toBasis))
+
+namespace standardLattice
+
+public instance instDiscreteTopology : DiscreteTopology (standardLattice d) :=
+  inferInstanceAs <| DiscreteTopology (Submodule.span ℤ (Set.range _))
+
+public instance instIsZLattice : IsZLattice ℝ (standardLattice d) :=
+  inferInstanceAs <| IsZLattice ℝ (Submodule.span ℤ (Set.range _))
+
+end standardLattice
+
+/- The fundamental cube `(0,1]^d` is *notation*, not a definition (cf. the cube machinery in
+`ForMathlib/CoordCube.lean`): it elaborates literally to the set-builder, so membership is
+judgemental and there is nothing to unfold. The precheck is disabled because Mathlib's set-builder
+syntax has no `quot_precheck` support. -/
+set_option quotPrecheck false in
 local notation "iocCube" =>
   {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
-local notation "sqrtdBall" =>
-  TopologicalSpace.Compacts.mk (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
-    (isCompact_closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
-local notation:max "dualLattice " L:max =>
-  LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
 
 namespace PoissonSummation
 
@@ -186,15 +196,14 @@ variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
 -- Re-declarations of the block-local notations from the top of the file (`local` scope ends with
--- each namespace block).
-local notation:max "standardLattice " d:max =>
-  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+-- each namespace block), plus the `√d`-ball as a `Compacts.mk` spelling.
+set_option quotPrecheck false in
 local notation "iocCube" =>
   {x : EuclideanSpace ℝ (Fin d) | ∀ i : Fin d, x i ∈ Set.Ioc (0 : ℝ) 1}
 local notation "sqrtdBall" =>
   TopologicalSpace.Compacts.mk (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
     (isCompact_closedBall (0 : EuclideanSpace ℝ (Fin d)) (Real.sqrt d))
-local notation "Λ" => standardLattice d
+local notation "Λ" => SchwartzMap.standardLattice d
 
 /-- The canonical equivalence between integer vectors `Fin d → ℤ` and the standard lattice
 `Λ = ℤ^d ⊆ ℝ^d`. Kept as a named definition: it reindexes sums over the lattice as sums over
@@ -255,7 +264,8 @@ public lemma periodization_add_lattice (x : E) (ℓ : Λ) :
 
 /-- The periodization factors through the quotient `(ℝ/ℤ)^d`. -/
 public lemma periodization_factorsThrough :
-    Function.FactorsThrough (periodization f) (coeFunE) := by
+    Function.FactorsThrough (periodization f)
+      (⟨coeFunE, continuous_coeFunE⟩ : C(E, UnitAddTorus (Fin d))) := by
   intro x y hxy
   obtain ⟨n, hn⟩ := exists_intVec_eq_sub_of_coeFunE_eq hxy
   have hx : x = y + intVec n := by rw [← hn]; abel
@@ -523,11 +533,10 @@ open SchwartzMap.PoissonSummation.Standard
 variable {d : ℕ}
 
 local notation "E" => EuclideanSpace ℝ (Fin d)
--- Re-declarations of the block-local notations from the top of the file (`local` scope ends with
--- each namespace block). `dualLattice L` is the dual `ℤ`-lattice for the Euclidean inner product:
--- the index set of the spectral side of Poisson summation.
-local notation:max "standardLattice " d:max =>
-  Submodule.span ℤ (Set.range (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ)))
+/- The dual `ℤ`-lattice for the Euclidean inner product is *notation*, not a definition (declared
+locally here and in `LPBound.lean`): it elaborates literally to `dualSubmodule`, so the
+discreteness instance from `ForMathlib/DualLattice.lean` applies to it directly. It is the index
+set of the spectral side of Poisson summation. -/
 local notation:max "dualLattice " L:max =>
   LinearMap.BilinForm.dualSubmodule (innerₗ (EuclideanSpace ℝ (Fin d))) L
 

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -11,8 +11,11 @@ public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
 For `d : ℕ` and `L : ℝ`, this file packages:
 
-* `cubeIco d L = [0, L)^d` and the closed inner cube `cubeIcc d L r = [r, L-r]^d` in
-  `EuclideanSpace ℝ (Fin d)`, with their membership API;
+* the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)` with its
+  shared membership/preimage/measure API (`mem_cubeBox`, `cubeBox_eq_preimage_ofLp`,
+  `volume_cubeBox`), and its two specialisations `cubeIco d L = cubeBox d [0, L) = [0, L)^d` and the
+  closed inner cube `cubeIcc d L r = cubeBox d [r, L-r] = [r, L-r]^d`, whose membership/volume facts
+  are one-line corollaries of the `cubeBox` API rather than re-derived per cube;
 * the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev`, not a standalone def) and the
   cubic lattice `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice`
   instances;
@@ -63,18 +66,28 @@ namespace EuclideanSpace
 
 variable {d : ℕ}
 
-/-- The half-open coordinate cube `[0, L)^d`. Used pervasively as the fundamental domain of
-`cubeLattice`; its membership API is `mem_cubeIco`. -/
+/-- The coordinate box `{x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)`: the points all of whose
+coordinates lie in `I ⊆ ℝ`. Both cubes below (`cubeIco`, `cubeIcc`) are special cases, and the
+measure/preimage API (`mem_cubeBox`, `cubeBox_eq_preimage_ofLp`, `volume_cubeBox`) is proved once
+here rather than re-derived per cube. -/
+@[expose] public def cubeBox (d : ℕ) (I : Set ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+  {x | ∀ i : Fin d, x i ∈ I}
+
+@[simp] public lemma mem_cubeBox {I : Set ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ cubeBox d I ↔ ∀ i, x i ∈ I := Iff.rfl
+
+/-- The half-open coordinate cube `[0, L)^d`, the coordinate box `cubeBox d [0, L)`. Used pervasively
+as the fundamental domain of `cubeLattice`; its membership API is `mem_cubeIco`. -/
 @[expose] public def cubeIco (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  {x | ∀ i : Fin d, x i ∈ Set.Ico (0 : ℝ) L}
+  cubeBox d (Set.Ico (0 : ℝ) L)
 
 @[simp] public lemma mem_cubeIco {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
     x ∈ cubeIco d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
 
-/-- The closed inner cube `[r, L-r]^d`, the locus where a radius-`r` ball stays inside
-`cubeIco L`. Membership API: `mem_cubeIcc`. -/
+/-- The closed inner cube `[r, L-r]^d`, the coordinate box `cubeBox d [r, L - r]`; the locus where a
+radius-`r` ball stays inside `cubeIco L`. Membership API: `mem_cubeIcc`. -/
 @[expose] public def cubeIcc (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  {x | ∀ i : Fin d, x i ∈ Set.Icc r (L - r)}
+  cubeBox d (Set.Icc r (L - r))
 
 @[simp] public lemma mem_cubeIcc {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
     x ∈ cubeIcc d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
@@ -109,7 +122,7 @@ public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
 public lemma fundamentalDomain_cubeBasis_eq_cubeIco (L : ℝ) (hL : 0 < L) :
     fundamentalDomain (cubeBasis d L hL) = cubeIco d L := by
   ext x
-  simp only [ZSpan.mem_fundamentalDomain, cubeIco, cubeBasis, Module.Basis.repr_isUnitSMul,
+  simp only [ZSpan.mem_fundamentalDomain, mem_cubeIco, cubeBasis, Module.Basis.repr_isUnitSMul,
     Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
     OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
     Set.mem_Ico]
@@ -131,28 +144,37 @@ private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet
     volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s :=
   (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
 
+/-- A coordinate box is the `ofLp`-preimage of the product box `∏ i, I`. This is the single
+preimage identity from which both cubes' preimage/measure facts are read off. -/
+public lemma cubeBox_eq_preimage_ofLp (I : Set ℝ) :
+    cubeBox d I =
+      (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' (Set.pi Set.univ fun _ : Fin d ↦ I) := by
+  ext x; simp [mem_cubeBox, Set.mem_pi]
+
+/-- The volume of a coordinate box `cubeBox d I` is `volume I ^ d`. -/
+public lemma volume_cubeBox (I : Set ℝ) (hI : MeasurableSet I) :
+    volume (cubeBox d I) = volume I ^ d := by
+  rw [cubeBox_eq_preimage_ofLp, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ hI),
+    volume_pi, Measure.pi_pi]
+  simp
+
 /-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
 public lemma volume_cubeIco (L : ℝ) : volume (cubeIco d L) = (ENNReal.ofReal L) ^ d := by
-  have hcube : cubeIco d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-      (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
-    ext x; simp [mem_cubeIco, Set.mem_pi]
-  rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
-    volume_pi, Measure.pi_pi]
-  simp [Real.volume_Ico, sub_zero]
+  rw [show cubeIco d L = cubeBox d (Set.Ico (0 : ℝ) L) from rfl,
+    volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
 
 /-- `cubeIcc d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
 public lemma cubeIcc_eq_preimage_ofLp (L r : ℝ) :
     cubeIcc d L r =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-        (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
-  ext x; simp [mem_cubeIcc, Pi.le_def, forall_and]
+        (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) :=
+  cubeBox_eq_preimage_ofLp (Set.Icc r (L - r))
 
 /-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
 public lemma volume_cubeIcc (L r : ℝ) :
     volume (cubeIcc d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
-  rw [cubeIcc_eq_preimage_ofLp, volume_preimage_ofLp _
-    (.pi Set.countable_univ fun _ _ ↦ measurableSet_Icc), volume_pi, Measure.pi_pi]
-  simp [Real.volume_Icc, show L - r - r = L - 2 * r by ring]
+  rw [show cubeIcc d L r = cubeBox d (Set.Icc r (L - r)) from rfl,
+    volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, show L - r - r = L - 2 * r by ring]
 
 /-- Only finitely many `cubeLattice` points lie in a ball of radius `R`. -/
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -10,13 +10,13 @@ public import Mathlib
 
 For `d : ℕ` and `L : ℝ`, this file packages:
 
-* `coordCube d L = [0, L)^d` and the closed inner cube `coordCubeInner d L r = [r, L-r]^d` in
+* `cubeIco d L = [0, L)^d` and the closed inner cube `cubeIcc d L r = [r, L-r]^d` in
   `EuclideanSpace ℝ (Fin d)`, with their membership API;
 * the scaled standard basis `cubeBasis d L hL` and the cubic lattice `cubeLattice d L hL = L • ℤ^d`
   it spans, with `DiscreteTopology`/`IsZLattice` instances;
-* the basic geometry and measure of these objects: `coordCube` is the fundamental domain of
-  `cubeBasis` (`fundamentalDomain_cubeBasis_eq_coordCube`), every point has a unique lattice
-  translate in it (`coordCube_unique_covers`), it is bounded, and the volumes are `L^d` and
+* the basic geometry and measure of these objects: `cubeIco` is the fundamental domain of
+  `cubeBasis` (`fundamentalDomain_cubeBasis_eq_cubeIco`), every point has a unique lattice
+  translate in it (`cubeIco_unique_covers`), it is bounded, and the volumes are `L^d` and
   `(L - 2r)^d`. Only finitely many lattice points lie in a ball (`finite_lattice_in_ball`).
 
 Everything is placed in the `EuclideanSpace` namespace, its natural home.
@@ -33,23 +33,23 @@ namespace EuclideanSpace
 variable {d : ℕ}
 
 /-- The half-open coordinate cube `[0, L)^d`. Used pervasively as the fundamental domain of
-`cubeLattice`; its membership API is `mem_coordCube`. -/
-@[expose] public def coordCube (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+`cubeLattice`; its membership API is `mem_cubeIco`. -/
+@[expose] public def cubeIco (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
   {x | ∀ i : Fin d, x i ∈ Set.Ico (0 : ℝ) L}
 
-@[simp] public lemma mem_coordCube {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ coordCube d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
+@[simp] public lemma mem_cubeIco {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ cubeIco d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
 
 /-- The closed inner cube `[r, L-r]^d`, the locus where a radius-`r` ball stays inside
-`coordCube L`. Membership API: `mem_coordCubeInner`. -/
-@[expose] public def coordCubeInner (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+`cubeIco L`. Membership API: `mem_cubeIcc`. -/
+@[expose] public def cubeIcc (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
   {x | ∀ i : Fin d, x i ∈ Set.Icc r (L - r)}
 
-@[simp] public lemma mem_coordCubeInner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ coordCubeInner d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
+@[simp] public lemma mem_cubeIcc {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ cubeIcc d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
 
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is `coordCube d L` (`fundamentalDomain_cubeBasis_eq_coordCube`). -/
+its fundamental domain is `cubeIco d L` (`fundamentalDomain_cubeBasis_eq_cubeIco`). -/
 @[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
     Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
   (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
@@ -69,25 +69,25 @@ public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
   inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
 
 /-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
-public lemma fundamentalDomain_cubeBasis_eq_coordCube (L : ℝ) (hL : 0 < L) :
-    fundamentalDomain (cubeBasis d L hL) = coordCube d L := by
+public lemma fundamentalDomain_cubeBasis_eq_cubeIco (L : ℝ) (hL : 0 < L) :
+    fundamentalDomain (cubeBasis d L hL) = cubeIco d L := by
   ext x
-  simp only [ZSpan.mem_fundamentalDomain, coordCube, cubeBasis, Module.Basis.repr_isUnitSMul,
+  simp only [ZSpan.mem_fundamentalDomain, cubeIco, cubeBasis, Module.Basis.repr_isUnitSMul,
     Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
     OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
     Set.mem_Ico]
   exact forall_congr' fun i =>
     and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
 
-/-- Every point has a unique `cubeLattice` translate lying in the cube `coordCube d L`. -/
-public lemma coordCube_unique_covers (L : ℝ) (hL : 0 < L) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ coordCube d L := fun x => by
-  simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
+/-- Every point has a unique `cubeLattice` translate lying in the cube `cubeIco d L`. -/
+public lemma cubeIco_unique_covers (L : ℝ) (hL : 0 < L) :
+    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ cubeIco d L := fun x => by
+  simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
-/-- The cube `coordCube d L` is a bounded set. -/
-public lemma isBounded_coordCube (L : ℝ) (hL : 0 < L) : IsBounded (coordCube d L) := by
-  simpa [fundamentalDomain_cubeBasis_eq_coordCube L hL] using
+/-- The cube `cubeIco d L` is a bounded set. -/
+public lemma isBounded_cubeIco (L : ℝ) (hL : 0 < L) : IsBounded (cubeIco d L) := by
+  simpa [fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
     fundamentalDomain_isBounded (cubeBasis d L hL)
 
 private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet s) :
@@ -95,25 +95,25 @@ private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet
   (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
 
 /-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
-public lemma volume_coordCube (L : ℝ) : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
-  have hcube : coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
+public lemma volume_cubeIco (L : ℝ) : volume (cubeIco d L) = (ENNReal.ofReal L) ^ d := by
+  have hcube : cubeIco d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
       (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
-    ext x; simp [mem_coordCube, Set.mem_pi]
+    ext x; simp [mem_cubeIco, Set.mem_pi]
   rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
     volume_pi, Measure.pi_pi]
   simp [Real.volume_Ico, sub_zero]
 
-/-- `coordCubeInner d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
-public lemma coordCubeInner_eq_preimage_ofLp (L r : ℝ) :
-    coordCubeInner d L r =
+/-- `cubeIcc d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
+public lemma cubeIcc_eq_preimage_ofLp (L r : ℝ) :
+    cubeIcc d L r =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
         (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
-  ext x; simp [mem_coordCubeInner, Pi.le_def, forall_and]
+  ext x; simp [mem_cubeIcc, Pi.le_def, forall_and]
 
 /-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
-public lemma volume_coordCubeInner (L r : ℝ) :
-    volume (coordCubeInner d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
-  rw [coordCubeInner_eq_preimage_ofLp, volume_preimage_ofLp _
+public lemma volume_cubeIcc (L r : ℝ) :
+    volume (cubeIcc d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
+  rw [cubeIcc_eq_preimage_ofLp, volume_preimage_ofLp _
     (.pi Set.countable_univ fun _ _ ↦ measurableSet_Icc), volume_pi, Measure.pi_pi]
   simp [Real.volume_Icc, show L - r - r = L - 2 * r by ring]
 

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -13,8 +13,9 @@ For `d : ℕ` and `L : ℝ`, this file packages:
 
 * `cubeIco d L = [0, L)^d` and the closed inner cube `cubeIcc d L r = [r, L-r]^d` in
   `EuclideanSpace ℝ (Fin d)`, with their membership API;
-* the scaled standard basis `cubeBasis d L hL` and the cubic lattice `cubeLattice d L hL = L • ℤ^d`
-  it spans, with `DiscreteTopology`/`IsZLattice` instances;
+* the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev`, not a standalone def) and the
+  cubic lattice `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice`
+  instances;
 * the basic geometry and measure of these objects: `cubeIco` is the fundamental domain of
   `cubeBasis` (`fundamentalDomain_cubeBasis_eq_cubeIco`), every point has a unique lattice
   translate in it (`cubeIco_unique_covers`), it is bounded, and the volumes are `L^d` and
@@ -79,8 +80,14 @@ variable {d : ℕ}
     x ∈ cubeIcc d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
 
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is `cubeIco d L` (`fundamentalDomain_cubeBasis_eq_cubeIco`). -/
-@[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
+its fundamental domain is `cubeIco d L` (`fundamentalDomain_cubeBasis_eq_cubeIco`).
+
+This is a reducible *abbreviation*, not a standalone definition: it is a one-line shorthand for
+`Basis.isUnitSMul`, carries no API of its own, and is only ever passed straight to Mathlib's `ZSpan`
+basis lemmas. Keeping it `abbrev` (rather than `def`) means it unfolds definitionally — no unfolding
+lemmas, no `cubeBasis_apply`-style API — so it behaves like notation while still accepting the
+positivity proof `hL` that a syntactic `notation` could not supply to `IsUnit.mk0`. -/
+@[expose] public noncomputable abbrev cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
     Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
   (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
 

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -21,9 +21,38 @@ For `d : ℕ` and `L : ℝ`, this file packages:
 
 Everything is placed in the `EuclideanSpace` namespace, its natural home.
 
+## Why a cube, and not an arbitrary lattice basis?
+
+The cube `L • ℤ^d` enters the Cohn–Elkies density argument (`LPBound.lean`) only through its
+*boundary geometry*. The lattice/fundamental-domain *counting* layer is already basis-generic and
+delegates to Mathlib's `ZSpan`: a translate of a fundamental domain is again a fundamental domain
+(`vadd_unique_covers`), the cell-assignment map exists for any basis
+(`fundamentalDomainCover`), the domain is bounded (`ZSpan.fundamentalDomain_isBounded`), meets a
+ball finitely (`ZSpan.setFinite_inter`), tiles space
+(`ZSpan.exist_unique_vadd_mem_fundamentalDomain`), and has covolume `volume (fundamentalDomain b)`
+(`ZLattice.covolume_eq_measure_fundamentalDomain`).
+
+What genuinely needs the cube — and is *not* available for a general `ZSpan.fundamentalDomain b` —
+is the boundary control of the LP bound, which rests on two facts with no current Mathlib analogue:
+
+* an **inradius / boundary-safe inner core**: a ball of radius `r` about a point of the inner cube
+  `cubeIcc d L r` stays inside `cubeIco d L` (`ball_subset_cubeIco_of_mem_inner`). For a sheared
+  parallelepiped the safe inner region is not a coordinate-box shrink; it depends on the dual-basis
+  norms / the parallelepiped inradius.  *Upstream TODO:*
+  `ZSpan.ball_subset_fundamentalDomain_of_mem_inner`.
+* a **boundary-shell volume asymptotic** under homothety: the relative volume of the
+  `r`-neighbourhood of the cell boundary vanishes as the lattice is scaled (here the explicit
+  `((L+1)^d - (L-2)^d)/L^d → 0`, `tendsto_volume_cubeShell_div_volume_cubeIco_zero`). For a general
+  fundamental domain this is a Minkowski-content statement.  *Upstream TODO:*
+  `ZSpan.tendsto_volume_boundaryThickening_div_volume_fundamentalDomain_zero`.
+
+So the answer to "why so much for `L • ℤ^d`?" is: the counting is generic (and is written that
+way), while the cube is the one fundamental domain whose inradius and boundary-shell volume are
+elementary.
+
 Upstream target: `Mathlib/Algebra/Module/ZLattice/` (scaled integer lattice) together with the
-measure-theoretic facts. Imports here are left as `public import Mathlib`; they are narrowed at
-upstreaming time.
+measure-theoretic facts and the two general boundary lemmas above. Imports here are left as
+`public import Mathlib`; they are narrowed at upstreaming time.
 -/
 
 open MeasureTheory Metric ZSpan Module Bornology

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 Sidharth Hariharan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sidharth Hariharan
+-/
+module
+public import Mathlib
+
+/-! # The scaled integer lattice `L • ℤ^d` and its coordinate cube
+
+For `d : ℕ` and `L : ℝ`, this file packages:
+
+* `coordCube d L = [0, L)^d` and the closed inner cube `coordCubeInner d L r = [r, L-r]^d` in
+  `EuclideanSpace ℝ (Fin d)`, with their membership API;
+* the scaled standard basis `cubeBasis d L hL` and the cubic lattice `cubeLattice d L hL = L • ℤ^d`
+  it spans, with `DiscreteTopology`/`IsZLattice` instances;
+* the basic geometry and measure of these objects: `coordCube` is the fundamental domain of
+  `cubeBasis` (`fundamentalDomain_cubeBasis_eq_coordCube`), every point has a unique lattice
+  translate in it (`coordCube_unique_covers`), it is bounded, and the volumes are `L^d` and
+  `(L - 2r)^d`. Only finitely many lattice points lie in a ball (`finite_lattice_in_ball`).
+
+Everything is placed in the `EuclideanSpace` namespace, its natural home.
+
+Upstream target: `Mathlib/Algebra/Module/ZLattice/` (scaled integer lattice) together with the
+measure-theoretic facts. Imports here are left as `public import Mathlib`; they are narrowed at
+upstreaming time.
+-/
+
+open MeasureTheory Metric ZSpan Module Bornology
+
+namespace EuclideanSpace
+
+variable {d : ℕ}
+
+/-- The half-open coordinate cube `[0, L)^d`. Used pervasively as the fundamental domain of
+`cubeLattice`; its membership API is `mem_coordCube`. -/
+@[expose] public def coordCube (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+  {x | ∀ i : Fin d, x i ∈ Set.Ico (0 : ℝ) L}
+
+@[simp] public lemma mem_coordCube {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ coordCube d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
+
+/-- The closed inner cube `[r, L-r]^d`, the locus where a radius-`r` ball stays inside
+`coordCube L`. Membership API: `mem_coordCubeInner`. -/
+@[expose] public def coordCubeInner (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+  {x | ∀ i : Fin d, x i ∈ Set.Icc r (L - r)}
+
+@[simp] public lemma mem_coordCubeInner {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
+    x ∈ coordCubeInner d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
+
+/-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
+its fundamental domain is `coordCube d L` (`fundamentalDomain_cubeBasis_eq_coordCube`). -/
+@[expose] public noncomputable def cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
+    Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
+  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
+
+/-- The cubic lattice `L • ℤ^d`, spanned by `cubeBasis d L hL`. Standalone so it can carry
+`ZLattice`/`DiscreteTopology` instances and act as the period lattice of the cube packing. -/
+@[expose] public noncomputable def cubeLattice (d : ℕ) (L : ℝ) (hL : 0 < L) :
+    Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
+  Submodule.span ℤ (Set.range (cubeBasis d L hL))
+
+public instance instDiscreteTopology_cubeLattice (L : ℝ) (hL : 0 < L) :
+    DiscreteTopology (cubeLattice d L hL) :=
+  inferInstanceAs (DiscreteTopology (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
+
+public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
+    IsZLattice ℝ (cubeLattice d L hL) :=
+  inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
+
+/-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
+public lemma fundamentalDomain_cubeBasis_eq_coordCube (L : ℝ) (hL : 0 < L) :
+    fundamentalDomain (cubeBasis d L hL) = coordCube d L := by
+  ext x
+  simp only [ZSpan.mem_fundamentalDomain, coordCube, cubeBasis, Module.Basis.repr_isUnitSMul,
+    Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
+    OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
+    Set.mem_Ico]
+  exact forall_congr' fun i =>
+    and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
+
+/-- Every point has a unique `cubeLattice` translate lying in the cube `coordCube d L`. -/
+public lemma coordCube_unique_covers (L : ℝ) (hL : 0 < L) :
+    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ coordCube d L := fun x => by
+  simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_coordCube L hL] using
+    exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
+
+/-- The cube `coordCube d L` is a bounded set. -/
+public lemma isBounded_coordCube (L : ℝ) (hL : 0 < L) : IsBounded (coordCube d L) := by
+  simpa [fundamentalDomain_cubeBasis_eq_coordCube L hL] using
+    fundamentalDomain_isBounded (cubeBasis d L hL)
+
+private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet s) :
+    volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s :=
+  (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
+
+/-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
+public lemma volume_coordCube (L : ℝ) : volume (coordCube d L) = (ENNReal.ofReal L) ^ d := by
+  have hcube : coordCube d L = (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
+      (Set.pi Set.univ fun _ : Fin d ↦ Set.Ico (0 : ℝ) L) := by
+    ext x; simp [mem_coordCube, Set.mem_pi]
+  rw [hcube, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ measurableSet_Ico),
+    volume_pi, Measure.pi_pi]
+  simp [Real.volume_Ico, sub_zero]
+
+/-- `coordCubeInner d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
+public lemma coordCubeInner_eq_preimage_ofLp (L r : ℝ) :
+    coordCubeInner d L r =
+      (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
+        (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) := by
+  ext x; simp [mem_coordCubeInner, Pi.le_def, forall_and]
+
+/-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
+public lemma volume_coordCubeInner (L r : ℝ) :
+    volume (coordCubeInner d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
+  rw [coordCubeInner_eq_preimage_ofLp, volume_preimage_ofLp _
+    (.pi Set.countable_univ fun _ _ ↦ measurableSet_Icc), volume_pi, Measure.pi_pi]
+  simp [Real.volume_Icc, show L - r - r = L - 2 * r by ring]
+
+/-- Only finitely many `cubeLattice` points lie in a ball of radius `R`. -/
+public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :
+    Set.Finite {g : cubeLattice d L hL | (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 R} := by
+  refine (Set.Finite.preimage_embedding (f := ⟨fun g : cubeLattice d L hL =>
+    (g : EuclideanSpace ℝ (Fin d)), Subtype.val_injective⟩) (by
+      simpa [cubeLattice] using ZSpan.setFinite_inter (b := cubeBasis d L hL)
+        (s := ball (0 : EuclideanSpace ℝ (Fin d)) R) Metric.isBounded_ball)).subset fun g hg => ?_
+  exact ⟨hg, g.property⟩
+
+end EuclideanSpace

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib
+public import Mathlib.Algebra.Module.ZLattice.Basic
+public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
 /-! # The scaled integer lattice `L • ℤ^d` and its coordinate cube
 

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -78,9 +78,11 @@ variable {d : ℕ}
 
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`, given `hL : 0 < L`. This is
 *notation*, not a definition: it elaborates literally to `Basis.isUnitSMul` on the standard basis,
-so Mathlib's `ZSpan` lemmas apply to it directly and there is nothing to unfold. -/
+so Mathlib's `ZSpan` lemmas apply to it directly and there is nothing to unfold. (The right-hand
+side is written projection-free because the notation precheck does not support `.foo` syntax.) -/
 local notation:max "cubeBasis " d:max L:max hL:max =>
-  (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
+  Module.Basis.isUnitSMul (OrthonormalBasis.toBasis (EuclideanSpace.basisFun (Fin d) ℝ))
+    fun _ : Fin d ↦ IsUnit.mk0 L (LT.lt.ne' hL)
 
 /-- The cubic lattice `L • ℤ^d`, the span of `cubeBasis d L hL`. This is *notation*, not a
 definition: it elaborates literally to `Submodule.span ℤ (Set.range …)`, so Mathlib's

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -7,22 +7,25 @@ module
 public import Mathlib.Algebra.Module.ZLattice.Basic
 public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
-/-! # The scaled integer lattice `L • ℤ^d` and its coordinate cube
+/-! # The scaled integer lattice `L • ℤ^d` and its coordinate boxes
 
 For `d : ℕ` and `L : ℝ`, this file packages:
 
-* the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)` with its
-  shared membership/preimage/measure API (`mem_cubeBox`, `cubeBox_eq_preimage_ofLp`,
-  `volume_cubeBox`), and its two specialisations `cubeIco d L = cubeBox d [0, L) = [0, L)^d` and the
-  closed inner cube `cubeIcc d L r = cubeBox d [r, L-r] = [r, L-r]^d`, whose membership/volume facts
-  are one-line corollaries of the `cubeBox` API rather than re-derived per cube;
-* the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev`, not a standalone def) and the
-  cubic lattice `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice`
-  instances;
-* the basic geometry and measure of these objects: `cubeIco` is the fundamental domain of
-  `cubeBasis` (`fundamentalDomain_cubeBasis_eq_cubeIco`), every point has a unique lattice
-  translate in it (`cubeIco_unique_covers`), it is bounded, and the volumes are `L^d` and
-  `(L - 2r)^d`. Only finitely many lattice points lie in a ball (`finite_lattice_in_ball`).
+* the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)`. This is a
+  reducible `abbrev`, not a standalone definition: membership is definitionally `∀ i, x i ∈ I`
+  (`hx i` and `fun i => …` work with no unfolding lemma), so it behaves like notation for the
+  set-builder while keeping call sites readable. Its real API is the cross-structure content:
+  `cubeBox_eq_preimage_ofLp`, `measurableSet_cubeBox`, and `volume_cubeBox`
+  (`volume (cubeBox d I) = volume I ^ d`). The cubes of the LP bound are written inline as
+  `cubeBox d (Set.Ico 0 L) = [0, L)^d` and `cubeBox d (Set.Icc r (L - r)) = [r, L-r]^d` — there are
+  deliberately no named specialisations (and hence no per-cube API to maintain);
+* the scaled standard basis `cubeBasis d L hL` (also a reducible `abbrev`) and the cubic lattice
+  `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice` instances.
+  `cubeLattice` is the one standalone definition, kept so it can carry those instances;
+* the basic geometry: `cubeBox d (Set.Ico 0 L)` is the fundamental domain of `cubeBasis`
+  (`fundamentalDomain_cubeBasis`), every point has a unique lattice translate in it
+  (`cubeLattice_unique_covers`), it is bounded (`isBounded_cubeBox_Ico`), and only finitely many
+  lattice points lie in a ball (`finite_lattice_in_ball`).
 
 Everything is placed in the `EuclideanSpace` namespace, its natural home.
 
@@ -41,13 +44,13 @@ What genuinely needs the cube — and is *not* available for a general `ZSpan.fu
 is the boundary control of the LP bound, which rests on two facts with no current Mathlib analogue:
 
 * an **inradius / boundary-safe inner core**: a ball of radius `r` about a point of the inner cube
-  `cubeIcc d L r` stays inside `cubeIco d L` (`ball_subset_cubeIco_of_mem_inner`). For a sheared
-  parallelepiped the safe inner region is not a coordinate-box shrink; it depends on the dual-basis
-  norms / the parallelepiped inradius.  *Upstream TODO:*
-  `ZSpan.ball_subset_fundamentalDomain_of_mem_inner`.
+  `cubeBox d (Set.Icc r (L - r))` stays inside `cubeBox d (Set.Ico 0 L)`
+  (`ball_subset_cubeBox_of_mem_inner`). For a sheared parallelepiped the safe inner region is not a
+  coordinate-box shrink; it depends on the dual-basis norms / the parallelepiped inradius.
+  *Upstream TODO:* `ZSpan.ball_subset_fundamentalDomain_of_mem_inner`.
 * a **boundary-shell volume asymptotic** under homothety: the relative volume of the
   `r`-neighbourhood of the cell boundary vanishes as the lattice is scaled (here the explicit
-  `((L+1)^d - (L-2)^d)/L^d → 0`, `tendsto_volume_cubeShell_div_volume_cubeIco_zero`). For a general
+  `((L+1)^d - (L-2)^d)/L^d → 0`, `tendsto_volume_cubeShell_div_volume_cubeBox_zero`). For a general
   fundamental domain this is a Minkowski-content statement.  *Upstream TODO:*
   `ZSpan.tendsto_volume_boundaryThickening_div_volume_fundamentalDomain_zero`.
 
@@ -67,33 +70,14 @@ namespace EuclideanSpace
 variable {d : ℕ}
 
 /-- The coordinate box `{x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)`: the points all of whose
-coordinates lie in `I ⊆ ℝ`. Both cubes below (`cubeIco`, `cubeIcc`) are special cases, and the
-measure/preimage API (`mem_cubeBox`, `cubeBox_eq_preimage_ofLp`, `volume_cubeBox`) is proved once
-here rather than re-derived per cube. -/
-@[expose] public def cubeBox (d : ℕ) (I : Set ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
+coordinates lie in `I ⊆ ℝ`. A reducible `abbrev`, so membership is definitionally `∀ i, x i ∈ I`
+and no membership/unfolding API is needed; the substantive API is `cubeBox_eq_preimage_ofLp`,
+`measurableSet_cubeBox`, and `volume_cubeBox`. -/
+@[expose] public abbrev cubeBox (d : ℕ) (I : Set ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
   {x | ∀ i : Fin d, x i ∈ I}
 
-@[simp] public lemma mem_cubeBox {I : Set ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ cubeBox d I ↔ ∀ i, x i ∈ I := Iff.rfl
-
-/-- The half-open coordinate cube `[0, L)^d`, the coordinate box `cubeBox d [0, L)`. Used pervasively
-as the fundamental domain of `cubeLattice`; its membership API is `mem_cubeIco`. -/
-@[expose] public def cubeIco (d : ℕ) (L : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  cubeBox d (Set.Ico (0 : ℝ) L)
-
-@[simp] public lemma mem_cubeIco {L : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ cubeIco d L ↔ ∀ i, x i ∈ Set.Ico (0 : ℝ) L := Iff.rfl
-
-/-- The closed inner cube `[r, L-r]^d`, the coordinate box `cubeBox d [r, L - r]`; the locus where a
-radius-`r` ball stays inside `cubeIco L`. Membership API: `mem_cubeIcc`. -/
-@[expose] public def cubeIcc (d : ℕ) (L r : ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  cubeBox d (Set.Icc r (L - r))
-
-@[simp] public lemma mem_cubeIcc {L r : ℝ} {x : EuclideanSpace ℝ (Fin d)} :
-    x ∈ cubeIcc d L r ↔ ∀ i, x i ∈ Set.Icc r (L - r) := Iff.rfl
-
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is `cubeIco d L` (`fundamentalDomain_cubeBasis_eq_cubeIco`).
+its fundamental domain is `cubeBox d (Set.Ico 0 L)` (`fundamentalDomain_cubeBasis`).
 
 This is a reducible *abbreviation*, not a standalone definition: it is a one-line shorthand for
 `Basis.isUnitSMul`, carries no API of its own, and is only ever passed straight to Mathlib's `ZSpan`
@@ -119,62 +103,50 @@ public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
   inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
 
 /-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
-public lemma fundamentalDomain_cubeBasis_eq_cubeIco (L : ℝ) (hL : 0 < L) :
-    fundamentalDomain (cubeBasis d L hL) = cubeIco d L := by
+public lemma fundamentalDomain_cubeBasis (L : ℝ) (hL : 0 < L) :
+    fundamentalDomain (cubeBasis d L hL) = cubeBox d (Set.Ico 0 L) := by
   ext x
-  simp only [ZSpan.mem_fundamentalDomain, mem_cubeIco, cubeBasis, Module.Basis.repr_isUnitSMul,
+  simp only [ZSpan.mem_fundamentalDomain, cubeBasis, Module.Basis.repr_isUnitSMul,
     Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
     OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
     Set.mem_Ico]
   exact forall_congr' fun i =>
     and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
 
-/-- Every point has a unique `cubeLattice` translate lying in the cube `cubeIco d L`. -/
-public lemma cubeIco_unique_covers (L : ℝ) (hL : 0 < L) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ cubeIco d L := fun x => by
-  simpa [cubeLattice, fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
+/-- Every point has a unique `cubeLattice` translate lying in the cube `[0, L)^d`. -/
+public lemma cubeLattice_unique_covers (L : ℝ) (hL : 0 < L) :
+    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ cubeBox d (Set.Ico 0 L) := fun x => by
+  simpa [cubeLattice, fundamentalDomain_cubeBasis L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
-/-- The cube `cubeIco d L` is a bounded set. -/
-public lemma isBounded_cubeIco (L : ℝ) (hL : 0 < L) : IsBounded (cubeIco d L) := by
-  simpa [fundamentalDomain_cubeBasis_eq_cubeIco L hL] using
+/-- The cube `[0, L)^d` is a bounded set. -/
+public lemma isBounded_cubeBox_Ico (L : ℝ) (hL : 0 < L) :
+    IsBounded (cubeBox d (Set.Ico 0 L)) := by
+  simpa [fundamentalDomain_cubeBasis L hL] using
     fundamentalDomain_isBounded (cubeBasis d L hL)
 
-private lemma volume_preimage_ofLp (s : Set (Fin d → ℝ)) (hs : MeasurableSet s) :
-    volume ((fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' s) = volume s :=
-  (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage hs.nullMeasurableSet
-
 /-- A coordinate box is the `ofLp`-preimage of the product box `∏ i, I`. This is the single
-preimage identity from which both cubes' preimage/measure facts are read off. -/
+preimage identity from which the boxes' measurability and volume are read off. -/
 public lemma cubeBox_eq_preimage_ofLp (I : Set ℝ) :
     cubeBox d I =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' (Set.pi Set.univ fun _ : Fin d ↦ I) := by
-  ext x; simp [mem_cubeBox, Set.mem_pi]
+  ext x; simp [Set.mem_pi]
+
+/-- A coordinate box over a measurable interval is measurable. -/
+public lemma measurableSet_cubeBox {I : Set ℝ} (hI : MeasurableSet I) :
+    MeasurableSet (cubeBox d I) := by
+  rw [cubeBox_eq_preimage_ofLp]
+  exact (MeasurableSet.pi Set.countable_univ fun _ _ => hI).preimage
+    (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
 
 /-- The volume of a coordinate box `cubeBox d I` is `volume I ^ d`. -/
 public lemma volume_cubeBox (I : Set ℝ) (hI : MeasurableSet I) :
     volume (cubeBox d I) = volume I ^ d := by
-  rw [cubeBox_eq_preimage_ofLp, volume_preimage_ofLp _ (.pi Set.countable_univ fun _ _ ↦ hI),
+  rw [cubeBox_eq_preimage_ofLp,
+    (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage
+      (MeasurableSet.pi Set.countable_univ fun _ _ ↦ hI).nullMeasurableSet,
     volume_pi, Measure.pi_pi]
   simp
-
-/-- The volume of the cube `[0, L)^d` is `L ^ d`. -/
-public lemma volume_cubeIco (L : ℝ) : volume (cubeIco d L) = (ENNReal.ofReal L) ^ d := by
-  rw [show cubeIco d L = cubeBox d (Set.Ico (0 : ℝ) L) from rfl,
-    volume_cubeBox _ measurableSet_Ico, Real.volume_Ico, sub_zero]
-
-/-- `cubeIcc d L r` is the `ofLp`-preimage of the product set `[r, L - r]^d`. -/
-public lemma cubeIcc_eq_preimage_ofLp (L r : ℝ) :
-    cubeIcc d L r =
-      (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹'
-        (Set.pi Set.univ fun _ : Fin d ↦ Set.Icc r (L - r)) :=
-  cubeBox_eq_preimage_ofLp (Set.Icc r (L - r))
-
-/-- The volume of the closed inner cube `[r, L - r]^d` is `(L - 2r) ^ d`. -/
-public lemma volume_cubeIcc (L r : ℝ) :
-    volume (cubeIcc d L r) = (ENNReal.ofReal (L - 2 * r)) ^ d := by
-  rw [show cubeIcc d L r = cubeBox d (Set.Icc r (L - r)) from rfl,
-    volume_cubeBox _ measurableSet_Icc, Real.volume_Icc, show L - r - r = L - 2 * r by ring]
 
 /-- Only finitely many `cubeLattice` points lie in a ball of radius `R`. -/
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -7,24 +7,22 @@ module
 public import Mathlib.Algebra.Module.ZLattice.Basic
 public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
-/-! # The scaled integer lattice `L • ℤ^d` and its coordinate boxes
+/-! # The scaled integer lattice `L • ℤ^d` and its coordinate cubes
 
 For `d : ℕ` and `L : ℝ`, this file packages:
 
-* the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)`. This is a
-  reducible `abbrev`, not a standalone definition: membership is definitionally `∀ i, x i ∈ I`
-  (`hx i` and `fun i => …` work with no unfolding lemma), so it behaves like notation for the
-  set-builder while keeping call sites readable. Its real API is the cross-structure content:
-  `cubeBox_eq_preimage_ofLp`, `measurableSet_cubeBox`, and `volume_cubeBox`
-  (`volume (cubeBox d I) = volume I ^ d`). The cubes of the LP bound are written inline as
-  `cubeBox d (Set.Ico 0 L) = [0, L)^d` and `cubeBox d (Set.Icc r (L - r)) = [r, L-r]^d` — there are
-  deliberately no named specialisations (and hence no per-cube API to maintain);
-* the scaled standard basis `cubeBasis d L hL` (also a reducible `abbrev`) and the cubic lattice
+* the measure theory of coordinate cubes `{x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I}`.
+  There is deliberately **no definition** for this set: the set-builder is written inline
+  (membership is judgementally `∀ i, x i ∈ I`, so no membership or unfolding API exists at all).
+  The lemmas record the genuine content: such a cube is the `ofLp`-preimage of a product box
+  (`cube_eq_preimage_ofLp`), is measurable (`measurableSet_cube`), and has volume `volume I ^ d`
+  (`volume_cube`, with endpoint corollaries `volume_cube_Ico`/`volume_cube_Icc`);
+* the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev`) and the cubic lattice
   `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice` instances.
   `cubeLattice` is the one standalone definition, kept so it can carry those instances;
-* the basic geometry: `cubeBox d (Set.Ico 0 L)` is the fundamental domain of `cubeBasis`
+* the basic geometry: `[0, L)^d` is the fundamental domain of `cubeBasis`
   (`fundamentalDomain_cubeBasis`), every point has a unique lattice translate in it
-  (`cubeLattice_unique_covers`), it is bounded (`isBounded_cubeBox_Ico`), and only finitely many
+  (`cubeLattice_unique_covers`), it is bounded (`isBounded_cube_Ico`), and only finitely many
   lattice points lie in a ball (`finite_lattice_in_ball`).
 
 Everything is placed in the `EuclideanSpace` namespace, its natural home.
@@ -44,15 +42,15 @@ What genuinely needs the cube — and is *not* available for a general `ZSpan.fu
 is the boundary control of the LP bound, which rests on two facts with no current Mathlib analogue:
 
 * an **inradius / boundary-safe inner core**: a ball of radius `r` about a point of the inner cube
-  `cubeBox d (Set.Icc r (L - r))` stays inside `cubeBox d (Set.Ico 0 L)`
-  (`ball_subset_cubeBox_of_mem_inner`). For a sheared parallelepiped the safe inner region is not a
-  coordinate-box shrink; it depends on the dual-basis norms / the parallelepiped inradius.
+  `[r, L-r]^d` stays inside `[0, L)^d` (`ball_subset_cube_of_mem_inner` in `LPBound.lean`). For a
+  sheared parallelepiped the safe inner region is not a coordinate-box shrink; it depends on the
+  dual-basis norms / the parallelepiped inradius.
   *Upstream TODO:* `ZSpan.ball_subset_fundamentalDomain_of_mem_inner`.
 * a **boundary-shell volume asymptotic** under homothety: the relative volume of the
   `r`-neighbourhood of the cell boundary vanishes as the lattice is scaled (here the explicit
-  `((L+1)^d - (L-2)^d)/L^d → 0`, `tendsto_volume_cubeShell_div_volume_cubeBox_zero`). For a general
-  fundamental domain this is a Minkowski-content statement.  *Upstream TODO:*
-  `ZSpan.tendsto_volume_boundaryThickening_div_volume_fundamentalDomain_zero`.
+  `((L+1)^d - (L-2)^d)/L^d → 0`, `tendsto_volume_cubeShell_div_volume_cube_zero` in
+  `LPBound.lean`). For a general fundamental domain this is a Minkowski-content statement.
+  *Upstream TODO:* `ZSpan.tendsto_volume_boundaryThickening_div_volume_fundamentalDomain_zero`.
 
 So the answer to "why so much for `L • ℤ^d`?" is: the counting is generic (and is written that
 way), while the cube is the one fundamental domain whose inradius and boundary-shell volume are
@@ -69,15 +67,8 @@ namespace EuclideanSpace
 
 variable {d : ℕ}
 
-/-- The coordinate box `{x | ∀ i, x i ∈ I}` in `EuclideanSpace ℝ (Fin d)`: the points all of whose
-coordinates lie in `I ⊆ ℝ`. A reducible `abbrev`, so membership is definitionally `∀ i, x i ∈ I`
-and no membership/unfolding API is needed; the substantive API is `cubeBox_eq_preimage_ofLp`,
-`measurableSet_cubeBox`, and `volume_cubeBox`. -/
-@[expose] public abbrev cubeBox (d : ℕ) (I : Set ℝ) : Set (EuclideanSpace ℝ (Fin d)) :=
-  {x | ∀ i : Fin d, x i ∈ I}
-
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is `cubeBox d (Set.Ico 0 L)` (`fundamentalDomain_cubeBasis`).
+its fundamental domain is the cube `[0, L)^d` (`fundamentalDomain_cubeBasis`).
 
 This is a reducible *abbreviation*, not a standalone definition: it is a one-line shorthand for
 `Basis.isUnitSMul`, carries no API of its own, and is only ever passed straight to Mathlib's `ZSpan`
@@ -104,7 +95,8 @@ public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
 
 /-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
 public lemma fundamentalDomain_cubeBasis (L : ℝ) (hL : 0 < L) :
-    fundamentalDomain (cubeBasis d L hL) = cubeBox d (Set.Ico 0 L) := by
+    fundamentalDomain (cubeBasis d L hL) =
+      {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} := by
   ext x
   simp only [ZSpan.mem_fundamentalDomain, cubeBasis, Module.Basis.repr_isUnitSMul,
     Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
@@ -115,38 +107,51 @@ public lemma fundamentalDomain_cubeBasis (L : ℝ) (hL : 0 < L) :
 
 /-- Every point has a unique `cubeLattice` translate lying in the cube `[0, L)^d`. -/
 public lemma cubeLattice_unique_covers (L : ℝ) (hL : 0 < L) :
-    ∀ x, ∃! g : cubeLattice d L hL, g +ᵥ x ∈ cubeBox d (Set.Ico 0 L) := fun x => by
+    ∀ x, ∃! g : cubeLattice d L hL,
+      g +ᵥ x ∈ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} := fun x => by
   simpa [cubeLattice, fundamentalDomain_cubeBasis L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
 /-- The cube `[0, L)^d` is a bounded set. -/
-public lemma isBounded_cubeBox_Ico (L : ℝ) (hL : 0 < L) :
-    IsBounded (cubeBox d (Set.Ico 0 L)) := by
+public lemma isBounded_cube_Ico (L : ℝ) (hL : 0 < L) :
+    IsBounded {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} := by
   simpa [fundamentalDomain_cubeBasis L hL] using
     fundamentalDomain_isBounded (cubeBasis d L hL)
 
-/-- A coordinate box is the `ofLp`-preimage of the product box `∏ i, I`. This is the single
-preimage identity from which the boxes' measurability and volume are read off. -/
-public lemma cubeBox_eq_preimage_ofLp (I : Set ℝ) :
-    cubeBox d I =
+/-- A coordinate cube is the `ofLp`-preimage of the product box `∏ i, I`. This is the single
+preimage identity from which the cubes' measurability and volume are read off. -/
+public lemma cube_eq_preimage_ofLp (I : Set ℝ) :
+    {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} =
       (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' (Set.pi Set.univ fun _ : Fin d ↦ I) := by
   ext x; simp [Set.mem_pi]
 
-/-- A coordinate box over a measurable interval is measurable. -/
-public lemma measurableSet_cubeBox {I : Set ℝ} (hI : MeasurableSet I) :
-    MeasurableSet (cubeBox d I) := by
-  rw [cubeBox_eq_preimage_ofLp]
+/-- A coordinate cube over a measurable set of reals is measurable. -/
+public lemma measurableSet_cube {I : Set ℝ} (hI : MeasurableSet I) :
+    MeasurableSet {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} := by
+  rw [cube_eq_preimage_ofLp]
   exact (MeasurableSet.pi Set.countable_univ fun _ _ => hI).preimage
     (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
 
-/-- The volume of a coordinate box `cubeBox d I` is `volume I ^ d`. -/
-public lemma volume_cubeBox (I : Set ℝ) (hI : MeasurableSet I) :
-    volume (cubeBox d I) = volume I ^ d := by
-  rw [cubeBox_eq_preimage_ofLp,
+/-- The volume of a coordinate cube is `volume I ^ d`. -/
+public lemma volume_cube (I : Set ℝ) (hI : MeasurableSet I) :
+    volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} = volume I ^ d := by
+  rw [cube_eq_preimage_ofLp,
     (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage
       (MeasurableSet.pi Set.countable_univ fun _ _ ↦ hI).nullMeasurableSet,
     volume_pi, Measure.pi_pi]
   simp
+
+/-- The volume of the half-open cube `[a, b)^d` is `(b - a) ^ d`. -/
+public lemma volume_cube_Ico (a b : ℝ) :
+    volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico a b} =
+      ENNReal.ofReal (b - a) ^ d := by
+  rw [volume_cube _ measurableSet_Ico, Real.volume_Ico]
+
+/-- The volume of the closed cube `[a, b]^d` is `(b - a) ^ d`. -/
+public lemma volume_cube_Icc (a b : ℝ) :
+    volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc a b} =
+      ENNReal.ofReal (b - a) ^ d := by
+  rw [volume_cube _ measurableSet_Icc, Real.volume_Icc]
 
 /-- Only finitely many `cubeLattice` points lie in a ball of radius `R`. -/
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -11,12 +11,14 @@ public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
 For `d : ℕ` and `L : ℝ`, this file packages:
 
-* the measure theory of coordinate cubes `{x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I}`.
+* the measure theory of coordinate cubes `{x : EuclideanSpace ℝ ι | ∀ i, x i ∈ I}`, over an
+  arbitrary finite index type `ι` (the endpoint corollaries are specialised to `Fin d`).
   There is deliberately **no definition** for this set: the set-builder is written inline
   (membership is judgementally `∀ i, x i ∈ I`, so no membership or unfolding API exists at all).
   The lemmas record the genuine content: such a cube is the `ofLp`-preimage of a product box
-  (`cube_eq_preimage_ofLp`), is measurable (`measurableSet_cube`), and has volume `volume I ^ d`
-  (`volume_cube`, with endpoint corollaries `volume_cube_Ico`/`volume_cube_Icc`);
+  (`cube_eq_preimage_ofLp`), is measurable (`measurableSet_cube`), and has volume
+  `volume I ^ card ι` (`volume_cube`, with endpoint corollaries
+  `volume_cube_Ico`/`volume_cube_Icc`);
 * the basic geometry of the scaled standard lattice: `[0, L)^d` is the fundamental domain of the
   scaled standard basis (`fundamentalDomain_cubeBasis`), every point has a unique lattice
   translate in it (`cubeLattice_unique_covers`), it is bounded (`isBounded_cube_Ico`), and only
@@ -66,15 +68,14 @@ way), while the cube is the one fundamental domain whose inradius and boundary-s
 elementary.
 
 Upstream target: `Mathlib/Algebra/Module/ZLattice/` (scaled integer lattice) together with the
-measure-theoretic facts and the two general boundary lemmas above. Imports here are left as
-`public import Mathlib`; they are narrowed at upstreaming time.
+measure-theoretic facts and the two general boundary lemmas above.
 -/
 
 open MeasureTheory Metric ZSpan Module Bornology
 
 namespace EuclideanSpace
 
-variable {d : ℕ}
+variable {d : ℕ} {ι : Type*} [Fintype ι]
 
 /-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`, given `hL : 0 < L`. This is
 *notation*, not a definition: it elaborates literally to `Basis.isUnitSMul` on the standard basis,
@@ -104,9 +105,9 @@ public lemma fundamentalDomain_cubeBasis (L : ℝ) (hL : 0 < L) :
 
 /-- Every point has a unique translate along the lattice `L • ℤ^d` lying in the cube
 `[0, L)^d`. -/
-public lemma cubeLattice_unique_covers (L : ℝ) (hL : 0 < L) :
-    ∀ x, ∃! g : cubeLattice d L hL,
-      g +ᵥ x ∈ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} := fun x => by
+public lemma cubeLattice_unique_covers (L : ℝ) (hL : 0 < L) (x : EuclideanSpace ℝ (Fin d)) :
+    ∃! g : cubeLattice d L hL,
+      g +ᵥ x ∈ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} := by
   simpa [fundamentalDomain_cubeBasis L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
@@ -119,22 +120,22 @@ public lemma isBounded_cube_Ico (L : ℝ) (hL : 0 < L) :
 /-- A coordinate cube is the `ofLp`-preimage of the product box `∏ i, I`. This is the single
 preimage identity from which the cubes' measurability and volume are read off. -/
 public lemma cube_eq_preimage_ofLp (I : Set ℝ) :
-    {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} =
-      (fun x : EuclideanSpace ℝ (Fin d) ↦ x.ofLp) ⁻¹' (Set.pi Set.univ fun _ : Fin d ↦ I) := by
+    {x : EuclideanSpace ℝ ι | ∀ i, x i ∈ I} =
+      (fun x : EuclideanSpace ℝ ι ↦ x.ofLp) ⁻¹' (Set.pi Set.univ fun _ : ι ↦ I) := by
   ext x; simp [Set.mem_pi]
 
 /-- A coordinate cube over a measurable set of reals is measurable. -/
 public lemma measurableSet_cube {I : Set ℝ} (hI : MeasurableSet I) :
-    MeasurableSet {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} := by
+    MeasurableSet {x : EuclideanSpace ℝ ι | ∀ i, x i ∈ I} := by
   rw [cube_eq_preimage_ofLp]
   exact (MeasurableSet.pi Set.countable_univ fun _ _ => hI).preimage
-    (PiLp.volume_preserving_ofLp (ι := Fin d)).measurable
+    (PiLp.volume_preserving_ofLp (ι := ι)).measurable
 
-/-- The volume of a coordinate cube is `volume I ^ d`. -/
+/-- The volume of a coordinate cube is `volume I ^ card ι`. -/
 public lemma volume_cube (I : Set ℝ) (hI : MeasurableSet I) :
-    volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I} = volume I ^ d := by
+    volume {x : EuclideanSpace ℝ ι | ∀ i, x i ∈ I} = volume I ^ Fintype.card ι := by
   rw [cube_eq_preimage_ofLp,
-    (PiLp.volume_preserving_ofLp (ι := Fin d)).measure_preimage
+    (PiLp.volume_preserving_ofLp (ι := ι)).measure_preimage
       (MeasurableSet.pi Set.countable_univ fun _ _ ↦ hI).nullMeasurableSet,
     volume_pi, Measure.pi_pi]
   simp
@@ -143,15 +144,18 @@ public lemma volume_cube (I : Set ℝ) (hI : MeasurableSet I) :
 public lemma volume_cube_Ico (a b : ℝ) :
     volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico a b} =
       ENNReal.ofReal (b - a) ^ d := by
-  rw [volume_cube _ measurableSet_Ico, Real.volume_Ico]
+  rw [volume_cube _ measurableSet_Ico, Real.volume_Ico, Fintype.card_fin]
 
 /-- The volume of the closed cube `[a, b]^d` is `(b - a) ^ d`. -/
 public lemma volume_cube_Icc (a b : ℝ) :
     volume {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Icc a b} =
       ENNReal.ofReal (b - a) ^ d := by
-  rw [volume_cube _ measurableSet_Icc, Real.volume_Icc]
+  rw [volume_cube _ measurableSet_Icc, Real.volume_Icc, Fintype.card_fin]
 
-/-- Only finitely many points of the lattice `L • ℤ^d` lie in a ball of radius `R`. -/
+/-- Only finitely many points of the lattice `L • ℤ^d` lie in a ball of radius `R`. Basis-free
+sibling: `ZLattice.finite_norm_le` (`ForMathlib/SchwartzLatticeSummable.lean`) proves the same
+finiteness for any discrete `ℤ`-submodule of a proper space, with no basis and no `IsZLattice`;
+TODO: derive this lemma from it when both are upstreamed. -/
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :
     Set.Finite {g : cubeLattice d L hL | (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 R} := by
   refine (Set.Finite.preimage_embedding (f := ⟨fun g : cubeLattice d L hL =>

--- a/SpherePacking/ForMathlib/CoordCube.lean
+++ b/SpherePacking/ForMathlib/CoordCube.lean
@@ -17,13 +17,22 @@ For `d : ℕ` and `L : ℝ`, this file packages:
   The lemmas record the genuine content: such a cube is the `ofLp`-preimage of a product box
   (`cube_eq_preimage_ofLp`), is measurable (`measurableSet_cube`), and has volume `volume I ^ d`
   (`volume_cube`, with endpoint corollaries `volume_cube_Ico`/`volume_cube_Icc`);
-* the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev`) and the cubic lattice
-  `cubeLattice d L hL = L • ℤ^d` it spans, with `DiscreteTopology`/`IsZLattice` instances.
-  `cubeLattice` is the one standalone definition, kept so it can carry those instances;
-* the basic geometry: `[0, L)^d` is the fundamental domain of `cubeBasis`
-  (`fundamentalDomain_cubeBasis`), every point has a unique lattice translate in it
-  (`cubeLattice_unique_covers`), it is bounded (`isBounded_cube_Ico`), and only finitely many
-  lattice points lie in a ball (`finite_lattice_in_ball`).
+* the basic geometry of the scaled standard lattice: `[0, L)^d` is the fundamental domain of the
+  scaled standard basis (`fundamentalDomain_cubeBasis`), every point has a unique lattice
+  translate in it (`cubeLattice_unique_covers`), it is bounded (`isBounded_cube_Ico`), and only
+  finitely many lattice points lie in a ball (`finite_lattice_in_ball`).
+
+This file contains **no definitions at all** — only lemmas. The scaled standard basis and the
+cubic lattice `L • ℤ^d` it spans are *notation* (`cubeBasis d L hL`, `cubeLattice d L hL`),
+expanding literally to `Basis.isUnitSMul` on the standard basis and to
+`Submodule.span ℤ (Set.range …)` of it. Consequently:
+
+* there is no API and nothing to unfold — Mathlib's `ZSpan`/`ZLattice` lemmas apply directly to
+  the expansions, and the `DiscreteTopology`/`IsZLattice` instances are found by Mathlib's own
+  instance synthesis on the span spelling (no local instances needed);
+* the notations are declared `local`ly here and re-declared at their point of use in
+  `LPBound.lean`, following this project's existing pattern for cross-file notation (cf. `ℝ⁸`).
+  Exported lemma *types* contain only the expanded Mathlib terms.
 
 Everything is placed in the `EuclideanSpace` namespace, its natural home.
 
@@ -67,49 +76,36 @@ namespace EuclideanSpace
 
 variable {d : ℕ}
 
-/-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`; its span is `cubeLattice` and
-its fundamental domain is the cube `[0, L)^d` (`fundamentalDomain_cubeBasis`).
-
-This is a reducible *abbreviation*, not a standalone definition: it is a one-line shorthand for
-`Basis.isUnitSMul`, carries no API of its own, and is only ever passed straight to Mathlib's `ZSpan`
-basis lemmas. Keeping it `abbrev` (rather than `def`) means it unfolds definitionally — no unfolding
-lemmas, no `cubeBasis_apply`-style API — so it behaves like notation while still accepting the
-positivity proof `hL` that a syntactic `notation` could not supply to `IsUnit.mk0`. -/
-@[expose] public noncomputable abbrev cubeBasis (d : ℕ) (L : ℝ) (hL : 0 < L) :
-    Basis (Fin d) ℝ (EuclideanSpace ℝ (Fin d)) :=
+/-- The standard basis of `EuclideanSpace ℝ (Fin d)` scaled by `L`, given `hL : 0 < L`. This is
+*notation*, not a definition: it elaborates literally to `Basis.isUnitSMul` on the standard basis,
+so Mathlib's `ZSpan` lemmas apply to it directly and there is nothing to unfold. -/
+local notation:max "cubeBasis " d:max L:max hL:max =>
   (EuclideanSpace.basisFun (Fin d) ℝ).toBasis.isUnitSMul fun _ : Fin d ↦ IsUnit.mk0 L hL.ne'
 
-/-- The cubic lattice `L • ℤ^d`, spanned by `cubeBasis d L hL`. Standalone so it can carry
-`ZLattice`/`DiscreteTopology` instances and act as the period lattice of the cube packing. -/
-@[expose] public noncomputable def cubeLattice (d : ℕ) (L : ℝ) (hL : 0 < L) :
-    Submodule ℤ (EuclideanSpace ℝ (Fin d)) :=
+/-- The cubic lattice `L • ℤ^d`, the span of `cubeBasis d L hL`. This is *notation*, not a
+definition: it elaborates literally to `Submodule.span ℤ (Set.range …)`, so Mathlib's
+`DiscreteTopology`/`IsZLattice` instances for spans of basis ranges apply to it directly. -/
+local notation:max "cubeLattice " d:max L:max hL:max =>
   Submodule.span ℤ (Set.range (cubeBasis d L hL))
 
-public instance instDiscreteTopology_cubeLattice (L : ℝ) (hL : 0 < L) :
-    DiscreteTopology (cubeLattice d L hL) :=
-  inferInstanceAs (DiscreteTopology (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
-
-public instance instIsZLattice_cubeLattice (L : ℝ) (hL : 0 < L) :
-    IsZLattice ℝ (cubeLattice d L hL) :=
-  inferInstanceAs (IsZLattice ℝ (Submodule.span ℤ (Set.range (cubeBasis d L hL))))
-
-/-- The fundamental domain of the scaled basis `cubeBasis d L hL` is the cube `[0, L)^d`. -/
+/-- The fundamental domain of the scaled standard basis is the cube `[0, L)^d`. -/
 public lemma fundamentalDomain_cubeBasis (L : ℝ) (hL : 0 < L) :
     fundamentalDomain (cubeBasis d L hL) =
       {x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ Set.Ico 0 L} := by
   ext x
-  simp only [ZSpan.mem_fundamentalDomain, cubeBasis, Module.Basis.repr_isUnitSMul,
+  simp only [ZSpan.mem_fundamentalDomain, Module.Basis.repr_isUnitSMul,
     Units.smul_def, Units.val_inv_eq_inv_val, IsUnit.unit_spec, smul_eq_mul,
     OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr, Set.mem_setOf_eq,
     Set.mem_Ico]
   exact forall_congr' fun i =>
     and_congr (mul_nonneg_iff_of_pos_left (inv_pos.2 hL)) (inv_mul_lt_one₀ hL)
 
-/-- Every point has a unique `cubeLattice` translate lying in the cube `[0, L)^d`. -/
+/-- Every point has a unique translate along the lattice `L • ℤ^d` lying in the cube
+`[0, L)^d`. -/
 public lemma cubeLattice_unique_covers (L : ℝ) (hL : 0 < L) :
     ∀ x, ∃! g : cubeLattice d L hL,
       g +ᵥ x ∈ {y : EuclideanSpace ℝ (Fin d) | ∀ i, y i ∈ Set.Ico 0 L} := fun x => by
-  simpa [cubeLattice, fundamentalDomain_cubeBasis L hL] using
+  simpa [fundamentalDomain_cubeBasis L hL] using
     exist_unique_vadd_mem_fundamentalDomain (cubeBasis d L hL) x
 
 /-- The cube `[0, L)^d` is a bounded set. -/
@@ -153,13 +149,13 @@ public lemma volume_cube_Icc (a b : ℝ) :
       ENNReal.ofReal (b - a) ^ d := by
   rw [volume_cube _ measurableSet_Icc, Real.volume_Icc]
 
-/-- Only finitely many `cubeLattice` points lie in a ball of radius `R`. -/
+/-- Only finitely many points of the lattice `L • ℤ^d` lie in a ball of radius `R`. -/
 public lemma finite_lattice_in_ball (L : ℝ) (hL : 0 < L) (R : ℝ) :
     Set.Finite {g : cubeLattice d L hL | (g : EuclideanSpace ℝ (Fin d)) ∈ ball 0 R} := by
   refine (Set.Finite.preimage_embedding (f := ⟨fun g : cubeLattice d L hL =>
-    (g : EuclideanSpace ℝ (Fin d)), Subtype.val_injective⟩) (by
-      simpa [cubeLattice] using ZSpan.setFinite_inter (b := cubeBasis d L hL)
-        (s := ball (0 : EuclideanSpace ℝ (Fin d)) R) Metric.isBounded_ball)).subset fun g hg => ?_
+    (g : EuclideanSpace ℝ (Fin d)), Subtype.val_injective⟩)
+    (ZSpan.setFinite_inter (b := cubeBasis d L hL)
+      (s := ball (0 : EuclideanSpace ℝ (Fin d)) R) Metric.isBounded_ball)).subset fun g hg => ?_
   exact ⟨hg, g.property⟩
 
 end EuclideanSpace

--- a/SpherePacking/ForMathlib/CoordCube.md
+++ b/SpherePacking/ForMathlib/CoordCube.md
@@ -1,0 +1,99 @@
+# Mathlib PR-overlap report: `CoordCube.lean`
+
+*Prepared June 2026. PR data verified directly against the GitHub REST API; `gh` was unavailable in
+the build environment.*
+
+## What this file contributes
+
+`SpherePacking/ForMathlib/CoordCube.lean` packages the scaled integer lattice `L·ℤ^d` and its
+coordinate cube in `EuclideanSpace ℝ (Fin d)`:
+
+- `cubeIco d L = [0,L)^d` (the fundamental domain) and `cubeIcc d L r = [r,L−r]^d` (the
+  boundary-safe core), with membership/preimage API;
+- the scaled standard basis `cubeBasis d L hL` (via `Basis.isUnitSMul`) and the lattice
+  `cubeLattice d L hL = span ℤ (range (cubeBasis …))`, with `DiscreteTopology`/`IsZLattice`
+  instances;
+- the geometry/measure: `cubeIco` is the fundamental domain of `cubeBasis`
+  (`fundamentalDomain_cubeBasis_eq_cubeIco`), unique covering, boundedness, volumes `L^d` and
+  `(L−2r)^d`, and finiteness of lattice points in a ball.
+
+It is the period-lattice/fundamental-domain machinery of the cube sphere packing used by the
+Cohn–Elkies density approximation in `LPBound.lean`.
+
+## Relationship to existing Mathlib (`ZSpan`)
+
+The generic lattice facts here are **thin specialisations of Mathlib's `ZSpan` API** for an arbitrary
+basis (`Mathlib/Algebra/Module/ZLattice/Basic.lean`): `fundamentalDomain` (line 92),
+`fundamentalDomain_isBounded` (248), `exist_unique_vadd_mem_fundamentalDomain` (261),
+`setFinite_inter` (331), `measure_fundamentalDomain`/`volume_fundamentalDomain` (372/388),
+`isAddFundamentalDomain` (353). Indeed `cubeIco d L` *is* `ZSpan.fundamentalDomain (cubeBasis d L hL)`
+(proved here), and our unique-covering / boundedness / finiteness lemmas are already one-line
+delegations to the corresponding `ZSpan` lemmas.
+
+What is **irreducibly cube-specific** is only:
+
+1. the explicit coordinate cube `[0,L)^d` and inner cube `[r,L−r]^d` (coordinate access, needed for
+   the LP boundary analysis);
+2. the explicit volumes `L^d` and `(L−2r)^d`, and the boundary-shell asymptotics
+   `((L+1)^d − (L−2)^d)/L^d → 0`.
+
+This is the answer to the natural "why so much for `L·ℤ^n`?" question: the *counting / fundamental
+domain* content is generic (and should ultimately be consumed from `ZSpan` directly, not re-derived),
+while the *boundary geometry* genuinely requires the cube — see the "Two missing Mathlib lemmas"
+section below.
+
+## Adjacent open PRs (`Algebra/Module/ZLattice`)
+
+Two open PRs touch the same fundamental-domain / `ZSpan` area:
+
+- **#10345 — "feat(Algebra.Module.Zlattice): Add Voronoi Domain"** —
+  <https://github.com/leanprover-community/mathlib4/pull/10345> (author **newell**, open). A Voronoi
+  domain is an alternative fundamental domain of a lattice. This is the closest neighbour: it
+  develops fundamental-domain theory for lattices and is the place where a *general* (non-cube)
+  fundamental-domain volume/boundary API would most naturally live.
+- **#33746 — "feat(Algebra/Module/ZLattice): align `ZSpan.floor` to `Int.floor` API"** —
+  <https://github.com/leanprover-community/mathlib4/pull/33746> (author **ster-oc**, open). API
+  alignment on the `ZSpan.floor`/`fract` functions underlying `fundamentalDomain`. Worth tracking so
+  any cube lemmas we upstream use the post-alignment names.
+
+No open PR adds a scaled-integer-lattice cube or its volume specifically; that part is uncontested.
+
+## Two missing Mathlib lemmas (future contributions)
+
+A planned general-basis refactor of `LPBound.lean` showed that the cube cannot be eliminated from the
+density argument without two lemmas that **do not currently exist in Mathlib**. Both are natural
+additions to `Mathlib/Algebra/Module/ZLattice/` (and would also serve PR #10345's Voronoi-domain
+theory):
+
+1. **`ZSpan.ball_subset_fundamentalDomain_of_mem_inner`** — an inradius / boundary-safe inner core:
+   for a basis `b` and radius `r`, a suitable inner region of `fundamentalDomain b` has the property
+   that a Euclidean ball of radius `r` around any of its points stays inside the fundamental
+   parallelepiped. For a non-orthogonal basis this inner core is *not* a coordinate shrink (it depends
+   on the dual-basis norms / parallelepiped inradius), which is why the cube case is currently special.
+2. **`ZSpan.tendsto_volume_boundaryThickening_div_volume_fundamentalDomain_zero`** — a Minkowski-content
+   statement: the relative volume of the `r`-thickening of the fundamental-domain boundary vanishes
+   under lattice homothety (`t → ∞`), because the boundary thickening scales like `t^{d−1}` and the
+   cell like `t^d`. The cube proof replaces this with the explicit algebraic identity
+   `(L+1)^d − (L−2)^d` over `L^d`.
+
+These are recorded as TODOs in the module docstring of `CoordCube.lean`.
+
+## Collaboration avenues
+
+1. **Coordinate the general fundamental-domain volume/boundary API with PR #10345.** The two missing
+   lemmas above belong in the same Voronoi/fundamental-domain development; offering them as additions
+   to (or a follow-up of) #10345 avoids fragmenting the lattice-geometry API.
+2. **Upstream only the genuinely cube-specific content** — the scaled basis `cubeBasis`, the
+   identification `cubeIco = fundamentalDomain (cubeBasis …)`, and the explicit volumes — into
+   `Mathlib/Algebra/Module/ZLattice/`, consuming `ZSpan` for everything generic rather than
+   re-deriving it.
+3. **Track #33746** for the `ZSpan.floor`/`fract` naming so the upstreamed cube lemmas match.
+
+## Recommendation
+
+Most of this file is `ZSpan` plumbing and should not be upstreamed as-is; only the scaled cube and
+its volumes are new. The higher-value contribution is the **two missing general lemmas**, ideally
+coordinated with the Voronoi-domain PR #10345.
+
+**Upstream target:** `Mathlib/Algebra/Module/ZLattice/` (scaled-cube specialisation + the two general
+boundary lemmas).

--- a/SpherePacking/ForMathlib/CoordCube.md
+++ b/SpherePacking/ForMathlib/CoordCube.md
@@ -8,11 +8,12 @@ the build environment.*
 `SpherePacking/ForMathlib/CoordCube.lean` packages the scaled integer lattice `L·ℤ^d` and its
 coordinate boxes in `EuclideanSpace ℝ (Fin d)`:
 
-- the measure theory of coordinate cubes `{x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I}`. There is
-  deliberately **no definition** for this set — the set-builder is written inline, so membership is
-  judgemental and no membership/unfolding API exists. The lemmas carry the genuine content:
-  `cube_eq_preimage_ofLp`, `measurableSet_cube`, and `volume_cube` (`= volume I ^ d`, with endpoint
-  corollaries `volume_cube_Ico`/`volume_cube_Icc`);
+- the measure theory of coordinate cubes `{x : EuclideanSpace ℝ ι | ∀ i, x i ∈ I}`, over an
+  arbitrary finite index type `ι`. There is deliberately **no definition** for this set — the
+  set-builder is written inline, so membership is judgemental and no membership/unfolding API
+  exists. The lemmas carry the genuine content: `cube_eq_preimage_ofLp`, `measurableSet_cube`,
+  and `volume_cube` (`= volume I ^ card ι`, with `Fin d` endpoint corollaries
+  `volume_cube_Ico`/`volume_cube_Icc`);
 - the scaled standard basis `cubeBasis d L hL` and the lattice
   `cubeLattice d L hL = span ℤ (range (cubeBasis …))` — both are *local notation*, not
   definitions: they expand literally to `Basis.isUnitSMul` and `Submodule.span`, so Mathlib's

--- a/SpherePacking/ForMathlib/CoordCube.md
+++ b/SpherePacking/ForMathlib/CoordCube.md
@@ -13,9 +13,11 @@ coordinate boxes in `EuclideanSpace ℝ (Fin d)`:
   judgemental and no membership/unfolding API exists. The lemmas carry the genuine content:
   `cube_eq_preimage_ofLp`, `measurableSet_cube`, and `volume_cube` (`= volume I ^ d`, with endpoint
   corollaries `volume_cube_Ico`/`volume_cube_Icc`);
-- the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev` over `Basis.isUnitSMul`) and
-  the lattice `cubeLattice d L hL = span ℤ (range (cubeBasis …))` — the one standalone definition,
-  kept to carry the `DiscreteTopology`/`IsZLattice` instances;
+- the scaled standard basis `cubeBasis d L hL` and the lattice
+  `cubeLattice d L hL = span ℤ (range (cubeBasis …))` — both are *local notation*, not
+  definitions: they expand literally to `Basis.isUnitSMul` and `Submodule.span`, so Mathlib's
+  `ZSpan`/`ZLattice` lemmas and the `DiscreteTopology`/`IsZLattice` instances apply directly to
+  the expansions (the file contains no definitions and no instances at all, only lemmas);
 - the geometry: `[0, L)^d` is the fundamental domain of `cubeBasis`
   (`fundamentalDomain_cubeBasis`), unique covering (`cubeLattice_unique_covers`), boundedness
   (`isBounded_cube_Ico`), and finiteness of lattice points in a ball

--- a/SpherePacking/ForMathlib/CoordCube.md
+++ b/SpherePacking/ForMathlib/CoordCube.md
@@ -6,16 +6,21 @@ the build environment.*
 ## What this file contributes
 
 `SpherePacking/ForMathlib/CoordCube.lean` packages the scaled integer lattice `L·ℤ^d` and its
-coordinate cube in `EuclideanSpace ℝ (Fin d)`:
+coordinate boxes in `EuclideanSpace ℝ (Fin d)`:
 
-- `cubeIco d L = [0,L)^d` (the fundamental domain) and `cubeIcc d L r = [r,L−r]^d` (the
-  boundary-safe core), with membership/preimage API;
-- the scaled standard basis `cubeBasis d L hL` (via `Basis.isUnitSMul`) and the lattice
-  `cubeLattice d L hL = span ℤ (range (cubeBasis …))`, with `DiscreteTopology`/`IsZLattice`
-  instances;
-- the geometry/measure: `cubeIco` is the fundamental domain of `cubeBasis`
-  (`fundamentalDomain_cubeBasis_eq_cubeIco`), unique covering, boundedness, volumes `L^d` and
-  `(L−2r)^d`, and finiteness of lattice points in a ball.
+- the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}`, a reducible `abbrev` (membership is
+  definitional, so there is no membership/unfolding API), with the cross-structure content
+  `cubeBox_eq_preimage_ofLp`, `measurableSet_cubeBox`, and `volume_cubeBox`
+  (`volume (cubeBox d I) = volume I ^ d`). The LP bound's cubes are written inline as
+  `cubeBox d (Set.Ico 0 L) = [0,L)^d` and `cubeBox d (Set.Icc r (L−r)) = [r,L−r]^d`; there are
+  deliberately no named per-cube specialisations;
+- the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev` over `Basis.isUnitSMul`) and
+  the lattice `cubeLattice d L hL = span ℤ (range (cubeBasis …))` — the one standalone definition,
+  kept to carry the `DiscreteTopology`/`IsZLattice` instances;
+- the geometry: `cubeBox d (Set.Ico 0 L)` is the fundamental domain of `cubeBasis`
+  (`fundamentalDomain_cubeBasis`), unique covering (`cubeLattice_unique_covers`), boundedness
+  (`isBounded_cubeBox_Ico`), and finiteness of lattice points in a ball
+  (`finite_lattice_in_ball`).
 
 It is the period-lattice/fundamental-domain machinery of the cube sphere packing used by the
 Cohn–Elkies density approximation in `LPBound.lean`.
@@ -26,7 +31,8 @@ The generic lattice facts here are **thin specialisations of Mathlib's `ZSpan` A
 basis (`Mathlib/Algebra/Module/ZLattice/Basic.lean`): `fundamentalDomain` (line 92),
 `fundamentalDomain_isBounded` (248), `exist_unique_vadd_mem_fundamentalDomain` (261),
 `setFinite_inter` (331), `measure_fundamentalDomain`/`volume_fundamentalDomain` (372/388),
-`isAddFundamentalDomain` (353). Indeed `cubeIco d L` *is* `ZSpan.fundamentalDomain (cubeBasis d L hL)`
+`isAddFundamentalDomain` (353). Indeed `cubeBox d (Set.Ico 0 L)` *is*
+`ZSpan.fundamentalDomain (cubeBasis d L hL)`
 (proved here), and our unique-covering / boundedness / finiteness lemmas are already one-line
 delegations to the corresponding `ZSpan` lemmas.
 
@@ -84,7 +90,7 @@ These are recorded as TODOs in the module docstring of `CoordCube.lean`.
    lemmas above belong in the same Voronoi/fundamental-domain development; offering them as additions
    to (or a follow-up of) #10345 avoids fragmenting the lattice-geometry API.
 2. **Upstream only the genuinely cube-specific content** — the scaled basis `cubeBasis`, the
-   identification `cubeIco = fundamentalDomain (cubeBasis …)`, and the explicit volumes — into
+   identification `cubeBox d (Set.Ico 0 L) = fundamentalDomain (cubeBasis …)`, and the box volume — into
    `Mathlib/Algebra/Module/ZLattice/`, consuming `ZSpan` for everything generic rather than
    re-deriving it.
 3. **Track #33746** for the `ZSpan.floor`/`fract` naming so the upstreamed cube lemmas match.

--- a/SpherePacking/ForMathlib/CoordCube.md
+++ b/SpherePacking/ForMathlib/CoordCube.md
@@ -8,18 +8,17 @@ the build environment.*
 `SpherePacking/ForMathlib/CoordCube.lean` packages the scaled integer lattice `L·ℤ^d` and its
 coordinate boxes in `EuclideanSpace ℝ (Fin d)`:
 
-- the coordinate box `cubeBox d I = {x | ∀ i, x i ∈ I}`, a reducible `abbrev` (membership is
-  definitional, so there is no membership/unfolding API), with the cross-structure content
-  `cubeBox_eq_preimage_ofLp`, `measurableSet_cubeBox`, and `volume_cubeBox`
-  (`volume (cubeBox d I) = volume I ^ d`). The LP bound's cubes are written inline as
-  `cubeBox d (Set.Ico 0 L) = [0,L)^d` and `cubeBox d (Set.Icc r (L−r)) = [r,L−r]^d`; there are
-  deliberately no named per-cube specialisations;
+- the measure theory of coordinate cubes `{x : EuclideanSpace ℝ (Fin d) | ∀ i, x i ∈ I}`. There is
+  deliberately **no definition** for this set — the set-builder is written inline, so membership is
+  judgemental and no membership/unfolding API exists. The lemmas carry the genuine content:
+  `cube_eq_preimage_ofLp`, `measurableSet_cube`, and `volume_cube` (`= volume I ^ d`, with endpoint
+  corollaries `volume_cube_Ico`/`volume_cube_Icc`);
 - the scaled standard basis `cubeBasis d L hL` (a reducible `abbrev` over `Basis.isUnitSMul`) and
   the lattice `cubeLattice d L hL = span ℤ (range (cubeBasis …))` — the one standalone definition,
   kept to carry the `DiscreteTopology`/`IsZLattice` instances;
-- the geometry: `cubeBox d (Set.Ico 0 L)` is the fundamental domain of `cubeBasis`
+- the geometry: `[0, L)^d` is the fundamental domain of `cubeBasis`
   (`fundamentalDomain_cubeBasis`), unique covering (`cubeLattice_unique_covers`), boundedness
-  (`isBounded_cubeBox_Ico`), and finiteness of lattice points in a ball
+  (`isBounded_cube_Ico`), and finiteness of lattice points in a ball
   (`finite_lattice_in_ball`).
 
 It is the period-lattice/fundamental-domain machinery of the cube sphere packing used by the
@@ -31,7 +30,7 @@ The generic lattice facts here are **thin specialisations of Mathlib's `ZSpan` A
 basis (`Mathlib/Algebra/Module/ZLattice/Basic.lean`): `fundamentalDomain` (line 92),
 `fundamentalDomain_isBounded` (248), `exist_unique_vadd_mem_fundamentalDomain` (261),
 `setFinite_inter` (331), `measure_fundamentalDomain`/`volume_fundamentalDomain` (372/388),
-`isAddFundamentalDomain` (353). Indeed `cubeBox d (Set.Ico 0 L)` *is*
+`isAddFundamentalDomain` (353). Indeed the cube `[0, L)^d` *is*
 `ZSpan.fundamentalDomain (cubeBasis d L hL)`
 (proved here), and our unique-covering / boundedness / finiteness lemmas are already one-line
 delegations to the corresponding `ZSpan` lemmas.
@@ -90,7 +89,7 @@ These are recorded as TODOs in the module docstring of `CoordCube.lean`.
    lemmas above belong in the same Voronoi/fundamental-domain development; offering them as additions
    to (or a follow-up of) #10345 avoids fragmenting the lattice-geometry API.
 2. **Upstream only the genuinely cube-specific content** — the scaled basis `cubeBasis`, the
-   identification `cubeBox d (Set.Ico 0 L) = fundamentalDomain (cubeBasis …)`, and the box volume — into
+   identification `[0, L)^d = fundamentalDomain (cubeBasis …)`, and the cube volume — into
    `Mathlib/Algebra/Module/ZLattice/`, consuming `ZSpan` for everything generic rather than
    re-deriving it.
 3. **Track #33746** for the `ZSpan.floor`/`fract` naming so the upstreamed cube lemmas match.

--- a/SpherePacking/ForMathlib/DualLattice.lean
+++ b/SpherePacking/ForMathlib/DualLattice.lean
@@ -19,12 +19,14 @@ For a nondegenerate bilinear form `B` on a finite-dimensional real vector space 
 This closes part of the TODO in `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean`
 ("Properly develop the material in the context of lattices"). For the Euclidean inner product the
 nondegeneracy hypothesis is automatic, so we additionally register the discreteness as an instance
-(`innerₗ_nondegenerate` + the `instance` below); this is what the Cohn–Elkies linear-programming
+(`instDiscreteTopology_dualSubmodule_innerₗ` below); this is what the Cohn–Elkies linear-programming
 bound consumes when summing over the dual lattice.
 
 Upstream target: `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean` (plus the inner-product
-instance near `Mathlib/Analysis/InnerProductSpace/`). Imports here are left as `public import
-Mathlib`; they are narrowed at upstreaming time.
+instance near `Mathlib/Analysis/InnerProductSpace/`). At upstreaming time one would also add the
+companion `IsZLattice ℝ (B.dualSubmodule Λ)` (not needed here — the LP bound consumes only
+discreteness). Imports here are left as `public import Mathlib`; they are narrowed at upstreaming
+time.
 -/
 
 open scoped RealInnerProductSpace
@@ -53,14 +55,13 @@ section InnerProduct
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
 
-/-- The Euclidean inner product, viewed as a bilinear form, is nondegenerate. -/
-public theorem innerₗ_nondegenerate : (innerₗ E : LinearMap.BilinForm ℝ E).Nondegenerate := by
-  constructor <;> intro x hx <;>
-    exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))
-
-/-- The dual of a full `ℤ`-lattice for the Euclidean inner product is discrete. -/
-public instance [FiniteDimensional ℝ E] (Λ : Submodule ℤ E) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
+/-- The dual of a full `ℤ`-lattice for the Euclidean inner product is discrete. The nondegeneracy
+of `innerₗ E` is automatic (`⟪x, x⟫ = 0 ↔ x = 0`), so this is an instance. -/
+public instance instDiscreteTopology_dualSubmodule_innerₗ [FiniteDimensional ℝ E]
+    (Λ : Submodule ℤ E) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
     DiscreteTopology (LinearMap.BilinForm.dualSubmodule (innerₗ E) Λ) :=
-  LinearMap.BilinForm.discreteTopology_dualSubmodule innerₗ_nondegenerate Λ
+  LinearMap.BilinForm.discreteTopology_dualSubmodule
+    (by constructor <;> intro x hx <;>
+      exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))) Λ
 
 end InnerProduct

--- a/SpherePacking/ForMathlib/DualLattice.lean
+++ b/SpherePacking/ForMathlib/DualLattice.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
 -/
 module
-public import Mathlib
+public import Mathlib.Algebra.Module.ZLattice.Basic
+public import Mathlib.Algebra.Ring.IsFormallyReal
+public import Mathlib.Data.Real.Hom
+public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
 
 /-! # The dual of a `ℤ`-lattice is a discrete `ℤ`-lattice
 

--- a/SpherePacking/ForMathlib/DualLattice.lean
+++ b/SpherePacking/ForMathlib/DualLattice.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Sidharth Hariharan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sidharth Hariharan
+-/
+module
+public import Mathlib
+
+/-! # The dual of a `ℤ`-lattice is a discrete `ℤ`-lattice
+
+For a nondegenerate bilinear form `B` on a finite-dimensional real vector space `M`, the dual
+`ℤ`-submodule `B.dualSubmodule Λ` of a full `ℤ`-lattice `Λ` is again discrete: by
+`BilinForm.dualSubmodule_span_of_basis` it is spanned by the dual basis of an integral basis of
+`Λ`, hence is itself the span of an `ℝ`-basis, i.e. a `ℤ`-lattice.
+
+This closes part of the TODO in `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean`
+("Properly develop the material in the context of lattices"). For the Euclidean inner product the
+nondegeneracy hypothesis is automatic, so we additionally register the discreteness as an instance
+(`innerₗ_nondegenerate` + the `instance` below); this is what the Cohn–Elkies linear-programming
+bound consumes when summing over the dual lattice.
+
+Upstream target: `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean` (plus the inner-product
+instance near `Mathlib/Analysis/InnerProductSpace/`). Imports here are left as `public import
+Mathlib`; they are narrowed at upstreaming time.
+-/
+
+open scoped RealInnerProductSpace
+open LinearMap (BilinForm)
+
+namespace LinearMap.BilinForm
+
+variable {M : Type*} [NormedAddCommGroup M] [NormedSpace ℝ M] [FiniteDimensional ℝ M]
+
+/-- The dual of a full `ℤ`-lattice with respect to a nondegenerate bilinear form is discrete: it
+is spanned by the dual basis of an integral basis of the lattice. -/
+public theorem discreteTopology_dualSubmodule {B : BilinForm ℝ M} (hB : B.Nondegenerate)
+    (Λ : Submodule ℤ M) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
+    DiscreteTopology (B.dualSubmodule Λ) := by
+  -- `bZ` is an integral basis of `Λ`; its `B`-dual basis spans the dual submodule.
+  let bZ := Module.Free.chooseBasis ℤ Λ
+  have hspan : B.dualSubmodule Λ =
+      Submodule.span ℤ (Set.range (B.dualBasis hB (bZ.ofZLatticeBasis ℝ Λ))) := by
+    simpa [bZ.ofZLatticeBasis_span (K := ℝ) (L := Λ)] using
+      dualSubmodule_span_of_basis (B := B) (R := ℤ) (S := ℝ) hB (bZ.ofZLatticeBasis ℝ Λ)
+  exact hspan ▸ inferInstance
+
+end LinearMap.BilinForm
+
+section InnerProduct
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The Euclidean inner product, viewed as a bilinear form, is nondegenerate. -/
+public theorem innerₗ_nondegenerate : (innerₗ E : LinearMap.BilinForm ℝ E).Nondegenerate := by
+  constructor <;> intro x hx <;>
+    exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))
+
+/-- The dual of a full `ℤ`-lattice for the Euclidean inner product is discrete. -/
+public instance [FiniteDimensional ℝ E] (Λ : Submodule ℤ E) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
+    DiscreteTopology (LinearMap.BilinForm.dualSubmodule (innerₗ E) Λ) :=
+  LinearMap.BilinForm.discreteTopology_dualSubmodule innerₗ_nondegenerate Λ
+
+end InnerProduct

--- a/SpherePacking/ForMathlib/DualLattice.lean
+++ b/SpherePacking/ForMathlib/DualLattice.lean
@@ -5,6 +5,9 @@ Authors: Sidharth Hariharan
 -/
 module
 public import Mathlib.Algebra.Module.ZLattice.Basic
+-- The two imports below are `#min_imports` artifacts: they carry instances that the elaboration
+-- of this file's statements depends on (cf. the `CStarMatrix` note in
+-- `SpherePacking/UpperBound.lean`). Do not remove without a full build.
 public import Mathlib.Algebra.Ring.IsFormallyReal
 public import Mathlib.Data.Real.Hom
 public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
@@ -18,15 +21,14 @@ For a nondegenerate bilinear form `B` on a finite-dimensional real vector space 
 
 This closes part of the TODO in `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean`
 ("Properly develop the material in the context of lattices"). For the Euclidean inner product the
-nondegeneracy hypothesis is automatic, so we additionally register the discreteness as an instance
-(`instDiscreteTopology_dualSubmodule_innerₗ` below); this is what the Cohn–Elkies linear-programming
-bound consumes when summing over the dual lattice.
+nondegeneracy hypothesis is automatic (`innerₗ_nondegenerate`), so we additionally register the
+discreteness as an instance; this is what the Cohn–Elkies linear-programming bound consumes when
+summing over the dual lattice.
 
 Upstream target: `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean` (plus the inner-product
 instance near `Mathlib/Analysis/InnerProductSpace/`). At upstreaming time one would also add the
 companion `IsZLattice ℝ (B.dualSubmodule Λ)` (not needed here — the LP bound consumes only
-discreteness). Imports here are left as `public import Mathlib`; they are narrowed at upstreaming
-time.
+discreteness).
 -/
 
 open scoped RealInnerProductSpace
@@ -55,13 +57,15 @@ section InnerProduct
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
 
+/-- The real inner product, as a bilinear form, is nondegenerate: `⟪x, x⟫ = 0 ↔ x = 0`. -/
+public theorem innerₗ_nondegenerate : LinearMap.BilinForm.Nondegenerate (innerₗ E) := by
+  constructor <;> intro x hx <;>
+    exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))
+
 /-- The dual of a full `ℤ`-lattice for the Euclidean inner product is discrete. The nondegeneracy
-of `innerₗ E` is automatic (`⟪x, x⟫ = 0 ↔ x = 0`), so this is an instance. -/
-public instance instDiscreteTopology_dualSubmodule_innerₗ [FiniteDimensional ℝ E]
-    (Λ : Submodule ℤ E) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
-    DiscreteTopology (LinearMap.BilinForm.dualSubmodule (innerₗ E) Λ) :=
-  LinearMap.BilinForm.discreteTopology_dualSubmodule
-    (by constructor <;> intro x hx <;>
-      exact inner_self_eq_zero.1 (by simpa [innerₗ_apply_apply] using hx x : ⟪x, x⟫ = (0 : ℝ))) Λ
+of `innerₗ E` is automatic (`innerₗ_nondegenerate`), so this is an instance. -/
+public instance [FiniteDimensional ℝ E] (Λ : Submodule ℤ E) [DiscreteTopology Λ]
+    [IsZLattice ℝ Λ] : DiscreteTopology (LinearMap.BilinForm.dualSubmodule (innerₗ E) Λ) :=
+  LinearMap.BilinForm.discreteTopology_dualSubmodule innerₗ_nondegenerate Λ
 
 end InnerProduct

--- a/SpherePacking/ForMathlib/DualLattice.md
+++ b/SpherePacking/ForMathlib/DualLattice.md
@@ -1,0 +1,70 @@
+# Mathlib PR-overlap report: `DualLattice.lean`
+
+*Prepared June 2026. PR data verified directly against the GitHub REST API; `gh` was unavailable in
+the build environment.*
+
+## What this file contributes
+
+`SpherePacking/ForMathlib/DualLattice.lean` proves that the dual of a `ℤ`-lattice is again a discrete
+`ℤ`-lattice:
+
+```
+theorem LinearMap.BilinForm.discreteTopology_dualSubmodule
+    {B : BilinForm ℝ M} (hB : B.Nondegenerate)
+    (Λ : Submodule ℤ M) [DiscreteTopology Λ] [IsZLattice ℝ Λ] :
+    DiscreteTopology (B.dualSubmodule Λ)
+```
+
+for a nondegenerate bilinear form `B` on a finite-dimensional real space `M`. The proof uses the
+existing `BilinForm.dualSubmodule_span_of_basis`: the dual submodule is spanned by the `B`-dual basis
+of an integral basis of `Λ`, hence is itself the `ℤ`-span of an `ℝ`-basis — a lattice. The file also
+records `innerₗ_nondegenerate` (the Euclidean inner product is a nondegenerate bilinear form) and, for
+the inner-product case, registers the discreteness as an `instance`. The Cohn–Elkies bound consumes
+exactly this instance when summing over the dual lattice.
+
+## Overlap with existing Mathlib / open PRs
+
+**There is no open PR on dual lattices.** A search of the open queue for "dual lattice" returned only
+unrelated order-theoretic "dualisation" PRs (e.g. lattice-of-cones, `to_dual` for filters). The
+number-theoretic dual lattice is **uncontested**.
+
+(An earlier automated survey did not invent any dual-lattice PRs; this nil result is confirmed.)
+
+This file directly addresses an explicit Mathlib **TODO**. In
+`Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean`:
+
+- the module header lists `BilinForm.dualSubmodule_span_of_basis` ("the dual of a lattice is spanned
+  by the dual basis") and then a `## TODO` (around line 18) to **"Properly develop the material in the
+  context of lattices"**;
+- line 67 carries a further `-- TODO: Show that this is perfect when N is a lattice and B is
+  nondegenerate.`
+
+Our `discreteTopology_dualSubmodule` is precisely the first step of "develop the material in the
+context of lattices": it upgrades the existing *spanning* fact to the *lattice* fact (discreteness /
+being a `ZLattice`). It is built entirely on declarations already in that file
+(`dualSubmodule_span_of_basis`, `dualBasis`) plus `Basis.ofZLatticeBasis_span`.
+
+## Collaboration avenues
+
+1. **Submit directly into `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean`**, quoting the TODO it
+   resolves. Because it reuses that file's own API, the PR is self-contained and reviewer-friendly.
+2. **Consider strengthening to `IsZLattice ℝ (B.dualSubmodule Λ)`**, not merely `DiscreteTopology` —
+   the proof already exhibits the dual as the span of an `ℝ`-basis, so the full `ZLattice` instance is
+   within reach and is the more useful statement (it lets downstream users invoke covolume / Poisson
+   machinery on the dual). This also makes a larger dent in the "develop the material in the context
+   of lattices" TODO.
+3. **The inner-product instance** (`innerₗ_nondegenerate` + the `DiscreteTopology` instance for
+   `dualSubmodule (innerₗ E) Λ`) belongs near `Mathlib/Analysis/InnerProductSpace/`; offer it as a
+   second, smaller PR or a follow-up section so the bilinear-form file stays free of inner-product
+   imports.
+
+## Recommendation
+
+**Clean, uncontested upstream contribution that closes a standing TODO.** Submit
+`discreteTopology_dualSubmodule` (ideally upgraded to the full `IsZLattice` instance) into
+`DualLattice.lean`, and the Euclidean instance into the inner-product hierarchy. No coordination with
+other PRs is required; the only design choice is whether to ship `DiscreteTopology` or the stronger
+`IsZLattice`.
+
+**Upstream target:** `Mathlib/LinearAlgebra/BilinearForm/DualLattice.lean` (+ the inner-product
+instance near `Mathlib/Analysis/InnerProductSpace/`).

--- a/SpherePacking/ForMathlib/DualLattice.md
+++ b/SpherePacking/ForMathlib/DualLattice.md
@@ -17,10 +17,11 @@ theorem LinearMap.BilinForm.discreteTopology_dualSubmodule
 
 for a nondegenerate bilinear form `B` on a finite-dimensional real space `M`. The proof uses the
 existing `BilinForm.dualSubmodule_span_of_basis`: the dual submodule is spanned by the `B`-dual basis
-of an integral basis of `Λ`, hence is itself the `ℤ`-span of an `ℝ`-basis — a lattice. The file also
-records `innerₗ_nondegenerate` (the Euclidean inner product is a nondegenerate bilinear form) and, for
-the inner-product case, registers the discreteness as an `instance`. The Cohn–Elkies bound consumes
-exactly this instance when summing over the dual lattice.
+of an integral basis of `Λ`, hence is itself the `ℤ`-span of an `ℝ`-basis — a lattice. For the
+inner-product case the file registers the discreteness as the named instance
+`instDiscreteTopology_dualSubmodule_innerₗ`; the Euclidean nondegeneracy fact (formerly the separate
+`innerₗ_nondegenerate`, a one-call composition) is now inlined into that instance during cleanup. The
+Cohn–Elkies bound consumes exactly this instance when summing over the dual lattice.
 
 ## Overlap with existing Mathlib / open PRs
 

--- a/SpherePacking/ForMathlib/DualLattice.md
+++ b/SpherePacking/ForMathlib/DualLattice.md
@@ -18,9 +18,8 @@ theorem LinearMap.BilinForm.discreteTopology_dualSubmodule
 for a nondegenerate bilinear form `B` on a finite-dimensional real space `M`. The proof uses the
 existing `BilinForm.dualSubmodule_span_of_basis`: the dual submodule is spanned by the `B`-dual basis
 of an integral basis of `Λ`, hence is itself the `ℤ`-span of an `ℝ`-basis — a lattice. For the
-inner-product case the file registers the discreteness as the named instance
-`instDiscreteTopology_dualSubmodule_innerₗ`; the Euclidean nondegeneracy fact (formerly the separate
-`innerₗ_nondegenerate`, a one-call composition) is now inlined into that instance during cleanup. The
+inner-product case the file registers the discreteness as an (anonymous) instance, with the
+Euclidean nondegeneracy fact stated separately as the reusable lemma `innerₗ_nondegenerate`. The
 Cohn–Elkies bound consumes exactly this instance when summing over the dual lattice.
 
 ## Overlap with existing Mathlib / open PRs

--- a/SpherePacking/ForMathlib/FourierComp.lean
+++ b/SpherePacking/ForMathlib/FourierComp.lean
@@ -13,16 +13,16 @@ public import Mathlib.Analysis.InnerProductSpace.Adjoint
 For a linear automorphism `A` of a finite-dimensional real inner product space `V`, the Fourier
 transform of the precomposition `f ∘ A` is the Fourier transform of `f`, rescaled by `|det A|⁻¹`
 and reparametrised by the adjoint of `A⁻¹`:
-`𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A⁻¹)^* w)`.
-
-This is the multidimensional change-of-variables formula for the Fourier transform; the scalar
-`|det A|⁻¹` is the Jacobian factor and the adjoint appears because the Fourier pairing
-`⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the inner product. It is fully general over any
+`𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A⁻¹)^* w)`,
+together with its inverse-transform companion. The scalar `|det A|⁻¹` is the Jacobian factor and the
+adjoint appears because the Fourier pairing `⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the inner
+product. This is the full-Jacobian generalisation of mathlib's isometry lemma
+`Real.fourier_comp_linearIsometry`, valid for any codomain `E` with `[NormedSpace ℂ E]` over any
 `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`.
 
-Upstream target: `Mathlib/Analysis/Fourier/FourierTransform.lean` (or a dedicated
-`Mathlib/Analysis/Fourier/FourierTransformChangeOfVariables.lean`). Imports here are left as
-`public import Mathlib`; they are narrowed at upstreaming time.
+Upstream target: `Mathlib/Analysis/Fourier/FourierTransform.lean`, beside
+`Real.fourier_comp_linearIsometry`. Imports here are left as `public import Mathlib`; they are
+narrowed at upstreaming time.
 -/
 
 open scoped FourierTransform Real
@@ -30,20 +30,19 @@ open MeasureTheory
 
 namespace SpherePacking.ForMathlib.Fourier
 
-variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
-  [MeasurableSpace V] [BorelSpace V]
+variable {V E : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V] [NormedAddCommGroup E] [NormedSpace ℂ E]
 
 /-- Change-of-variables for the Fourier transform under an invertible linear map. For
-`A : V ≃ₗ[ℝ] V`, `𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A.symm).adjoint w)`. -/
-public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w : V) :
+`A : V ≃ₗ[ℝ] V`, `𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A.symm)^* w)`. -/
+public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → E) (w : V) :
     𝓕 (fun x ↦ f (A x)) w =
-      (abs (LinearMap.det (A : V →ₗ[ℝ] V)))⁻¹ •
-        𝓕 f (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) := by
+      |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ • 𝓕 f (LinearMap.adjoint (A.symm : V →ₗ[ℝ] V) w) := by
   have hmap : Measure.map (⇑A) (volume : Measure V) =
       ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹| • (volume : Measure V) :=
     Measure.map_linearMap_addHaar_eq_smul_addHaar volume (LinearEquiv.isUnit_det' A).ne_zero
   have hinner (y : V) :
-      inner ℝ (A.symm y) w = inner ℝ y (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) :=
+      inner ℝ (A.symm y) w = inner ℝ y (LinearMap.adjoint (A.symm : V →ₗ[ℝ] V) w) :=
     (LinearMap.adjoint_inner_right _ y w).symm
   calc 𝓕 (fun x ↦ f (A x)) w
       = ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y
@@ -56,5 +55,13 @@ public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w
           ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y := by
         rw [hmap, integral_smul_measure, ENNReal.toReal_ofReal (abs_nonneg _), abs_inv]
     _ = _ := by simp only [Real.fourier_eq, hinner]
+
+/-- Change-of-variables for the inverse Fourier transform under an invertible linear map; the
+inverse-transform companion of `fourier_comp_linearEquiv`. -/
+public theorem fourierInv_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → E) (w : V) :
+    𝓕⁻ (fun x ↦ f (A x)) w =
+      |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ • 𝓕⁻ f (LinearMap.adjoint (A.symm : V →ₗ[ℝ] V) w) := by
+  rw [Real.fourierInv_eq_fourier_neg, fourier_comp_linearEquiv, map_neg,
+    ← Real.fourierInv_eq_fourier_neg]
 
 end SpherePacking.ForMathlib.Fourier

--- a/SpherePacking/ForMathlib/FourierComp.lean
+++ b/SpherePacking/ForMathlib/FourierComp.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Auguste Poiroux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Auguste Poiroux
+-/
+module
+public import Mathlib
+
+/-! # Fourier transform under an invertible linear change of variables
+
+For a linear automorphism `A` of a finite-dimensional real inner product space `V`, the Fourier
+transform of the precomposition `f ∘ A` is the Fourier transform of `f`, rescaled by `|det A|⁻¹`
+and reparametrised by the adjoint of `A⁻¹`:
+`𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A⁻¹)^* w)`.
+
+This is the multidimensional change-of-variables formula for the Fourier transform; the scalar
+`|det A|⁻¹` is the Jacobian factor and the adjoint appears because the Fourier pairing
+`⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the inner product. It is fully general over any
+`[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`.
+
+Upstream target: `Mathlib/Analysis/Fourier/FourierTransform.lean` (or a dedicated
+`Mathlib/Analysis/Fourier/FourierTransformChangeOfVariables.lean`). Imports here are left as
+`public import Mathlib`; they are narrowed at upstreaming time.
+-/
+
+open scoped FourierTransform Real
+open MeasureTheory
+
+namespace SpherePacking.ForMathlib.Fourier
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V]
+
+/-- Change-of-variables for the Fourier transform under an invertible linear map. For
+`A : V ≃ₗ[ℝ] V`, `𝓕 (f ∘ A) w = |det A|⁻¹ • 𝓕 f ((A.symm).adjoint w)`. -/
+public theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w : V) :
+    𝓕 (fun x ↦ f (A x)) w =
+      (abs (LinearMap.det (A : V →ₗ[ℝ] V)))⁻¹ •
+        𝓕 f (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) := by
+  have hmap : Measure.map (⇑A) (volume : Measure V) =
+      ENNReal.ofReal |(LinearMap.det (A : V →ₗ[ℝ] V))⁻¹| • (volume : Measure V) :=
+    Measure.map_linearMap_addHaar_eq_smul_addHaar volume (LinearEquiv.isUnit_det' A).ne_zero
+  have hinner (y : V) :
+      inner ℝ (A.symm y) w = inner ℝ y (((A.symm : V ≃ₗ[ℝ] V).toLinearMap).adjoint w) :=
+    (LinearMap.adjoint_inner_right _ y w).symm
+  calc 𝓕 (fun x ↦ f (A x)) w
+      = ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y
+          ∂Measure.map (⇑A) (volume : Measure V) := by
+        simpa [Real.fourier_eq] using
+          (integral_map_equiv (μ := (volume : Measure V))
+            A.toContinuousLinearEquiv.toHomeomorph.toMeasurableEquiv
+            fun y ↦ Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y).symm
+    _ = |LinearMap.det (A : V →ₗ[ℝ] V)|⁻¹ •
+          ∫ y, Real.fourierChar (-(inner ℝ (A.symm y) w)) • f y := by
+        rw [hmap, integral_smul_measure, ENNReal.toReal_ofReal (abs_nonneg _), abs_inv]
+    _ = _ := by simp only [Real.fourier_eq, hinner]
+
+end SpherePacking.ForMathlib.Fourier

--- a/SpherePacking/ForMathlib/FourierComp.lean
+++ b/SpherePacking/ForMathlib/FourierComp.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib
+public import Mathlib.Analysis.CStarAlgebra.Classes
+public import Mathlib.Analysis.Fourier.FourierTransform
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-! # Fourier transform under an invertible linear change of variables
 

--- a/SpherePacking/ForMathlib/FourierComp.lean
+++ b/SpherePacking/ForMathlib/FourierComp.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
+-- `#min_imports` artifact: carries instances that the elaboration of this file's statements
+-- depends on (cf. the `CStarMatrix` note in `SpherePacking/UpperBound.lean`). Do not remove
+-- without a full build.
 public import Mathlib.Analysis.CStarAlgebra.Classes
 public import Mathlib.Analysis.Fourier.FourierTransform
 public import Mathlib.Analysis.InnerProductSpace.Adjoint
@@ -21,14 +24,14 @@ product. This is the full-Jacobian generalisation of mathlib's isometry lemma
 `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`.
 
 Upstream target: `Mathlib/Analysis/Fourier/FourierTransform.lean`, beside
-`Real.fourier_comp_linearIsometry`. Imports here are left as `public import Mathlib`; they are
-narrowed at upstreaming time.
+`Real.fourier_comp_linearIsometry`. The lemmas live in the `Real` namespace, matching that
+upstream neighbour.
 -/
 
 open scoped FourierTransform Real
 open MeasureTheory
 
-namespace SpherePacking.ForMathlib.Fourier
+namespace Real
 
 variable {V E : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
   [MeasurableSpace V] [BorelSpace V] [NormedAddCommGroup E] [NormedSpace ℂ E]
@@ -64,4 +67,4 @@ public theorem fourierInv_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → E) (
   rw [Real.fourierInv_eq_fourier_neg, fourier_comp_linearEquiv, map_neg,
     ← Real.fourierInv_eq_fourier_neg]
 
-end SpherePacking.ForMathlib.Fourier
+end Real

--- a/SpherePacking/ForMathlib/FourierComp.md
+++ b/SpherePacking/ForMathlib/FourierComp.md
@@ -9,15 +9,17 @@ the build environment.*
 change of variables**:
 
 ```
-theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w : V) :
-    𝓕 (fun x ↦ f (A x)) w = |det A|⁻¹ • 𝓕 f ((A.symm).adjoint w)
+theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → E) (w : V) :
+    𝓕 (fun x ↦ f (A x)) w = |det A|⁻¹ • 𝓕 f (LinearMap.adjoint A.symm w)
 ```
 
-over any `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`. The scalar
-`|det A|⁻¹` is the Jacobian factor (from `Measure.map_linearMap_addHaar_eq_smul_addHaar`) and the
-adjoint of `A⁻¹` appears because the Fourier pairing `⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the
-inner product. PSG uses it as the spectral-side change of variables that reduces lattice Poisson
-summation to the standard lattice.
+over any `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`, for any codomain
+`E` with `[NormedSpace ℂ E]`. (During cleanup the codomain was generalised from `ℂ` to `E`, matching
+mathlib's vector-valued `𝓕`, and the inverse-transform companion `fourierInv_comp_linearEquiv` was
+added — see avenues 1–2 below.) The scalar `|det A|⁻¹` is the Jacobian factor (from
+`Measure.map_linearMap_addHaar_eq_smul_addHaar`) and the adjoint of `A⁻¹` appears because the Fourier
+pairing `⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the inner product. PSG uses the forward lemma as the
+spectral-side change of variables that reduces lattice Poisson summation to the standard lattice.
 
 ## Overlap with existing Mathlib
 

--- a/SpherePacking/ForMathlib/FourierComp.md
+++ b/SpherePacking/ForMathlib/FourierComp.md
@@ -1,0 +1,78 @@
+# Mathlib PR-overlap report: `FourierComp.lean`
+
+*Prepared June 2026. PR data verified directly against the GitHub REST API; `gh` was unavailable in
+the build environment.*
+
+## What this file contributes
+
+`SpherePacking/ForMathlib/FourierComp.lean` proves the **Fourier transform under an invertible linear
+change of variables**:
+
+```
+theorem fourier_comp_linearEquiv (A : V ≃ₗ[ℝ] V) (f : V → ℂ) (w : V) :
+    𝓕 (fun x ↦ f (A x)) w = |det A|⁻¹ • 𝓕 f ((A.symm).adjoint w)
+```
+
+over any `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]`. The scalar
+`|det A|⁻¹` is the Jacobian factor (from `Measure.map_linearMap_addHaar_eq_smul_addHaar`) and the
+adjoint of `A⁻¹` appears because the Fourier pairing `⟪A x, w⟫ = ⟪x, A^* w⟫` moves `A` across the
+inner product. PSG uses it as the spectral-side change of variables that reduces lattice Poisson
+summation to the standard lattice.
+
+## Overlap with existing Mathlib
+
+Mathlib already has the **isometry special case** in
+`Mathlib/Analysis/Fourier/FourierTransform.lean`:
+
+- `fourier_comp_linearIsometry (A : W ≃ₗᵢ[ℝ] V) (f : V → E) (w : W)` (line 473), with alias
+  `fourierIntegral_comp_linearIsometry`;
+- `fourierInv_comp_linearIsometry` (line 506), with alias `fourierIntegralInv_comp_linearIsometry`.
+
+For an isometry `det = ±1`, the `|det|⁻¹` factor is `1` and the adjoint equals the inverse, so the
+isometry lemma is exactly our statement specialised. **Our lemma is the strict generalisation**: it
+drops the isometry hypothesis to an arbitrary linear automorphism, introducing the determinant
+factor. This is genuinely new content — there is no general-`A` change-of-variables for the Fourier
+transform in Mathlib today.
+
+No open PR was found that adds a general linear (non-isometric) change of variables for the Fourier
+transform.
+
+## Adjacent open PRs (Fourier ecosystem)
+
+- **#40583 — "feat(Analysis/Fourier/Convolution): drop continuity hypotheses from the convolution
+  theorems"** — <https://github.com/leanprover-community/mathlib4/pull/40583> (author **dennj**, open,
+  June 2026). Hypothesis-weakening work in the Fourier module; not change-of-variables, but the same
+  neighbourhood of the library and the same reviewers.
+- **#35291 — "feat(Fourier): improved version of Riemann-Lebesgue"** —
+  <https://github.com/leanprover-community/mathlib4/pull/35291> (author **mcdoll**, open, opened
+  2026-02-14). Reframes Riemann–Lebesgue as a corollary of extending the Schwartz Fourier transform
+  to `L¹`. `mcdoll` is the de-facto maintainer of the Fourier-analysis corner and the right reviewer
+  to engage.
+
+## Collaboration avenues
+
+1. **Position the PR as "generalise `fourier_comp_linearIsometry`."** The cleanest framing for
+   reviewers: keep the existing isometry lemma as the corollary, add `fourier_comp_linearEquiv` as
+   the general statement, and prove the isometry version *from* it (or note the relationship). This
+   slots directly into `FourierTransform.lean` next to the existing lemmas and is an easy review
+   because it strictly extends an accepted result.
+
+2. **Add the inverse-transform companion.** Mathlib pairs `fourier_comp_linearIsometry` with
+   `fourierInv_comp_linearIsometry`. To match, our PR should add the `𝓕⁻` companion of
+   `fourier_comp_linearEquiv` (via `fourierInv_eq_fourier_neg`), so the general case has the same API
+   surface as the isometry case.
+
+3. **Engage `mcdoll` early.** Given the active Fourier work (#35291, and the convolution
+   generalisation #40583), a short Zulip note proposing the general change-of-variables — with the
+   determinant factor and adjoint reparametrisation — will surface any naming/placement preferences
+   (e.g. whether it belongs in `FourierTransform.lean` or a new
+   `FourierTransformChangeOfVariables.lean`) before a PR is opened.
+
+## Recommendation
+
+**Upstream candidate, high confidence, low controversy.** Submit `fourier_comp_linearEquiv` (plus its
+`𝓕⁻` companion) to `Mathlib/Analysis/Fourier/FourierTransform.lean`, framed as the general-`A`
+extension of the existing isometry lemmas. No competing PR exists; the only coordination is naming/
+placement with `mcdoll`.
+
+**Upstream target:** `Mathlib/Analysis/Fourier/FourierTransform.lean`.

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 Sidharth Hariharan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sidharth Hariharan, Auguste Poiroux
+-/
+module
+public import Mathlib
+
+/-! # Summability of a Schwartz function over a `ℤ`-lattice
+
+A Schwartz function on a finite-dimensional real normed space `E` is summable, in norm, over the
+translates of any discrete `ℤ`-submodule `L ⊆ E`. This is the basic summability input to (general)
+Poisson summation and to the Cohn–Elkies linear-programming bound.
+
+The proof combines Schwartz decay (`SchwartzMap.decay`) with the convergent dominating series
+`ZLattice.summable_norm_sub_inv_pow`. It needs neither an inner-product structure, nor that `L` be a
+full lattice (`IsZLattice`): only `[FiniteDimensional ℝ E]` and `[DiscreteTopology L]`.
+
+We record the pointwise summability (`summable_norm_comp_add`, `summable_comp_add`) and the
+locally-uniform version (`summable_norm_translateCM_restrict`): the sup-norms over a fixed compact
+of the lattice translates are summable, which is what lets one assemble the periodization
+`∑' ℓ, f (· + ℓ)` as a `tsum` of continuous maps.
+
+Upstream target: `Mathlib/Analysis/Distribution/SchwartzSpace/ZLattice.lean` (downstream of
+`SchwartzSpace.Basic` and `Algebra.Module.ZLattice.Summable`). Imports here are left as
+`public import Mathlib`; they are narrowed at upstreaming time.
+-/
+
+open MeasureTheory
+
+variable {E F : Type*}
+  [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+namespace SchwartzMap
+
+/-- Translate a Schwartz function `f` by a vector `ℓ`, as a continuous map `x ↦ f (x + ℓ)`. -/
+@[expose] public noncomputable def translateCM (f : 𝓢(E, F)) (ℓ : E) : C(E, F) :=
+  (f : C(E, F)).comp (ContinuousMap.addRight ℓ)
+
+@[simp] public theorem translateCM_apply (f : 𝓢(E, F)) (ℓ x : E) :
+    f.translateCM ℓ x = f (x + ℓ) := rfl
+
+end SchwartzMap
+
+variable [FiniteDimensional ℝ E]
+
+/-- A discrete `ℤ`-submodule of a finite-dimensional real normed space meets any closed ball in a
+finite set: only finitely many lattice points have norm `≤ r`. -/
+public theorem ZLattice.finite_norm_le (L : Submodule ℤ E) [DiscreteTopology L] (r : ℝ) :
+    ({ℓ : L | ‖(ℓ : E)‖ ≤ r} : Set L).Finite := by
+  have : DiscreteTopology L.toAddSubgroup := inferInstanceAs (DiscreteTopology L)
+  have hfin : (Metric.closedBall (0 : E) r ∩ (L.toAddSubgroup : Set E)).Finite :=
+    Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
+      Metric.isBounded_closedBall AddSubgroup.isClosed_of_discrete
+  refine .of_finite_image (hfin.subset ?_) Subtype.coe_injective.injOn
+  rintro _ ⟨ℓ, hℓ, rfl⟩
+  exact ⟨by simpa [Metric.mem_closedBall, dist_eq_norm] using hℓ, ℓ.2⟩
+
+namespace SchwartzMap
+
+/-- A Schwartz function has summable norms over any translate of a discrete `ℤ`-submodule of a
+finite-dimensional real normed space. -/
+public theorem summable_norm_comp_add (f : 𝓢(E, F)) (L : Submodule ℤ E) [DiscreteTopology L]
+    (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) := by
+  -- `k` is a decay order exceeding the rank, so the comparison series `‖· - b‖⁻¹ ^ k` converges.
+  let k : ℕ := Module.finrank ℤ L + 1
+  obtain ⟨C, _, hC⟩ := f.decay k 0
+  -- `b = -a` is the shift, so that `a + ℓ = ℓ - b`.
+  set b : E := -a
+  refine Summable.of_norm_bounded_eventually
+    (g := fun ℓ : L => (C + 1) * ‖(ℓ : E) - b‖⁻¹ ^ k) ?_ ?_
+  · simpa [mul_assoc] using
+      (ZLattice.summable_norm_sub_inv_pow (L := L) (n := k) (by simp [k]) b).mul_left (C + 1)
+  · -- The bound fails only on the finite set where `‖ℓ - b‖ ≤ 1`.
+    have hfin : ({ℓ : L | ‖(ℓ : E) - b‖ ≤ (1 : ℝ)} : Set L).Finite :=
+      (ZLattice.finite_norm_le (L := L) (1 + ‖b‖)).subset fun ℓ hℓ => by
+        simp only [Set.mem_setOf_eq] at hℓ ⊢
+        calc ‖(ℓ : E)‖ = ‖((ℓ : E) - b) + b‖ := by rw [sub_add_cancel]
+          _ ≤ ‖(ℓ : E) - b‖ + ‖b‖ := norm_add_le _ _
+          _ ≤ 1 + ‖b‖ := by linarith
+    refine hfin.subset fun ℓ hfail => ?_
+    by_contra hlarge
+    have hpos : 0 < ‖(ℓ : E) - b‖ ^ k :=
+      pow_pos (lt_of_lt_of_le one_pos (lt_of_not_ge hlarge).le) _
+    have hab : ‖a + (ℓ : E)‖ = ‖(ℓ : E) - b‖ := by simp [b, sub_eq_add_neg, add_comm]
+    have hdec : ‖(ℓ : E) - b‖ ^ k * ‖f (a + (ℓ : E))‖ ≤ C := by
+      simpa [hab, norm_iteratedFDeriv_zero] using hC (a + (ℓ : E))
+    have h1 : ‖f (a + (ℓ : E))‖ ≤ C / ‖(ℓ : E) - b‖ ^ k := (le_div_iff₀' hpos).2 hdec
+    have h2 : C / ‖(ℓ : E) - b‖ ^ k ≤ (C + 1) * ‖(ℓ : E) - b‖⁻¹ ^ k := by
+      simpa [div_eq_mul_inv, inv_pow] using
+        mul_le_mul_of_nonneg_right (by linarith : C ≤ C + 1)
+          (by positivity : 0 ≤ (‖(ℓ : E) - b‖ ^ k)⁻¹)
+    exact hfail (by simpa using h1.trans h2)
+
+/-- A Schwartz function is summable over any translate of a discrete `ℤ`-submodule. -/
+public theorem summable_comp_add [CompleteSpace F] (f : 𝓢(E, F)) (L : Submodule ℤ E)
+    [DiscreteTopology L] (a : E) : Summable (fun ℓ : L => f (a + (ℓ : E))) :=
+  Summable.of_norm (f.summable_norm_comp_add L a)
+
+private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x ℓ : G} {r : ℝ}
+    (hx : ‖x‖ ≤ r) (hℓ : 2 * r < ‖ℓ‖) : 1 / 2 * ‖ℓ‖ ≤ ‖x + ℓ‖ := by
+  have h : ‖ℓ‖ - ‖x‖ ≤ ‖x + ℓ‖ := by simpa [add_comm] using norm_sub_norm_le ℓ (-x)
+  linarith
+
+/-- Schwartz decay is locally uniform over a `ℤ`-lattice: the sup-norms over a fixed compact `K`
+of the lattice translates of `f` are summable. -/
+public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodule ℤ E)
+    [DiscreteTopology L] (K : TopologicalSpace.Compacts E) :
+    Summable (fun ℓ : L => ‖(f.translateCM (ℓ : E)).restrict K‖) := by
+  -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable over `L`.
+  let k : ℕ := Module.finrank ℤ L + 1
+  obtain ⟨C, hCpos, hC⟩ := f.decay k 0
+  simp_rw [norm_iteratedFDeriv_zero] at hC
+  obtain ⟨r, hrK⟩ := K.isCompact.isBounded.subset_closedBall (0 : E)
+  have hsum : Summable fun ℓ : L => ‖(ℓ : E)‖⁻¹ ^ k := by
+    simpa [k] using ZLattice.summable_norm_pow_inv (L := L) k (Nat.lt_succ_self _)
+  refine (hsum.mul_left (C * 2 ^ k)).of_norm_bounded_eventually ?_
+  filter_upwards [(ZLattice.finite_norm_le (L := L) (max (2 * r) 1)).eventually_cofinite_notMem]
+    with ℓ hℓ
+  have hRlt : max (2 * r) 1 < ‖(ℓ : E)‖ := lt_of_not_ge (by simpa using hℓ)
+  have hnorm_pos : 0 < ‖(ℓ : E)‖ := one_pos.trans_le ((le_max_right _ _).trans hRlt.le)
+  rw [norm_norm]
+  refine (ContinuousMap.norm_le _ (by positivity)).2 fun ⟨x, hxK⟩ => ?_
+  have hxr : ‖x‖ ≤ r := by simpa using hrK hxK
+  have hge : 1 / 2 * ‖(ℓ : E)‖ ≤ ‖x + (ℓ : E)‖ :=
+    half_norm_le_norm_add hxr ((le_max_left _ _).trans_lt hRlt)
+  have hpos : 0 < ‖x + (ℓ : E)‖ := (by positivity : (0 : ℝ) < 1 / 2 * ‖(ℓ : E)‖).trans_le hge
+  have hinv : ‖x + (ℓ : E)‖⁻¹ ≤ 2 * ‖(ℓ : E)‖⁻¹ := by
+    have h := inv_anti₀ (by positivity) hge
+    rwa [mul_inv, one_div, inv_inv] at h
+  calc ‖(f.translateCM (ℓ : E)) (⟨x, hxK⟩ : K)‖
+      = ‖f (x + (ℓ : E))‖ := rfl
+    _ ≤ C / ‖x + (ℓ : E)‖ ^ k := (le_div_iff₀' (pow_pos hpos k)).2 (hC _)
+    _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
+    _ ≤ C * (2 * ‖(ℓ : E)‖⁻¹) ^ k := by gcongr
+    _ = C * 2 ^ k * ‖(ℓ : E)‖⁻¹ ^ k := by rw [mul_pow, mul_assoc]
+
+end SchwartzMap

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
@@ -59,52 +59,14 @@ public theorem ZLattice.finite_norm_le (L : Submodule ℤ E) [DiscreteTopology L
 
 namespace SchwartzMap
 
-/-- A Schwartz function has summable norms over any translate of a discrete `ℤ`-submodule of a
-finite-dimensional real normed space. -/
-public theorem summable_norm_comp_add (f : 𝓢(E, F)) (L : Submodule ℤ E) [DiscreteTopology L]
-    (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) := by
-  -- `k` is a decay order exceeding the rank, so the comparison series `‖· - b‖⁻¹ ^ k` converges.
-  let k : ℕ := Module.finrank ℤ L + 1
-  obtain ⟨C, _, hC⟩ := f.decay k 0
-  -- `b = -a` is the shift, so that `a + ℓ = ℓ - b`.
-  set b : E := -a
-  refine Summable.of_norm_bounded_eventually
-    (g := fun ℓ : L => (C + 1) * ‖(ℓ : E) - b‖⁻¹ ^ k) ?_ ?_
-  · simpa [mul_assoc] using
-      (ZLattice.summable_norm_sub_inv_pow (L := L) (n := k) (by simp [k]) b).mul_left (C + 1)
-  · -- The bound fails only on the finite set where `‖ℓ - b‖ ≤ 1`.
-    have hfin : ({ℓ : L | ‖(ℓ : E) - b‖ ≤ (1 : ℝ)} : Set L).Finite :=
-      (ZLattice.finite_norm_le (L := L) (1 + ‖b‖)).subset fun ℓ hℓ => by
-        simp only [Set.mem_setOf_eq] at hℓ ⊢
-        calc ‖(ℓ : E)‖ = ‖((ℓ : E) - b) + b‖ := by rw [sub_add_cancel]
-          _ ≤ ‖(ℓ : E) - b‖ + ‖b‖ := norm_add_le _ _
-          _ ≤ 1 + ‖b‖ := by linarith
-    refine hfin.subset fun ℓ hfail => ?_
-    by_contra hlarge
-    have hpos : 0 < ‖(ℓ : E) - b‖ ^ k :=
-      pow_pos (lt_of_lt_of_le one_pos (lt_of_not_ge hlarge).le) _
-    have hab : ‖a + (ℓ : E)‖ = ‖(ℓ : E) - b‖ := by simp [b, sub_eq_add_neg, add_comm]
-    have hdec : ‖(ℓ : E) - b‖ ^ k * ‖f (a + (ℓ : E))‖ ≤ C := by
-      simpa [hab, norm_iteratedFDeriv_zero] using hC (a + (ℓ : E))
-    have h1 : ‖f (a + (ℓ : E))‖ ≤ C / ‖(ℓ : E) - b‖ ^ k := (le_div_iff₀' hpos).2 hdec
-    have h2 : C / ‖(ℓ : E) - b‖ ^ k ≤ (C + 1) * ‖(ℓ : E) - b‖⁻¹ ^ k := by
-      simpa [div_eq_mul_inv, inv_pow] using
-        mul_le_mul_of_nonneg_right (by linarith : C ≤ C + 1)
-          (by positivity : 0 ≤ (‖(ℓ : E) - b‖ ^ k)⁻¹)
-    exact hfail (by simpa using h1.trans h2)
-
-/-- A Schwartz function is summable over any translate of a discrete `ℤ`-submodule. -/
-public theorem summable_comp_add [CompleteSpace F] (f : 𝓢(E, F)) (L : Submodule ℤ E)
-    [DiscreteTopology L] (a : E) : Summable (fun ℓ : L => f (a + (ℓ : E))) :=
-  Summable.of_norm (f.summable_norm_comp_add L a)
-
 private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x ℓ : G} {r : ℝ}
     (hx : ‖x‖ ≤ r) (hℓ : 2 * r < ‖ℓ‖) : 1 / 2 * ‖ℓ‖ ≤ ‖x + ℓ‖ := by
   have h : ‖ℓ‖ - ‖x‖ ≤ ‖x + ℓ‖ := by simpa [add_comm] using norm_sub_norm_le ℓ (-x)
   linarith
 
 /-- Schwartz decay is locally uniform over a `ℤ`-lattice: the sup-norms over a fixed compact `K`
-of the lattice translates of `f` are summable. -/
+of the lattice translates of `f` are summable. This is the engine from which the pointwise
+summability `summable_norm_comp_add` follows, by taking `K` a singleton. -/
 public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodule ℤ E)
     [DiscreteTopology L] (K : TopologicalSpace.Compacts E) :
     Summable (fun ℓ : L => ‖(f.translateCM (ℓ : E)).restrict K‖) := by
@@ -135,5 +97,21 @@ public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodul
     _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
     _ ≤ C * (2 * ‖(ℓ : E)‖⁻¹) ^ k := by gcongr
     _ = C * 2 ^ k * ‖(ℓ : E)‖⁻¹ ^ k := by rw [mul_pow, mul_assoc]
+
+/-- A Schwartz function has summable norms over any translate of a discrete `ℤ`-submodule of a
+finite-dimensional real normed space: the singleton-compact case of
+`summable_norm_translateCM_restrict`, since the sup-norm over `{a}` is the value at `a`. -/
+public theorem summable_norm_comp_add (f : 𝓢(E, F)) (L : Submodule ℤ E) [DiscreteTopology L]
+    (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) := by
+  refine (f.summable_norm_translateCM_restrict L ⟨{a}, isCompact_singleton⟩).congr fun ℓ => ?_
+  refine le_antisymm ((ContinuousMap.norm_le _ (norm_nonneg _)).2 ?_)
+    (((f.translateCM (ℓ : E)).restrict {a}).norm_coe_le_norm ⟨a, rfl⟩)
+  rintro ⟨x, rfl⟩
+  exact le_rfl
+
+/-- A Schwartz function is summable over any translate of a discrete `ℤ`-submodule. -/
+public theorem summable_comp_add [CompleteSpace F] (f : 𝓢(E, F)) (L : Submodule ℤ E)
+    [DiscreteTopology L] (a : E) : Summable (fun ℓ : L => f (a + (ℓ : E))) :=
+  Summable.of_norm (f.summable_norm_comp_add L a)
 
 end SchwartzMap

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
@@ -14,13 +14,15 @@ translates of any discrete `ℤ`-submodule `L ⊆ E`. This is the basic summabil
 Poisson summation and to the Cohn–Elkies linear-programming bound.
 
 The proof combines Schwartz decay (`SchwartzMap.decay`) with the convergent dominating series
-`ZLattice.summable_norm_sub_inv_pow`. It needs neither an inner-product structure, nor that `L` be a
+`ZLattice.summable_norm_pow_inv`. It needs neither an inner-product structure, nor that `L` be a
 full lattice (`IsZLattice`): only `[FiniteDimensional ℝ E]` and `[DiscreteTopology L]`.
 
-We record the pointwise summability (`summable_norm_comp_add`, `summable_comp_add`) and the
-locally-uniform version (`summable_norm_translateCM_restrict`): the sup-norms over a fixed compact
-of the lattice translates are summable, which is what lets one assemble the periodization
-`∑' ℓ, f (· + ℓ)` as a `tsum` of continuous maps.
+We record the pointwise summability (`summable_norm_comp_add`) and the locally-uniform version
+(`summable_norm_restrict_comp_addRight`): the sup-norms over a fixed compact of the lattice
+translates are summable, which is what lets one assemble the periodization `∑' ℓ, f (· + ℓ)` as a
+`tsum` of continuous maps. The translate `x ↦ f (x + ℓ)` is written inline as the composite
+`(f : C(E, F)).comp (ContinuousMap.addRight ℓ)`, following mathlib's
+`Real.fourierCoeff_tsum_comp_add`.
 
 Upstream target: `Mathlib/Analysis/Distribution/SchwartzSpace/ZLattice.lean` (downstream of
 `SchwartzSpace.Basic` and `Algebra.Module.ZLattice.Summable`). Imports here are left as
@@ -33,23 +35,12 @@ variable {E F : Type*}
   [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F]
 
-namespace SchwartzMap
-
-/-- Translate a Schwartz function `f` by a vector `ℓ`, as a continuous map `x ↦ f (x + ℓ)`. -/
-@[expose] public noncomputable def translateCM (f : 𝓢(E, F)) (ℓ : E) : C(E, F) :=
-  (f : C(E, F)).comp (ContinuousMap.addRight ℓ)
-
-@[simp] public theorem translateCM_apply (f : 𝓢(E, F)) (ℓ x : E) :
-    f.translateCM ℓ x = f (x + ℓ) := rfl
-
-end SchwartzMap
-
-variable [FiniteDimensional ℝ E]
-
-/-- A discrete `ℤ`-submodule of a finite-dimensional real normed space meets any closed ball in a
-finite set: only finitely many lattice points have norm `≤ r`. -/
-public theorem ZLattice.finite_norm_le (L : Submodule ℤ E) [DiscreteTopology L] (r : ℝ) :
-    ({ℓ : L | ‖(ℓ : E)‖ ≤ r} : Set L).Finite := by
+omit [NormedSpace ℝ E] in
+/-- A discrete `ℤ`-submodule of a proper real normed space meets any closed ball in a finite set:
+only finitely many lattice points have norm `≤ r`. Strictly more general than
+`ZSpan.setFinite_inter` (no basis, no `IsZLattice`). -/
+public theorem ZLattice.finite_norm_le [ProperSpace E] (L : Submodule ℤ E) [DiscreteTopology L]
+    (r : ℝ) : ({ℓ : L | ‖(ℓ : E)‖ ≤ r} : Set L).Finite := by
   have : DiscreteTopology L.toAddSubgroup := inferInstanceAs (DiscreteTopology L)
   have hfin : (Metric.closedBall (0 : E) r ∩ (L.toAddSubgroup : Set E)).Finite :=
     Metric.finite_isBounded_inter_isClosed DiscreteTopology.isDiscrete
@@ -57,6 +48,8 @@ public theorem ZLattice.finite_norm_le (L : Submodule ℤ E) [DiscreteTopology L
   refine .of_finite_image (hfin.subset ?_) Subtype.coe_injective.injOn
   rintro _ ⟨ℓ, hℓ, rfl⟩
   exact ⟨by simpa [Metric.mem_closedBall, dist_eq_norm] using hℓ, ℓ.2⟩
+
+variable [FiniteDimensional ℝ E]
 
 namespace SchwartzMap
 
@@ -66,11 +59,11 @@ private lemma half_norm_le_norm_add {G : Type*} [SeminormedAddCommGroup G] {x �
   linarith
 
 /-- Schwartz decay is locally uniform over a `ℤ`-lattice: the sup-norms over a fixed compact `K`
-of the lattice translates of `f` are summable. This is the engine from which the pointwise
-summability `summable_norm_comp_add` follows, by taking `K` a singleton. -/
-public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodule ℤ E)
+of the lattice translates `x ↦ f (x + ℓ)` of `f` are summable. This is the engine from which the
+pointwise summability `summable_norm_comp_add` follows, by taking `K` a singleton. -/
+public theorem summable_norm_restrict_comp_addRight (f : 𝓢(E, F)) (L : Submodule ℤ E)
     [DiscreteTopology L] (K : TopologicalSpace.Compacts E) :
-    Summable (fun ℓ : L => ‖(f.translateCM (ℓ : E)).restrict K‖) := by
+    Summable (fun ℓ : L => ‖((f : C(E, F)).comp (ContinuousMap.addRight (ℓ : E))).restrict K‖) := by
   -- `k` is a decay order exceeding the lattice rank, so that `‖·‖⁻¹ ^ k` is summable over `L`.
   let k : ℕ := Module.finrank ℤ L + 1
   obtain ⟨C, hCpos, hC⟩ := f.decay k 0
@@ -92,7 +85,7 @@ public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodul
   have hinv : ‖x + (ℓ : E)‖⁻¹ ≤ 2 * ‖(ℓ : E)‖⁻¹ := by
     have h := inv_anti₀ (by positivity) hge
     rwa [mul_inv, one_div, inv_inv] at h
-  calc ‖(f.translateCM (ℓ : E)) (⟨x, hxK⟩ : K)‖
+  calc ‖((f : C(E, F)).comp (ContinuousMap.addRight (ℓ : E))) (⟨x, hxK⟩ : K)‖
       = ‖f (x + (ℓ : E))‖ := rfl
     _ ≤ C / ‖x + (ℓ : E)‖ ^ k := (le_div_iff₀' (pow_pos hpos k)).2 (hC _)
     _ = C * ‖x + (ℓ : E)‖⁻¹ ^ k := by rw [div_eq_mul_inv, inv_pow]
@@ -101,18 +94,13 @@ public theorem summable_norm_translateCM_restrict (f : 𝓢(E, F)) (L : Submodul
 
 /-- A Schwartz function has summable norms over any translate of a discrete `ℤ`-submodule of a
 finite-dimensional real normed space: the singleton-compact case of
-`summable_norm_translateCM_restrict`, since the sup-norm over `{a}` is the value at `a`. -/
+`summable_norm_restrict_comp_addRight`, since the sup-norm over `{a}` is the value at `a`. -/
 public theorem summable_norm_comp_add (f : 𝓢(E, F)) (L : Submodule ℤ E) [DiscreteTopology L]
     (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) := by
-  refine (f.summable_norm_translateCM_restrict L ⟨{a}, isCompact_singleton⟩).congr fun ℓ => ?_
+  refine (f.summable_norm_restrict_comp_addRight L ⟨{a}, isCompact_singleton⟩).congr fun ℓ => ?_
   refine le_antisymm ((ContinuousMap.norm_le _ (norm_nonneg _)).2 ?_)
-    (((f.translateCM (ℓ : E)).restrict {a}).norm_coe_le_norm ⟨a, rfl⟩)
+    ((((f : C(E, F)).comp (ContinuousMap.addRight (ℓ : E))).restrict {a}).norm_coe_le_norm ⟨a, rfl⟩)
   rintro ⟨x, rfl⟩
   exact le_rfl
-
-/-- A Schwartz function is summable over any translate of a discrete `ℤ`-submodule. -/
-public theorem summable_comp_add [CompleteSpace F] (f : 𝓢(E, F)) (L : Submodule ℤ E)
-    [DiscreteTopology L] (a : E) : Summable (fun ℓ : L => f (a + (ℓ : E))) :=
-  Summable.of_norm (f.summable_norm_comp_add L a)
 
 end SchwartzMap

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan, Auguste Poiroux
 -/
 module
-public import Mathlib
+public import Mathlib.Algebra.Module.ZLattice.Summable
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 
 /-! # Summability of a Schwartz function over a `ℤ`-lattice
 

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.lean
@@ -25,8 +25,7 @@ translates are summable, which is what lets one assemble the periodization `∑'
 `Real.fourierCoeff_tsum_comp_add`.
 
 Upstream target: `Mathlib/Analysis/Distribution/SchwartzSpace/ZLattice.lean` (downstream of
-`SchwartzSpace.Basic` and `Algebra.Module.ZLattice.Summable`). Imports here are left as
-`public import Mathlib`; they are narrowed at upstreaming time.
+`SchwartzSpace.Basic` and `Algebra.Module.ZLattice.Summable`).
 -/
 
 open MeasureTheory
@@ -38,7 +37,9 @@ variable {E F : Type*}
 omit [NormedSpace ℝ E] in
 /-- A discrete `ℤ`-submodule of a proper real normed space meets any closed ball in a finite set:
 only finitely many lattice points have norm `≤ r`. Strictly more general than
-`ZSpan.setFinite_inter` (no basis, no `IsZLattice`). -/
+`ZSpan.setFinite_inter` (no basis, no `IsZLattice`). Sibling:
+`EuclideanSpace.finite_lattice_in_ball` (`ForMathlib/CoordCube.lean`) states the open-ball version
+for the scaled cube lattice; TODO: derive that from this lemma when both are upstreamed. -/
 public theorem ZLattice.finite_norm_le [ProperSpace E] (L : Submodule ℤ E) [DiscreteTopology L]
     (r : ℝ) : ({ℓ : L | ‖(ℓ : E)‖ ≤ r} : Set L).Finite := by
   have : DiscreteTopology L.toAddSubgroup := inferInstanceAs (DiscreteTopology L)
@@ -94,13 +95,13 @@ public theorem summable_norm_restrict_comp_addRight (f : 𝓢(E, F)) (L : Submod
 
 /-- A Schwartz function has summable norms over any translate of a discrete `ℤ`-submodule of a
 finite-dimensional real normed space: the singleton-compact case of
-`summable_norm_restrict_comp_addRight`, since the sup-norm over `{a}` is the value at `a`. -/
+`summable_norm_restrict_comp_addRight`, since the value at `a` is dominated by the sup-norm
+over `{a}`. -/
 public theorem summable_norm_comp_add (f : 𝓢(E, F)) (L : Submodule ℤ E) [DiscreteTopology L]
-    (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) := by
-  refine (f.summable_norm_restrict_comp_addRight L ⟨{a}, isCompact_singleton⟩).congr fun ℓ => ?_
-  refine le_antisymm ((ContinuousMap.norm_le _ (norm_nonneg _)).2 ?_)
-    ((((f : C(E, F)).comp (ContinuousMap.addRight (ℓ : E))).restrict {a}).norm_coe_le_norm ⟨a, rfl⟩)
-  rintro ⟨x, rfl⟩
-  exact le_rfl
+    (a : E) : Summable (fun ℓ : L => ‖f (a + (ℓ : E))‖) :=
+  (f.summable_norm_restrict_comp_addRight L ⟨{a}, isCompact_singleton⟩).of_nonneg_of_le
+    (fun _ => norm_nonneg _) fun ℓ =>
+      (((f : C(E, F)).comp (ContinuousMap.addRight (ℓ : E))).restrict {a}).norm_coe_le_norm
+        ⟨a, rfl⟩
 
 end SchwartzMap

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.md
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.md
@@ -9,14 +9,19 @@ the build environment.*
 in norm, over the translates of any discrete `ℤ`-submodule of a finite-dimensional real normed
 space — the basic input to (general) Poisson summation and to the Cohn–Elkies bound:
 
-- `SchwartzMap.translateCM (f) (ℓ) : C(E, F)` — the translate `x ↦ f (x + ℓ)` as a continuous map
-  (with `@[simp] translateCM_apply`);
-- `ZLattice.finite_norm_le (L) (r) : {ℓ : L | ‖(ℓ:E)‖ ≤ r}.Finite` — a discrete `ℤ`-submodule meets
-  any closed ball finitely;
-- `SchwartzMap.summable_norm_comp_add (f) (L) (a) : Summable (fun ℓ : L ↦ ‖f (a + ℓ)‖)` and its
-  unnormed companion `summable_comp_add`;
-- `SchwartzMap.summable_norm_translateCM_restrict (f) (L) (K) : Summable (fun ℓ : L ↦
-  ‖(f.translateCM ℓ).restrict K‖)` — the locally-uniform (sup-norm over a compact) version.
+- `ZLattice.finite_norm_le (L) (r) : {ℓ : L | ‖(ℓ:E)‖ ≤ r}.Finite` — a discrete `ℤ`-submodule of a
+  `[ProperSpace E]` meets any closed ball finitely (generalised from `[FiniteDimensional ℝ E]` to its
+  actual hypothesis during cleanup);
+- `SchwartzMap.summable_norm_comp_add (f) (L) (a) : Summable (fun ℓ : L ↦ ‖f (a + ℓ)‖)` — the
+  user-facing pointwise form;
+- `SchwartzMap.summable_norm_restrict_comp_addRight (f) (L) (K) : Summable (fun ℓ : L ↦
+  ‖((f : C(E,F)).comp (.addRight ℓ)).restrict K‖)` — the locally-uniform (sup-norm over a compact)
+  engine.
+
+The translate `x ↦ f (x + ℓ)` is written inline as `(f : C(E, F)).comp (ContinuousMap.addRight ℓ)`
+(following mathlib's `Real.fourierCoeff_tsum_comp_add`); the former named `translateCM` /
+`translateCM_apply` helpers and the unnormed `summable_comp_add` (a one-call `Summable.of_norm`
+wrapper, with no call sites) were dropped during cleanup.
 
 The engine is Schwartz decay (`SchwartzMap.decay`) dominated by the convergent series
 `ZLattice.summable_norm_sub_inv_pow` / `summable_norm_pow_inv`. Crucially it needs **neither** an

--- a/SpherePacking/ForMathlib/SchwartzLatticeSummable.md
+++ b/SpherePacking/ForMathlib/SchwartzLatticeSummable.md
@@ -1,0 +1,84 @@
+# Mathlib PR-overlap report: `SchwartzLatticeSummable.lean`
+
+*Prepared June 2026. PR data verified directly against the GitHub REST API; `gh` was unavailable in
+the build environment.*
+
+## What this file contributes
+
+`SpherePacking/ForMathlib/SchwartzLatticeSummable.lean` proves that a Schwartz function is summable,
+in norm, over the translates of any discrete `ℤ`-submodule of a finite-dimensional real normed
+space — the basic input to (general) Poisson summation and to the Cohn–Elkies bound:
+
+- `SchwartzMap.translateCM (f) (ℓ) : C(E, F)` — the translate `x ↦ f (x + ℓ)` as a continuous map
+  (with `@[simp] translateCM_apply`);
+- `ZLattice.finite_norm_le (L) (r) : {ℓ : L | ‖(ℓ:E)‖ ≤ r}.Finite` — a discrete `ℤ`-submodule meets
+  any closed ball finitely;
+- `SchwartzMap.summable_norm_comp_add (f) (L) (a) : Summable (fun ℓ : L ↦ ‖f (a + ℓ)‖)` and its
+  unnormed companion `summable_comp_add`;
+- `SchwartzMap.summable_norm_translateCM_restrict (f) (L) (K) : Summable (fun ℓ : L ↦
+  ‖(f.translateCM ℓ).restrict K‖)` — the locally-uniform (sup-norm over a compact) version.
+
+The engine is Schwartz decay (`SchwartzMap.decay`) dominated by the convergent series
+`ZLattice.summable_norm_sub_inv_pow` / `summable_norm_pow_inv`. Crucially it needs **neither** an
+inner-product structure **nor** that `L` be full rank (`IsZLattice`): only `[FiniteDimensional ℝ E]`
+and `[DiscreteTopology L]`. This generality is what let us *deduplicate* — PSG and LPBound each
+previously carried their own copy of this argument.
+
+## Overlap with existing Mathlib / open PRs
+
+There is **no Mathlib lemma and no open PR** that proves Schwartz summability over a lattice, nor a
+higher-dimensional / general-lattice Poisson summation. `Mathlib/Analysis/Fourier/PoissonSummation.lean`
+covers the one-dimensional `ℤ ⊆ ℝ` case and is not under active PR development. A search of the open
+queue for "Poisson summation" returned nothing relevant. So the core summability lemmas here are
+**uncontested**.
+
+(Note: an earlier automated survey claimed several "Poisson summation" PRs; direct API checks showed
+those were spurious. They are not cited here.)
+
+Two API points worth recording, since an automated audit suggested otherwise:
+
+- `ZLattice.finite_norm_le` is **not** subsumed by `ZSpan.setFinite_inter`: the latter is stated for
+  the span of a basis, whereas our lemma handles an arbitrary discrete `Submodule ℤ E` and packages
+  the result as a finite set in the subtype `L`. It is built on `Metric.finite_isBounded_inter_isClosed`
+  and is worth keeping/upstreaming as the general statement.
+- `SchwartzMap.translateCM` is **not** in Mathlib: `compCLM`/`compCLMOfContinuousLinearEquiv`
+  precompose on the left; there is no right-translation-as-`ContinuousMap` constructor.
+
+## Adjacent open PRs (Schwartz / distribution ecosystem)
+
+The Schwartz-space corner of Mathlib is under active build-out, which is the right context for these
+lemmas:
+
+- **#37350 — "feat(Analysis/Distribution): define canonical maps between Schwartz/test functions,
+  distributions/tempered distributions"** —
+  <https://github.com/leanprover-community/mathlib4/pull/37350> (author **aditya-ramabadran**, open,
+  opened 2026-03-30, assigned by **ADedecker**). Establishes `𝒟 → 𝒮` and `𝒮' → 𝒟'` maps.
+- **#35291 — "feat(Fourier): improved version of Riemann-Lebesgue"** (author **mcdoll**, open) —
+  relates the Schwartz Fourier transform to its `L¹` extension. <https://github.com/leanprover-community/mathlib4/pull/35291>
+- **#40094 — "chore(Analysis/TemperedDistribution): add coercion and fix existing one"** (author
+  **mcdoll**, open, June 2026). <https://github.com/leanprover-community/mathlib4/pull/40094>
+- **#36326 — "Feat/gaussian schwartz map"** (author **Arnav-panjla**, open, opened 2026-03-07) —
+  the Gaussian as a Schwartz function in finite dimensions; a canonical example consumer of Schwartz
+  decay. <https://github.com/leanprover-community/mathlib4/pull/36326>
+
+## Collaboration avenues
+
+1. **Upstream the summability lemmas as their own small file**, downstream of `SchwartzSpace.Basic`
+   and `Algebra/Module/ZLattice/Summable` — there is no dependency on the distribution PRs, so this
+   can proceed independently and immediately. Proposed home:
+   `Mathlib/Analysis/Distribution/SchwartzSpace/ZLattice.lean`.
+2. **Coordinate naming with the Schwartz maintainers** (`mcdoll`, `ADedecker`, and `YaelDillies` who
+   has reviewed #37350). The `translateCM` translation operator in particular should be named to fit
+   whatever translation/precomposition conventions emerge from #37350/#40094.
+3. **`finite_norm_le` is a natural addition to `Algebra/Module/ZLattice/`**, and pairs with the
+   `setFinite_inter` already there; offer it as the general-discrete-submodule companion.
+
+## Recommendation
+
+Strong upstream candidate, **independent of the in-flight distribution PRs**. Land
+`finite_norm_le` in the ZLattice folder and the `SchwartzMap.summable_*` lemmas in a new
+`SchwartzSpace/ZLattice.lean`, coordinating names with the active Schwartz contributors. Keep
+`translateCM` bundled with them.
+
+**Upstream target:** `Mathlib/Analysis/Distribution/SchwartzSpace/ZLattice.lean` (+ `finite_norm_le`
+to `Mathlib/Algebra/Module/ZLattice/`).

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
-public import Mathlib
+public import Mathlib.Analysis.CStarAlgebra.Classes
+public import Mathlib.Analysis.Fourier.AddCircleMulti
 
 /-! # The quotient map `(ι → ℝ) → (ℝ/ℤ)^ι` presenting the unit torus
 

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
@@ -11,15 +11,26 @@ public import Mathlib.Analysis.Fourier.AddCircleMulti
 
 For an index type `ι`, the coordinatewise quotient map `coeFun ι : (ι → ℝ) → UnitAddTorus ι`
 presents the `ι`-dimensional unit torus `(ℝ/ℤ)^ι` as a quotient of `ℝ^ι`. We record its
-continuity, that it is an open quotient map, the value of the Fourier monomials `mFourier k` on
-its image, and the pull-back of Haar integration on the torus to a fundamental cube
-`∏ i, (t, t+1] ⊆ ℝ^ι`.
+continuity, that it is an open quotient map, and the value of the Fourier monomials `mFourier k`
+on its image.
+
+We also record the pull-back of Haar integration on the torus to a fundamental cube
+`∏ i, (t, t+1] ⊆ ℝ^ι`. Mathlib already proves this, more generally, as
+`UnitAddTorus.integral_preimage` — but that lemma is stated under a file-`local` measure-space
+instance `⟨AddCircle.haarAddCircle⟩` on `UnitAddCircle`, which differs (by a defeq-trivial `1 •`)
+from the global `AddCircle.measureSpace 1` that this project's torus integrals use, so it is not a
+drop-in. We therefore keep our own version against the global instance; at upstreaming time, once
+the instances are reconciled, it is subsumed by `UnitAddTorus.integral_preimage`.
 
 This is a companion to `Mathlib.Analysis.Fourier.AddCircleMulti` (which defines `UnitAddTorus`,
 `mFourier`, and `mFourierCoeff`).
 
-Upstream target: `Mathlib/Analysis/Fourier/AddCircleMulti.lean` (or a sibling file). Imports here
-are left as `public import Mathlib`; they are narrowed at upstreaming time.
+Upstream note: `coeFun ι` is definitionally `Pi.map (fun _ => QuotientAddGroup.mk)` (the coercion
+`(· : UnitAddCircle)` is `QuotientAddGroup.mk`), and `mFourier_apply_coeFun` is a single-`simp`
+unfolding; on upstreaming `coeFun` would be inlined and these lemmas folded into
+`Mathlib/Analysis/Fourier/AddCircleMulti.lean`. They are kept here as the project-local quotient
+API on which `PoissonSummationGeneral.lean` builds. Imports here are left as `public import
+Mathlib`; they are narrowed at upstreaming time.
 -/
 
 open scoped FourierTransform Real
@@ -50,12 +61,14 @@ variable [Fintype ι]
 
 /-- Evaluate the additive character `mFourier k` on a point `x : ℝ^ι` viewed in the torus
 via `coeFun`. -/
-public theorem mFourier_apply_coeFun_ofLp (k : ι → ℤ) (x : EuclideanSpace ℝ ι) :
-    UnitAddTorus.mFourier k (coeFun ι (WithLp.ofLp x)) =
+public theorem mFourier_apply_coeFun (k : ι → ℤ) (x : ι → ℝ) :
+    UnitAddTorus.mFourier k (coeFun ι x) =
       Complex.exp (2 * π * Complex.I * (∑ i : ι, (k i : ℝ) * x i)) := by
   simp [UnitAddTorus.mFourier, coeFun, ← Complex.exp_sum, Finset.mul_sum, mul_assoc]
 
-/-- Pull back Haar integration on `(ℝ/ℤ)^ι` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`. -/
+/-- Pull back Haar integration on `(ℝ/ℤ)^ι` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`. Stated
+against the global `AddCircle.measureSpace 1` instance (see the module docstring on why mathlib's
+`UnitAddTorus.integral_preimage` is not a drop-in). -/
 public theorem integral_eq_integral_preimage_coeFun (t : ℝ) (g : UnitAddTorus ι → ℂ)
     (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus ι))) :
     (∫ y : UnitAddTorus ι, g y) =

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Auguste Poiroux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Auguste Poiroux
+-/
+module
+public import Mathlib
+
+/-! # The quotient map `(ι → ℝ) → (ℝ/ℤ)^ι` presenting the unit torus
+
+For an index type `ι`, the coordinatewise quotient map `coeFun ι : (ι → ℝ) → UnitAddTorus ι`
+presents the `ι`-dimensional unit torus `(ℝ/ℤ)^ι` as a quotient of `ℝ^ι`. We record its
+continuity, that it is an open quotient map, the value of the Fourier monomials `mFourier k` on
+its image, and the pull-back of Haar integration on the torus to a fundamental cube
+`∏ i, (t, t+1] ⊆ ℝ^ι`.
+
+This is a companion to `Mathlib.Analysis.Fourier.AddCircleMulti` (which defines `UnitAddTorus`,
+`mFourier`, and `mFourierCoeff`).
+
+Upstream target: `Mathlib/Analysis/Fourier/AddCircleMulti.lean` (or a sibling file). Imports here
+are left as `public import Mathlib`; they are narrowed at upstreaming time.
+-/
+
+open scoped FourierTransform Real
+open MeasureTheory
+
+namespace UnitAddTorus
+
+variable {ι : Type*}
+
+/-- The coordinatewise quotient map `(ι → ℝ) → (ℝ/ℤ)^ι`, sending `x` to `i ↦ (x i : ℝ/ℤ)`. It is
+the fundamental projection presenting the torus as a quotient of `ℝ^ι`. -/
+@[expose] public def coeFun (ι : Type*) : (ι → ℝ) → UnitAddTorus ι :=
+  fun x i => (x i : UnitAddCircle)
+
+@[simp] public theorem coeFun_apply (x : ι → ℝ) (i : ι) :
+    coeFun ι x i = (x i : UnitAddCircle) := rfl
+
+/-- The coordinatewise quotient map `coeFun` is continuous. -/
+@[continuity, fun_prop]
+public theorem continuous_coeFun : Continuous (coeFun ι) :=
+  continuous_pi fun i => (AddCircle.continuous_mk' 1).comp (continuous_apply i)
+
+/-- `coeFun` is an open quotient map, so it presents `(ℝ/ℤ)^ι` as a quotient of `ℝ^ι`. -/
+public theorem isOpenQuotientMap_coeFun (ι : Type*) : IsOpenQuotientMap (coeFun ι) :=
+  .piMap fun _ ↦ QuotientAddGroup.isOpenQuotientMap_mk
+
+variable [Fintype ι]
+
+/-- Evaluate the additive character `mFourier k` on a point `x : ℝ^ι` viewed in the torus
+via `coeFun`. -/
+public theorem mFourier_apply_coeFun_ofLp (k : ι → ℤ) (x : EuclideanSpace ℝ ι) :
+    UnitAddTorus.mFourier k (coeFun ι (WithLp.ofLp x)) =
+      Complex.exp (2 * π * Complex.I * (∑ i : ι, (k i : ℝ) * x i)) := by
+  simp [UnitAddTorus.mFourier, coeFun, ← Complex.exp_sum, Finset.mul_sum, mul_assoc]
+
+/-- Pull back Haar integration on `(ℝ/ℤ)^ι` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`. -/
+public theorem integral_eq_integral_preimage_coeFun (t : ℝ) (g : UnitAddTorus ι → ℂ)
+    (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus ι))) :
+    (∫ y : UnitAddTorus ι, g y) =
+      ∫ x, g (coeFun ι x) ∂(volume : Measure (ι → ℝ)).restrict
+        (Set.univ.pi fun _ : ι => Set.Ioc t (t + 1)) := by
+  have hmp : MeasurePreserving (coeFun ι)
+      (Measure.pi fun _ : ι => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)))
+      (volume : Measure (UnitAddTorus ι)) :=
+    measurePreserving_pi _ _ fun _ => UnitAddCircle.measurePreserving_mk t
+  have hrestrict : (volume : Measure (ι → ℝ)).restrict
+        (Set.univ.pi fun _ : ι => Set.Ioc t (t + 1)) =
+      Measure.pi fun _ : ι => (volume : Measure ℝ).restrict (Set.Ioc t (t + 1)) :=
+    Measure.restrict_pi_pi _ _
+  rw [hrestrict, ← hmp.map_eq]
+  exact integral_map hmp.aemeasurable (hmp.map_eq.symm ▸ hg)
+
+end UnitAddTorus

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Auguste Poiroux
 -/
 module
+-- `#min_imports` artifact: carries instances that the elaboration of this file's statements
+-- depends on (cf. the `CStarMatrix` note in `SpherePacking/UpperBound.lean`). Do not remove
+-- without a full build.
 public import Mathlib.Analysis.CStarAlgebra.Classes
 public import Mathlib.Analysis.Fourier.AddCircleMulti
 
@@ -29,8 +32,7 @@ Upstream note: `coeFun ι` is definitionally `Pi.map (fun _ => QuotientAddGroup.
 `(· : UnitAddCircle)` is `QuotientAddGroup.mk`), and `mFourier_apply_coeFun` is a single-`simp`
 unfolding; on upstreaming `coeFun` would be inlined and these lemmas folded into
 `Mathlib/Analysis/Fourier/AddCircleMulti.lean`. They are kept here as the project-local quotient
-API on which `PoissonSummationGeneral.lean` builds. Imports here are left as `public import
-Mathlib`; they are narrowed at upstreaming time.
+API on which `PoissonSummationGeneral.lean` builds.
 -/
 
 open scoped FourierTransform Real
@@ -66,10 +68,11 @@ public theorem mFourier_apply_coeFun (k : ι → ℤ) (x : ι → ℝ) :
       Complex.exp (2 * π * Complex.I * (∑ i : ι, (k i : ℝ) * x i)) := by
   simp [UnitAddTorus.mFourier, coeFun, ← Complex.exp_sum, Finset.mul_sum, mul_assoc]
 
-/-- Pull back Haar integration on `(ℝ/ℤ)^ι` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`. Stated
-against the global `AddCircle.measureSpace 1` instance (see the module docstring on why mathlib's
-`UnitAddTorus.integral_preimage` is not a drop-in). -/
-public theorem integral_eq_integral_preimage_coeFun (t : ℝ) (g : UnitAddTorus ι → ℂ)
+/-- Pull back Haar integration on `(ℝ/ℤ)^ι` to the fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`, for
+any Banach-space-valued integrand. Stated against the global `AddCircle.measureSpace 1` instance
+(see the module docstring on why mathlib's `UnitAddTorus.integral_preimage` is not a drop-in). -/
+public theorem integral_eq_integral_preimage_coeFun {G : Type*} [NormedAddCommGroup G]
+    [NormedSpace ℝ G] (t : ℝ) (g : UnitAddTorus ι → G)
     (hg : AEStronglyMeasurable g (volume : Measure (UnitAddTorus ι))) :
     (∫ y : UnitAddTorus ι, g y) =
       ∫ x, g (coeFun ι x) ∂(volume : Measure (ι → ℝ)).restrict

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.md
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.md
@@ -15,10 +15,14 @@ harmonic-analysis user needs:
 - `continuous_coeFun` (tagged `@[continuity, fun_prop]`);
 - `isOpenQuotientMap_coeFun` — `coeFun` is an open quotient map (via `IsOpenQuotientMap.piMap` and
   `QuotientAddGroup.isOpenQuotientMap_mk`);
-- `mFourier_apply_coeFun_ofLp` — the value of the torus Fourier monomial `mFourier k` on the image
-  of a Euclidean point;
+- `mFourier_apply_coeFun (k) (x : ι → ℝ)` — the value of the torus Fourier monomial `mFourier k` on
+  the image of a point (during cleanup this was restated on `ι → ℝ`, dropping the spurious
+  `EuclideanSpace`/`WithLp.ofLp` wrapper of the former `mFourier_apply_coeFun_ofLp`);
 - `integral_eq_integral_preimage_coeFun` — the pull-back of Haar integration on `(ℝ/ℤ)^ι` to a
-  fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`.
+  fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`. Mathlib has this more generally as
+  `UnitAddTorus.integral_preimage`, but that lemma is stated under a file-`local` measure-space
+  instance `⟨AddCircle.haarAddCircle⟩` that differs (by a defeq-trivial `1 •`) from the global
+  `AddCircle.measureSpace 1` the project uses, so it is not a drop-in and we keep our version.
 
 It is a companion to `Mathlib/Analysis/Fourier/AddCircleMulti.lean`, which already defines
 `UnitAddTorus`, `mFourier`, and `mFourierCoeff`. The first two declarations are stated for an

--- a/SpherePacking/ForMathlib/UnitAddTorusQuotient.md
+++ b/SpherePacking/ForMathlib/UnitAddTorusQuotient.md
@@ -1,0 +1,87 @@
+# Mathlib PR-overlap report: `UnitAddTorusQuotient.lean`
+
+*Prepared June 2026. PR data verified directly against the GitHub REST API
+(`api.github.com/repos/leanprover-community/mathlib4`); `gh` was unavailable in the build
+environment.*
+
+## What this file contributes
+
+`SpherePacking/ForMathlib/UnitAddTorusQuotient.lean` packages the coordinatewise quotient map that
+presents the `ι`-dimensional unit torus as a quotient of `ℝ^ι`, together with the analytic API a
+harmonic-analysis user needs:
+
+- `UnitAddTorus.coeFun (ι : Type*) : (ι → ℝ) → UnitAddTorus ι`, `x ↦ (i ↦ (x i : ℝ/ℤ))`, with
+  `@[simp] coeFun_apply`;
+- `continuous_coeFun` (tagged `@[continuity, fun_prop]`);
+- `isOpenQuotientMap_coeFun` — `coeFun` is an open quotient map (via `IsOpenQuotientMap.piMap` and
+  `QuotientAddGroup.isOpenQuotientMap_mk`);
+- `mFourier_apply_coeFun_ofLp` — the value of the torus Fourier monomial `mFourier k` on the image
+  of a Euclidean point;
+- `integral_eq_integral_preimage_coeFun` — the pull-back of Haar integration on `(ℝ/ℤ)^ι` to a
+  fundamental cube `∏ i, (t, t+1] ⊆ ℝ^ι`.
+
+It is a companion to `Mathlib/Analysis/Fourier/AddCircleMulti.lean`, which already defines
+`UnitAddTorus`, `mFourier`, and `mFourierCoeff`. The first two declarations are stated for an
+arbitrary index type `ι`; the Fourier/integral facts add `[Fintype ι]`.
+
+## Overlapping open PR
+
+**PR #39460 — "feat(Algebra/Module/ZLattice): Quotient by `IsZLattice` is group isomorphic to
+`UnitAddTorus`"** — <https://github.com/leanprover-community/mathlib4/pull/39460>
+(author **Deicyde**, **draft**, opened 2026-05-16).
+
+Its main result is `quotientAddEquivUnitAddTorus : (E ⧸ L) ≃+ UnitAddTorus ι` for any
+`IsZLattice ℝ L`. The PR body states it is "currently left as a draft for educational purpose" and
+points to a Zulip discussion about the right definition of the torus.
+
+This is a **strong, complementary overlap**, not a collision:
+
+- #39460 builds the **algebraic** object — the additive-group isomorphism between the lattice
+  quotient `E ⧸ L` and `UnitAddTorus ι`. It works at the level of `IsZLattice`, i.e. an abstract
+  full-rank lattice in a finite-dimensional space.
+- Our file builds the **topological / measure-theoretic** layer of the *standard* quotient map
+  `ℝ^ι → (ℝ/ℤ)^ι`: continuity, the open-quotient property, the action of the Fourier characters,
+  and the Haar-measure pull-back to a fundamental cube. These are exactly the facts one needs to
+  *do analysis* on the torus (descend periodic functions, compute Fourier coefficients as cube
+  integrals) — which is how PSG consumes them in Poisson summation.
+
+The two are layered: #39460's `≃+` is the algebraic identification, ours is the analytic interface
+to the same quotient. A natural unified contribution would expose both — the group isomorphism *and*
+the statement that the underlying map is an open quotient map that pulls Haar measure back to a
+fundamental domain.
+
+## Collaboration avenues
+
+1. **Engage on the Zulip thread referenced by #39460.** Because the PR is an explicitly educational
+   draft and the definition of the torus is still under discussion, this is the moment to align our
+   `coeFun` with their `quotientAddEquivUnitAddTorus` so the maps compose definitionally — ideally
+   `coeFun` factors as `(quotient mk) ≫ quotientAddEquivUnitAddTorus`, making our continuity and
+   measure lemmas transport for free to their `≃+`.
+
+2. **Offer the analytic API as a follow-up PR keyed off #39460.** Once their `≃+` lands, our
+   `continuous_coeFun`, `isOpenQuotientMap_coeFun`, `mFourier_apply_coeFun_ofLp`, and
+   `integral_eq_integral_preimage_coeFun` are the obvious next file in
+   `Mathlib/Analysis/Fourier/AddCircleMulti.lean`. We should rebase our lemmas to be stated in terms
+   of their canonical map rather than re-introducing a parallel `coeFun`, to avoid two
+   near-duplicate projections in Mathlib.
+
+3. **Help unstick the draft.** The PR is a draft and may be stalled on definitional bikeshedding
+   (the Zulip thread). A concrete downstream use case — "here is the Poisson-summation machinery
+   that needs exactly this quotient, with its measure pull-back" — is often what converts an
+   educational draft into a merge-track PR. Linking our use case is low-effort, high-value.
+
+## Adjacent context
+
+`Mathlib/Analysis/Fourier/AddCircleMulti.lean` (the multidimensional-torus Fourier file our work sits
+on top of) appears to be already merged with no active follow-up PR on `mFourier`/`mFourierCoeff`, so
+the analytic API above is uncontested territory beyond #39460.
+
+## Recommendation
+
+**Do not upstream `coeFun` independently.** Coordinate with #39460: align `coeFun` to their
+`quotientAddEquivUnitAddTorus`, then propose the continuity / open-quotient / measure-pull-back
+lemmas as a companion PR. Until then, keep our file as-is (it is the working analytic interface for
+PSG), and record the dependency so that import-narrowing time also becomes coordination time.
+
+**Upstream target:** `Mathlib/Analysis/Fourier/AddCircleMulti.lean` (or a sibling), downstream of
+#39460.

--- a/SpherePacking/MainTheorem.lean
+++ b/SpherePacking/MainTheorem.lean
@@ -43,6 +43,9 @@ public lemma sqrt2_ne_zero : (Real.sqrt (2 : ℝ)) ≠ 0 :=
 
 /-- The scaled Schwartz function used for the dimension-8 Cohn-Elkies LP bound. -/
 @[expose] public noncomputable def scaledMagic : 𝓢(ℝ⁸, ℂ) :=
+  -- Short-circuit a `ContinuousSMul ℝ ℝ⁸` synthesis loop on `EuclideanSpace`'s `PiLp` structure
+  -- inside `toContinuousLinearEquiv`.
+  have : ContinuousSMul ℝ ℝ⁸ := inferInstance
   SchwartzMap.compCLMOfContinuousLinearEquiv ℂ
     ((LinearEquiv.smulOfNeZero (K := ℝ) (M := ℝ⁸)
       (Real.sqrt 2) sqrt2_ne_zero).toContinuousLinearEquiv) g

--- a/SpherePacking/MainTheorem.lean
+++ b/SpherePacking/MainTheorem.lean
@@ -4,13 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Gareth Ma
 -/
 module
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
+
 public import SpherePacking.E8.Packing
 public import SpherePacking.UpperBound
 public import SpherePacking.CohnElkies.LPBound
 public import SpherePacking.CohnElkies.PoissonSummationGeneral
 public import SpherePacking.MagicFunction.a.Eigenfunction
 public import SpherePacking.MagicFunction.b.Eigenfunction
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-!
 # Main theorem: optimal sphere packing in dimension 8

--- a/SpherePacking/MainTheorem.lean
+++ b/SpherePacking/MainTheorem.lean
@@ -278,8 +278,7 @@ public theorem SpherePackingConstant_le_E8Packing_density :
       SpherePackingConstant 8 ≤ (scaledMagic 0).re.toNNReal / (𝓕 (⇑scaledMagic) 0).re.toNNReal *
         volume (ball (0 : ℝ⁸) (1 / 2 : ℝ)) := by
     simpa using
-      (SpherePacking.CohnElkies.LinearProgrammingBound (d := 8)
-        (f := (scaledMagic : 𝓢(ℝ⁸, ℂ))) hne
+      (LinearProgrammingBound (d := 8) (f := (scaledMagic : 𝓢(ℝ⁸, ℂ))) hne
         scaledMagic_real' scaledMagic_real_fourier' scaledMagic_cohnElkies₁'
         scaledMagic_cohnElkies₂' (Nat.succ_pos 7))
   have hratio : (scaledMagic 0).re.toNNReal / (𝓕 (⇑scaledMagic) 0).re.toNNReal = (16 : ℝ≥0∞) := by

--- a/SpherePacking/MainTheorem.lean
+++ b/SpherePacking/MainTheorem.lean
@@ -31,7 +31,7 @@ lattice packing to obtain the dimension-8 optimal packing density.
 namespace SpherePacking
 
 open scoped FourierTransform ENNReal SchwartzMap
-open SchwartzMap SpherePacking.ForMathlib.Fourier
+open SchwartzMap
 open MeasureTheory Real SpherePacking Metric
 open MagicFunction.g.CohnElkies
 
@@ -74,8 +74,7 @@ public theorem fourier_scaledMagic_zero : FT scaledMagic 0 = (1 / 16 : ℂ) := b
         (abs (LinearMap.det (A : ℝ⁸ →ₗ[ℝ] ℝ⁸)))⁻¹ • (𝓕 (g : ℝ⁸ → ℂ)) 0 := by
     simpa [FourierTransform.fourierCLE_apply, SchwartzMap.fourier_coe, scaledMagic, c, A,
       SchwartzMap.compCLMOfContinuousLinearEquiv_apply] using
-      (SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv
-        (A := A) (f := (g : ℝ⁸ → ℂ)) (w := (0 : ℝ⁸)))
+      (Real.fourier_comp_linearEquiv (A := A) (f := (g : ℝ⁸ → ℂ)) (w := (0 : ℝ⁸)))
   simp_all
 
 /-- Convenience form of `fourier_scaledMagic_zero` for the coerced function `⇑scaledMagic`. -/
@@ -237,7 +236,7 @@ private lemma fourier_scaledMagic_eq (x : ℝ⁸) :
       |LinearMap.det (scaleEquiv : ℝ⁸ →ₗ[ℝ] ℝ⁸)|⁻¹ •
         𝓕 g ((LinearMap.adjoint ((scaleEquiv.symm : ℝ⁸ ≃ₗ[ℝ] ℝ⁸) : ℝ⁸ →ₗ[ℝ] ℝ⁸)) x) := by
   simpa [SpherePacking.scaledMagic, scaleEquiv, SchwartzMap.fourier_coe] using
-    SpherePacking.ForMathlib.Fourier.fourier_comp_linearEquiv (A := scaleEquiv) (f := g) (w := x)
+    Real.fourier_comp_linearEquiv (A := scaleEquiv) (f := g) (w := x)
 
 /-- The Fourier transform `𝓕 scaledMagic` is real-valued (scaled variant of `g_real_fourier`). -/
 public theorem scaledMagic_real_fourier' :
@@ -279,7 +278,8 @@ public theorem SpherePackingConstant_le_E8Packing_density :
       SpherePackingConstant 8 ≤ (scaledMagic 0).re.toNNReal / (𝓕 (⇑scaledMagic) 0).re.toNNReal *
         volume (ball (0 : ℝ⁸) (1 / 2 : ℝ)) := by
     simpa using
-      (LinearProgrammingBound (d := 8) (f := (scaledMagic : 𝓢(ℝ⁸, ℂ))) hne
+      (SpherePacking.CohnElkies.LinearProgrammingBound (d := 8)
+        (f := (scaledMagic : 𝓢(ℝ⁸, ℂ))) hne
         scaledMagic_real' scaledMagic_real_fourier' scaledMagic_cohnElkies₁'
         scaledMagic_cohnElkies₂' (Nat.succ_pos 7))
   have hratio : (scaledMagic 0).re.toNNReal / (𝓕 (⇑scaledMagic) 0).re.toNNReal = (16 : ℝ≥0∞) := by

--- a/SpherePacking/UpperBound.lean
+++ b/SpherePacking/UpperBound.lean
@@ -12,6 +12,9 @@ public import Mathlib.Analysis.Complex.CauchyIntegral
 public import Mathlib.Analysis.Normed.Module.Connected
 public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+-- The `CStarMatrix` `@[default_instance]` for `HMul` is consulted during numeric-literal `*`
+-- defaulting; it must be publicly visible here or it surfaces as an "unknown constant".
+public import Mathlib.Analysis.CStarAlgebra.CStarMatrix
 import SpherePacking.ModularForms.SlashActionAuxil
 import SpherePacking.ForMathlib.DerivHelpers
 import Mathlib.Analysis.Calculus.ParametricIntervalIntegral

--- a/SpherePacking/UpperBound.lean
+++ b/SpherePacking/UpperBound.lean
@@ -1,36 +1,37 @@
 module
-public import SpherePacking.Basic.PeriodicPacking
-public import SpherePacking.MagicFunction.b.Schwartz.Basic
-public import SpherePacking.MagicFunction.a.Schwartz.Basic
-public import SpherePacking.MagicFunction.g.CohnElkies.AnotherIntegral.A.IntegralLemmas
-public import SpherePacking.ModularForms.FG.Basic
-public import SpherePacking.ModularForms.EisensteinBase
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Analytic.IsolatedZeros
 public import Mathlib.Analysis.Calculus.ParametricIntegral
 public import Mathlib.Analysis.Complex.CauchyIntegral
 public import Mathlib.Analysis.Normed.Module.Connected
 public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 -- The `CStarMatrix` `@[default_instance]` for `HMul` is consulted during numeric-literal `*`
 -- defaulting; it must be publicly visible here or it surfaces as an "unknown constant".
 public import Mathlib.Analysis.CStarAlgebra.CStarMatrix
-import SpherePacking.ModularForms.SlashActionAuxil
-import SpherePacking.ForMathlib.DerivHelpers
 import Mathlib.Analysis.Calculus.ParametricIntervalIntegral
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.MeasureTheory.Integral.ExpDecay
+
+public import SpherePacking.Basic.PeriodicPacking
+public import SpherePacking.MagicFunction.b.Schwartz.Basic
+public import SpherePacking.MagicFunction.a.Schwartz.Basic
+public import SpherePacking.MagicFunction.g.CohnElkies.AnotherIntegral.A.IntegralLemmas
+public import SpherePacking.MagicFunction.g.CohnElkies.AnotherIntegral.B.Cancellation
+public import SpherePacking.ModularForms.FG.Basic
+public import SpherePacking.ModularForms.EisensteinBase
 import SpherePacking.CohnElkies.LPBound
+import SpherePacking.ForMathlib.DerivHelpers
+import SpherePacking.Integration.Measure
 import SpherePacking.MagicFunction.a.Eigenfunction
 import SpherePacking.MagicFunction.b.Eigenfunction
-import SpherePacking.Integration.Measure
-import SpherePacking.ModularForms.Delta
 import SpherePacking.MagicFunction.b.PsiBounds
-public import SpherePacking.MagicFunction.g.CohnElkies.AnotherIntegral.B.Cancellation
-public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.MeasureTheory.Integral.ExpDecay
+import SpherePacking.ModularForms.Delta
 import SpherePacking.ModularForms.FG.Inequalities
-import Mathlib.Analysis.SpecificLimits.Basic
+import SpherePacking.ModularForms.SlashActionAuxil
 
 /-!
 # Cohn-Elkies sign conditions for the magic function `g`

--- a/blueprint/src/subsections/cohn-elkies.tex
+++ b/blueprint/src/subsections/cohn-elkies.tex
@@ -1,7 +1,7 @@
 In 2003 Cohn and Elkies \cite{ElkiesCohn}  developed  linear programming bounds that apply directly to sphere packings. The goal of this section is to formalize the Cohn--Elkies linear programming bound.
 
 The following theorem is the key result of \cite{ElkiesCohn}. (Note that the original theorem is stated for a class of functions more general then Schwartz functions.)
-\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{SpherePacking.CohnElkies.LinearProgrammingBound_periodic}\leanok
+\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{LinearProgrammingBound_periodic}\leanok
 
 Let $X\subset\mathbb{R}^d$ be a discrete subset such that $\|x-y\|\geq 1$ for any distinct $x,y\in X$. Suppose that $X$ is $\Lambda$-periodic with respect to some lattice $\Lambda\subset\mathbb{R}^d$. Let $f:\R^d\to\R$ be a Schwartz function that is not identically zero and satisfies the following conditions:
 \begin{equation}\label{eqn:Cohn-Elkies-condition-1}f(x)\leq 0\mbox{ for } \|x\|\geq 1\end{equation} and
@@ -33,7 +33,7 @@ $$\Delta(\mathcal{P}_X)=\frac{\sharp (X/\Lambda)}{\mathrm{vol}(\mathbb{R}^d/\Lam
 This finishes the proof of the theorem for periodic packings.
 \end{proof}
 
-\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-general}\lean{SpherePacking.CohnElkies.LinearProgrammingBound}\leanok
+\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-general}\lean{LinearProgrammingBound}\leanok
   Let $f:\R^d\to\R$ be a Schwartz function that is not identically zero and satisfies \eqref{eqn:Cohn-Elkies-condition-1} and \eqref{eqn:Cohn-Elkies-condition-2}. Then the density of any $\Lambda$-periodic sphere packing is bounded above by $$\frac{f(0)}{\widehat{f}(0)}\cdot \mathrm{vol}(B_d(0,1/2)).$$
 \end{theorem}
 \begin{proof}\uses{thm:Cohn-Elkies-periodic,thm:periodic-packing-optimal}\lean{periodic_constant_eq_constant, periodic_constant_eq_periodic_constant_normalized}\leanok

--- a/blueprint/src/subsections/cohn-elkies.tex
+++ b/blueprint/src/subsections/cohn-elkies.tex
@@ -1,7 +1,7 @@
 In 2003 Cohn and Elkies \cite{ElkiesCohn}  developed  linear programming bounds that apply directly to sphere packings. The goal of this section is to formalize the Cohn--Elkies linear programming bound.
 
 The following theorem is the key result of \cite{ElkiesCohn}. (Note that the original theorem is stated for a class of functions more general then Schwartz functions.)
-\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{LinearProgrammingBound'}\leanok
+\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{LinearProgrammingBound_periodic}\leanok
 
 Let $X\subset\mathbb{R}^d$ be a discrete subset such that $\|x-y\|\geq 1$ for any distinct $x,y\in X$. Suppose that $X$ is $\Lambda$-periodic with respect to some lattice $\Lambda\subset\mathbb{R}^d$. Let $f:\R^d\to\R$ be a Schwartz function that is not identically zero and satisfies the following conditions:
 \begin{equation}\label{eqn:Cohn-Elkies-condition-1}f(x)\leq 0\mbox{ for } \|x\|\geq 1\end{equation} and

--- a/blueprint/src/subsections/cohn-elkies.tex
+++ b/blueprint/src/subsections/cohn-elkies.tex
@@ -1,7 +1,7 @@
 In 2003 Cohn and Elkies \cite{ElkiesCohn}  developed  linear programming bounds that apply directly to sphere packings. The goal of this section is to formalize the Cohn--Elkies linear programming bound.
 
 The following theorem is the key result of \cite{ElkiesCohn}. (Note that the original theorem is stated for a class of functions more general then Schwartz functions.)
-\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{LinearProgrammingBound_periodic}\leanok
+\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-periodic}\uses{def:Fourier-Transform, def:SpherePacking.density}\lean{SpherePacking.CohnElkies.LinearProgrammingBound_periodic}\leanok
 
 Let $X\subset\mathbb{R}^d$ be a discrete subset such that $\|x-y\|\geq 1$ for any distinct $x,y\in X$. Suppose that $X$ is $\Lambda$-periodic with respect to some lattice $\Lambda\subset\mathbb{R}^d$. Let $f:\R^d\to\R$ be a Schwartz function that is not identically zero and satisfies the following conditions:
 \begin{equation}\label{eqn:Cohn-Elkies-condition-1}f(x)\leq 0\mbox{ for } \|x\|\geq 1\end{equation} and
@@ -33,7 +33,7 @@ $$\Delta(\mathcal{P}_X)=\frac{\sharp (X/\Lambda)}{\mathrm{vol}(\mathbb{R}^d/\Lam
 This finishes the proof of the theorem for periodic packings.
 \end{proof}
 
-\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-general}\lean{LinearProgrammingBound}\leanok
+\begin{theorem}[Cohn--Elkies {\cite{ElkiesCohn}}]\label{thm:Cohn-Elkies-general}\lean{SpherePacking.CohnElkies.LinearProgrammingBound}\leanok
   Let $f:\R^d\to\R$ be a Schwartz function that is not identically zero and satisfies \eqref{eqn:Cohn-Elkies-condition-1} and \eqref{eqn:Cohn-Elkies-condition-2}. Then the density of any $\Lambda$-periodic sphere packing is bounded above by $$\frac{f(0)}{\widehat{f}(0)}\cdot \mathrm{vol}(B_d(0,1/2)).$$
 \end{theorem}
 \begin{proof}\uses{thm:Cohn-Elkies-periodic,thm:periodic-packing-optimal}\lean{periodic_constant_eq_constant, periodic_constant_eq_periodic_constant_normalized}\leanok


### PR DESCRIPTION
Started by Fable, finished by Opus :,)

## Summary

Cleanup pass over the Cohn–Elkies linear-programming bound and general Poisson summation, staging upstream-bound material under `SpherePacking/ForMathlib/`, followed by an aggressive definition-quality program guided by the principle **"notations are good; definitions are bad"** (every definition costs API lemmas and unfolding; minimise both).

### ForMathlib extraction & cleanup

- Extracted five upstream-bound files — `FourierComp`, `DualLattice`, `SchwartzLatticeSummable`, `UnitAddTorusQuotient`, `CoordCube` — each with a Mathlib PR-overlap report (`.md`) identifying adjacent open Mathlib PRs and collaboration avenues.
- Golfed and generalised along the way: Fourier change-of-variables codomain `ℂ → E`, `finite_norm_le` generalised to `[ProperSpace E]`, Schwartz-over-lattice summability deduplicated through one locally-uniform engine, imports minimised via `#min_imports`, and `LPBound`'s counting layer made basis-generic (delegating to Mathlib's `ZSpan`, with the cube kept only for its elementary boundary geometry).

### Definition-quality program

Applied the hierarchy **inline > notation > definition** to every definition this PR had introduced around the cube machinery. End state: **`CoordCube.lean` contains zero definitions, zero abbrevs, and zero instances — only lemmas** (plus two `local notation`s).

| Former declaration | Fate |
|---|---|
| `cubeIco`, `cubeIcc`, `cubeBox` | inlined as set-builders `{x \| ∀ i, x i ∈ I}` — membership is judgemental, so no membership/unfolding API exists at all |
| `mem_cubeIco`/`mem_cubeIcc`/`mem_cubeBox`, `volume_cubeIco`/`volume_cubeIcc`, `cubeIcc_eq_preimage_ofLp` | deleted (pure unfolding API) |
| `constVec` + `constVec_apply` | deleted — general-endpoint cubes express the shell's outer box `[-½, L+½]^d` directly, so the recentring `vadd`/`measure_vadd` gymnastics disappear |
| `cubeIcoCover` + 2 wrapper lemmas | inlined into the generic `fundamentalDomainCover` API |
| `cubeBasis` (abbrev) | **`local notation`** expanding to `Basis.isUnitSMul` on the standard basis (the positivity proof `hL` is spliced into the `IsUnit.mk0` witness) |
| `cubeLattice` (def) | **`local notation`** expanding to `Submodule.span ℤ (Set.range (cubeBasis d L hL))` |
| `instDiscreteTopology_cubeLattice`, `instIsZLattice_cubeLattice` | deleted — Mathlib's own `ZSpan` instances fire directly on the span expansion once the def wrapper stops blocking synthesis |

The surviving lemmas carry genuine content only: `cube_eq_preimage_ofLp`, `measurableSet_cube`, `volume_cube` (with `_Ico`/`_Icc` endpoint corollaries), `fundamentalDomain_cubeBasis`, `cubeLattice_unique_covers`, `isBounded_cube_Ico`, `finite_lattice_in_ball`.

Design notes:
- The notations are `local`, declared per consuming file (this project's existing `ℝ⁸` pattern). Since notation is elaboration-time, **exported lemma types contain only expanded Mathlib terms** — nothing custom survives into downstream code or a future Mathlib PR.
- Removing the `cubeLattice` def is what unblocked instance synthesis (the deleted instances were `inferInstanceAs` on the span spelling, i.e. Mathlib could already synthesise them), and it dissolved a defeq-but-syntactically-distinct subtype schism (`cubeLattice` vs its span) that had broken `simp`/`rw` unification in the pigeonhole argument.

### CI fixes along the way

- Added the missing `SchwartzLatticeSummable` import to the `SpherePacking.lean` aggregator (`lake exe mk_all --check`).
- Repointed the stale blueprint tag `\lean{LinearProgrammingBound'}` → `LinearProgrammingBound_periodic` (`checkdecls`).
- Replaced shape-fragile `simp`/`rw` steps with deterministic ones where goals arrived at defeq-but-distinct spellings: the `measure_diff` finiteness side-goal is now a `have` in a fixed `Icc` spelling, and the pigeonhole witness identity is proved in the ambient space via `map_neg (…).subtype` + `vadd_vadd`, `neg_add_cancel`, `zero_vadd`.
- Wrote the notation right-hand sides projection-free (Lean's notation quotation precheck does not support `.foo` syntax).

CI is green on the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc33QMUcfCjxphPXue49yW