### PR TITLE
refactor(RealDecay): consolidate decay lemmas into one general helper

### DIFF
--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -27,7 +27,7 @@ These lemmas are designed to be reusable for contour integral analysis where:
 ## Main results
 
 ### Asymptotic behavior
-- `tendsto_const_mul_pow_mul_exp_neg_atTop`: C · tⁿ · exp(-a·t) → 0 as t → ∞ for a > 0
+- `tendsto_const_mul_rpow_mul_exp_neg_atTop`: C · t^n · exp(-a·t) → 0 as t → ∞ for a > 0
 
 ### Integrability
 - `integrableOn_exp_mul_Ici`: exp(c*t) is integrable on [1,∞) for c < 0
@@ -50,25 +50,24 @@ section Integrability
 
 /-- exp(c*t) is integrable on [1,∞) for c < 0. -/
 lemma integrableOn_exp_mul_Ici (c : ℝ) (hc : c < 0) :
-    IntegrableOn (fun t => exp (c * t)) (Ici 1) volume :=
+    IntegrableOn (fun t ↦ exp (c * t)) (Ici 1) volume :=
   (integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrableOn_exp_mul_Ioi hc 1)
 
-/-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
-lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :
-    Tendsto (fun t => C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
-  simpa [mul_assoc, Real.rpow_natCast] using
-    (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero (n : ℝ) a ha).const_mul C
+/-- `C · t^n · exp(-a·t) → 0` as `t → ∞` for `a > 0` and any real power `n`. -/
+lemma tendsto_const_mul_rpow_mul_exp_neg_atTop (C a n : ℝ) (ha : 0 < a) :
+    Tendsto (fun t ↦ C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
+  simpa [mul_assoc] using (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero n a ha).const_mul C
 
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
-    IntegrableOn (fun t => t * exp (-a * t)) (Ici 1) volume := by
+    IntegrableOn (fun t ↦ t * exp (-a * t)) (Ici 1) volume := by
   rw [integrableOn_Ici_iff_integrableOn_Ioi]
   simpa [rpow_one] using (integrableOn_rpow_mul_exp_neg_mul_rpow (s := 1) (p := 1)
     (by norm_num) le_rfl ha).mono_set (Set.Ioi_subset_Ioi zero_le_one)
 
 /-- t² * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_sq_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
-    IntegrableOn (fun t => t^2 * exp (-a * t)) (Ici 1) volume := by
+    IntegrableOn (fun t ↦ t^2 * exp (-a * t)) (Ici 1) volume := by
   rw [integrableOn_Ici_iff_integrableOn_Ioi]
   simpa [rpow_one, rpow_two] using (integrableOn_rpow_mul_exp_neg_mul_rpow (s := 2) (p := 1)
     (by norm_num) le_rfl ha).mono_set (Set.Ioi_subset_Ioi zero_le_one)

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -70,6 +70,12 @@ lemma tendsto_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
     Tendsto (fun t => exp (-a * t)) atTop (nhds 0) := by
   simpa [rpow_zero] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 0 a ha
 
+/-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
+lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :
+    Tendsto (fun t => C * t ^ n * exp (-a * t)) atTop (nhds 0) := by
+  simpa [mul_assoc, Real.rpow_natCast] using
+    (tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero (n : ℝ) a ha).const_mul C
+
 /-- t * exp(-a*t) is integrable on [1,∞) for a > 0. -/
 lemma integrableOn_mul_exp_neg_Ici (a : ℝ) (ha : 0 < a) :
     IntegrableOn (fun t => t * exp (-a * t)) (Ici 1) volume := by

--- a/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/RealDecay.lean
@@ -27,9 +27,7 @@ These lemmas are designed to be reusable for contour integral analysis where:
 ## Main results
 
 ### Asymptotic behavior
-- `tendsto_exp_neg_atTop`: exp(-a*t) → 0 as t → ∞ for a > 0
-- `tendsto_mul_exp_neg_atTop`: t * exp(-a*t) → 0 as t → ∞ for a > 0
-- `tendsto_sq_mul_exp_neg_atTop`: t² * exp(-a*t) → 0 as t → ∞ for a > 0
+- `tendsto_const_mul_pow_mul_exp_neg_atTop`: C · tⁿ · exp(-a·t) → 0 as t → ∞ for a > 0
 
 ### Integrability
 - `integrableOn_exp_mul_Ici`: exp(c*t) is integrable on [1,∞) for c < 0
@@ -54,21 +52,6 @@ section Integrability
 lemma integrableOn_exp_mul_Ici (c : ℝ) (hc : c < 0) :
     IntegrableOn (fun t => exp (c * t)) (Ici 1) volume :=
   (integrableOn_Ici_iff_integrableOn_Ioi).mpr (integrableOn_exp_mul_Ioi hc 1)
-
-/-- t * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_mul_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => t * exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_one] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 1 a ha
-
-/-- t² * exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_sq_mul_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => t^2 * exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_two] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 2 a ha
-
-/-- exp(-a*t) → 0 as t → ∞ for a > 0. -/
-lemma tendsto_exp_neg_atTop (a : ℝ) (ha : 0 < a) :
-    Tendsto (fun t => exp (-a * t)) atTop (nhds 0) := by
-  simpa [rpow_zero] using tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero 0 a ha
 
 /-- `C · tⁿ · exp(-a·t) → 0` as `t → ∞` for `a > 0` (covers the `n = 0, 1, 2` decay terms). -/
 lemma tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a) :


### PR DESCRIPTION
## Summary

Consolidate the exponential-decay `Tendsto` helpers in `RealDecay.lean` into one `n`-parametrized lemma:

- **Add** `tendsto_const_mul_pow_mul_exp_neg_atTop (C a : ℝ) (n : ℕ) (ha : 0 < a)` — `C · tⁿ · exp(-a·t) → 0`.
- **Remove** the three single-power lemmas it subsumes (each is the `C = 1` case): `tendsto_exp_neg_atTop` (n=0), `tendsto_mul_exp_neg_atTop` (n=1), `tendsto_sq_mul_exp_neg_atTop` (n=2).

The removed lemmas had no remaining uses — the vertical/top-edge decay proofs in [#296](https://github.com/thefundamentaltheor3m/Sphere-Packing-Lean/pull/296) route through the general lemma.

## How this helps #296

#296 (ContourEndpoints) proves `tendsto_verticalBound_atTop` / `tendsto_topEdgeBound_atTop` term by term, each of the form `C · tⁿ · exp(-a·t)` (`n = 0, 1, 2`). With the general lemma every term is a one-line application instead of a five-line `const_mul / simp / convert / ring` block (`n = 2` directly, `n = 0, 1` via `simpa`).

## Notes

- **Must merge before #296.** #296 carries the identical RealDecay change so it stays buildable in the meantime; that change drops out once this merges.

## Test plan
- [x] `lake build` passes
- [x] No sorries; no new axioms
