### PR TITLE
feat(ResToImagAxis): inv/div + quotient-real-part API; use in FG

### DIFF
--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -561,6 +561,7 @@ theorem G_imag_axis_pos : ResToImagAxis.Pos G := by unfold G; fun_prop (disch :=
 `G(it)` is real for all `t > 0`.
 Blueprint: G = H₂³ (2H₂² + 5H₂H₄ + 5H₄²), product of real functions.
 -/
+@[fun_prop]
 theorem G_imag_axis_real : ResToImagAxis.Real G := G_imag_axis_pos.1
 
 /--
@@ -576,6 +577,7 @@ theorem F_imag_axis_pos : ResToImagAxis.Pos F := by
 `F(it)` is real for all `t > 0`.
 Blueprint: Follows from E₂, E₄, E₆ having real values on the imaginary axis.
 -/
+@[fun_prop]
 theorem F_imag_axis_real : ResToImagAxis.Real F := F_imag_axis_pos.1
 
 /-- `FmodGReal t = F(it)/G(it)` on the imaginary axis. (Placed here, after `F`/`G_imag_axis_real`,
@@ -1024,8 +1026,6 @@ theorem D_G_div_G_tendsto :
 /-- `L₁,₀(it)` is real for all `t > 0`. -/
 theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by
   unfold L₁₀
-  have hF := F_imag_axis_real
-  have hG := G_imag_axis_real
   fun_prop
 
 /-- `lim_{t→∞} L₁,₀(it)/(F(it)G(it)) = 1/2`. -/

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -1051,7 +1051,7 @@ theorem L₁₀_div_FG_tendsto :
     (tendsto_resToImagAxis_of_tendsto_atImInfty h_L_over_FG)
   simp only [show (1 / 2 : ℂ).re = (1 / 2 : ℝ) by norm_num] at h_re
   refine h_re.congr' ?_
-  filter_upwards [Filter.eventually_gt_atTop 0] with t _ht_pos
+  filter_upwards with t
   simp only [Function.comp_apply]
   exact ResToImagAxis.Real.re_div_mul_eq F_imag_axis_real G_imag_axis_real t
 

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -561,7 +561,6 @@ theorem G_imag_axis_pos : ResToImagAxis.Pos G := by unfold G; fun_prop (disch :=
 `G(it)` is real for all `t > 0`.
 Blueprint: G = H₂³ (2H₂² + 5H₂H₄ + 5H₄²), product of real functions.
 -/
-@[fun_prop]
 theorem G_imag_axis_real : ResToImagAxis.Real G := G_imag_axis_pos.1
 
 /--
@@ -577,7 +576,6 @@ theorem F_imag_axis_pos : ResToImagAxis.Pos F := by
 `F(it)` is real for all `t > 0`.
 Blueprint: Follows from E₂, E₄, E₆ having real values on the imaginary axis.
 -/
-@[fun_prop]
 theorem F_imag_axis_real : ResToImagAxis.Real F := F_imag_axis_pos.1
 
 /-- `FmodGReal t = F(it)/G(it)` on the imaginary axis. (Placed here, after `F`/`G_imag_axis_real`,
@@ -877,8 +875,9 @@ theorem D_G_div_G_tendsto :
 
 /-- `L₁,₀(it)` is real for all `t > 0`. -/
 theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by
-  unfold L₁₀
-  fun_prop
+  have hF := F_imag_axis_real
+  have hG := G_imag_axis_real
+  fun_prop [L₁₀]
 
 /-- `lim_{t→∞} L₁,₀(it)/(F(it)G(it)) = 1/2`. -/
 theorem L₁₀_div_FG_tendsto :

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -580,7 +580,7 @@ theorem F_imag_axis_real : ResToImagAxis.Real F := F_imag_axis_pos.1
 
 /-- `FmodGReal t = F(it)/G(it)` on the imaginary axis. (Placed here, after `F`/`G_imag_axis_real`,
 since the proof needs both realness facts.) -/
-theorem FmodG_eq_FmodGReal {t : ℝ} (ht : 0 < t) :
+theorem FmodG_eq_FmodGReal {t : ℝ} :
     FmodGReal t = (F.resToImagAxis t) / (G.resToImagAxis t) := by
   unfold FmodGReal FReal GReal
   exact (ResToImagAxis.Real.div_eq_real_div F_imag_axis_real G_imag_axis_real t).symm

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -73,9 +73,6 @@ theorem F_eq_FReal {t : ℝ} (ht : 0 < t) : F.resToImagAxis t = FReal t := by so
 
 theorem G_eq_GReal {t : ℝ} (ht : 0 < t) : G.resToImagAxis t = GReal t := by sorry
 
-theorem FmodG_eq_FmodGReal {t : ℝ} (ht : 0 < t) :
-    FmodGReal t = (F.resToImagAxis t) / (G.resToImagAxis t) := by sorry
-
 /--
 `F = 9 * (D E₄)²` by Ramanujan's formula.
 From `ramanujan_E₄`: `D E₄ = (1/3) * (E₂ * E₄ - E₆)`
@@ -176,11 +173,6 @@ private lemma logderiv_mul_eq (f h : ℍ → ℂ)
     D (f * h) z / (f z * h z) = D f z / f z + D h z / h z := by
   simp only [congrFun (D_mul f h hf_md hh_md) z, Pi.mul_apply, Pi.add_apply]
   field_simp [hf_ne, hh_ne]
-
-/-- `(a / b).re = a.re / b.re` when `b` is a real-valued complex number. -/
-private lemma div_re_of_im_eq_zero {a b : ℂ} (hb : b.im = 0) :
-    (a / b).re = a.re / b.re := by
-  rw [show b = ↑b.re from Complex.ext rfl (by simp [hb])]; exact Complex.div_ofReal_re a b.re
 
 /- Positivity of (quasi)modular forms on the imaginary axis. -/
 
@@ -585,6 +577,14 @@ theorem F_imag_axis_pos : ResToImagAxis.Pos F := by
 Blueprint: Follows from E₂, E₄, E₆ having real values on the imaginary axis.
 -/
 theorem F_imag_axis_real : ResToImagAxis.Real F := F_imag_axis_pos.1
+
+/-- `FmodGReal t = F(it)/G(it)` on the imaginary axis. (Placed here, after `F`/`G_imag_axis_real`,
+since the proof needs both realness facts.) -/
+theorem FmodG_eq_FmodGReal {t : ℝ} (ht : 0 < t) :
+    FmodGReal t = (F.resToImagAxis t) / (G.resToImagAxis t) := by
+  have _ := ht
+  unfold FmodGReal FReal GReal
+  exact (ResToImagAxis.Real.div_eq_real_div F_imag_axis_real G_imag_axis_real t).symm
 
 end ImagAxisProperties
 
@@ -1051,17 +1051,9 @@ theorem L₁₀_div_FG_tendsto :
     (tendsto_resToImagAxis_of_tendsto_atImInfty h_L_over_FG)
   simp only [show (1 / 2 : ℂ).re = (1 / 2 : ℝ) by norm_num] at h_re
   refine h_re.congr' ?_
-  filter_upwards [Filter.eventually_gt_atTop 0] with t ht_pos
-  simp only [Function.comp_apply, Function.resToImagAxis_apply, ResToImagAxis, ht_pos, ↓reduceDIte]
-  set z : ℍ := ⟨Complex.I * t, by simp [ht_pos]⟩ with hz
-  have hL := L₁₀_imag_axis_real t ht_pos
-  have hF := F_imag_axis_real t ht_pos
-  have hG := G_imag_axis_real t ht_pos
-  simp only [Function.resToImagAxis_apply, ResToImagAxis, ht_pos, ↓reduceDIte] at hL hF hG
-  rw [← hz] at hL hF hG
-  have hFG_im : (F z * G z).im = 0 := by rw [Complex.mul_im, hF, hG]; ring
-  have hFG_re : (F z * G z).re = (F z).re * (G z).re := by rw [Complex.mul_re, hF, hG]; ring
-  rw [div_re_of_im_eq_zero hFG_im, hFG_re]
+  filter_upwards [Filter.eventually_gt_atTop 0] with t _ht_pos
+  simp only [Function.comp_apply]
+  exact ResToImagAxis.Real.re_div_mul_eq F_imag_axis_real G_imag_axis_real t
 
 theorem L₁₀_eventually_pos_imag_axis : ResToImagAxis.EventuallyPos L₁₀ := by
   refine ⟨L₁₀_imag_axis_real, ?_⟩

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -1027,7 +1027,6 @@ theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by
   unfold L₁₀
   have hF := F_imag_axis_real
   have hG := G_imag_axis_real
-  have hGh := G_holo
   fun_prop
 
 /-- `lim_{t→∞} L₁,₀(it)/(F(it)G(it)) = 1/2`. -/

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -582,7 +582,6 @@ theorem F_imag_axis_real : ResToImagAxis.Real F := F_imag_axis_pos.1
 since the proof needs both realness facts.) -/
 theorem FmodG_eq_FmodGReal {t : ℝ} (ht : 0 < t) :
     FmodGReal t = (F.resToImagAxis t) / (G.resToImagAxis t) := by
-  have _ := ht
   unfold FmodGReal FReal GReal
   exact (ResToImagAxis.Real.div_eq_real_div F_imag_axis_real G_imag_axis_real t).symm
 

--- a/SpherePacking/ModularForms/ResToImagAxis.lean
+++ b/SpherePacking/ModularForms/ResToImagAxis.lean
@@ -145,10 +145,6 @@ theorem ResToImagAxis.Real.pow {F : ℍ → ℂ} (hF : ResToImagAxis.Real F) (n 
   | zero => exact ResToImagAxis.Real.one
   | succ n hn => exact hn.mul hF
 
-/-- (Relocated from `FG.lean`.) `(a/b).re = a.re/b.re` when `b` is real-valued. -/
-private theorem div_re_of_im_eq_zero {a b : ℂ} (hb : b.im = 0) : (a / b).re = a.re / b.re := by
-  rw [show b = ↑b.re from Complex.ext rfl (by simp [hb])]; exact Complex.div_ofReal_re a b.re
-
 @[fun_prop]
 theorem ResToImagAxis.Real.inv {F : ℍ → ℂ} (hF : ResToImagAxis.Real F) :
     ResToImagAxis.Real F⁻¹ := by
@@ -160,11 +156,11 @@ theorem ResToImagAxis.Real.inv {F : ℍ → ℂ} (hF : ResToImagAxis.Real F) :
 @[fun_prop]
 theorem ResToImagAxis.Real.div {F G : ℍ → ℂ} (hF : ResToImagAxis.Real F)
     (hG : ResToImagAxis.Real G) : ResToImagAxis.Real (F / G) := by
-  intro t ht
-  have hFreal := hF t ht
-  have hGreal := hG t ht
-  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFreal hGreal
-  simp [ResToImagAxis, ht, Pi.div_apply, Complex.div_im, hFreal, hGreal]
+  simpa [div_eq_mul_inv] using hF.mul hG.inv
+
+/-- `(a/b).re = a.re/b.re` when `b` is real-valued (building block for `re_div_eq`). -/
+private theorem div_re_of_im_eq_zero {a b : ℂ} (hb : b.im = 0) : (a / b).re = a.re / b.re := by
+  rw [show b = ↑b.re from Complex.ext rfl (by simp [hb])]; exact Complex.div_ofReal_re a b.re
 
 /-- Real part of a quotient on the imaginary axis is the quotient of real parts, provided the
 denominator `G` is real-valued there (the numerator's realness is not needed). -/
@@ -177,20 +173,25 @@ theorem ResToImagAxis.Real.re_div_eq {F G : ℍ → ℂ} (hG : ResToImagAxis.Rea
     simpa only [Pi.div_apply] using div_re_of_im_eq_zero hGreal
   · simp
 
+/-- Real part of a product on the imaginary axis is the product of real parts, when both factors are
+real-valued there. -/
+theorem ResToImagAxis.Real.re_mul_eq {F G : ℍ → ℂ} (hF : ResToImagAxis.Real F)
+    (hG : ResToImagAxis.Real G) (t : ℝ) :
+    ((F * G).resToImagAxis t).re = (F.resToImagAxis t).re * (G.resToImagAxis t).re := by
+  simp only [Function.resToImagAxis, ResToImagAxis]
+  split_ifs with ht
+  · have hFreal := hF t ht
+    have hGreal := hG t ht
+    simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFreal hGreal
+    simp [Pi.mul_apply, Complex.mul_re, hFreal, hGreal]
+  · simp
+
 /-- Real part of `F / (G * H)` on the imaginary axis, with `G` and `H` real-valued there. -/
 theorem ResToImagAxis.Real.re_div_mul_eq {F G H : ℍ → ℂ} (hG : ResToImagAxis.Real G)
     (hH : ResToImagAxis.Real H) (t : ℝ) :
     ((F / (G * H)).resToImagAxis t).re =
       (F.resToImagAxis t).re / ((G.resToImagAxis t).re * (H.resToImagAxis t).re) := by
-  rw [ResToImagAxis.Real.re_div_eq (hG.mul hH) t]
-  congr 1
-  simp only [Function.resToImagAxis, ResToImagAxis]
-  split_ifs with ht
-  · have hGreal := hG t ht
-    have hHreal := hH t ht
-    simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hGreal hHreal
-    simp [Pi.mul_apply, Complex.mul_re, hGreal, hHreal]
-  · simp
+  rw [ResToImagAxis.Real.re_div_eq (hG.mul hH) t, ResToImagAxis.Real.re_mul_eq hG hH t]
 
 theorem ResToImagAxis.Pos.const (c : ℝ) (hc : 0 < c) : ResToImagAxis.Pos (fun _ => c) :=
   ⟨ResToImagAxis.Real.const c, fun t ht ↦ by simp [ResToImagAxis, ht, hc]⟩
@@ -214,13 +215,8 @@ theorem ResToImagAxis.Pos.mul {F G : ℍ → ℂ} (hF : ResToImagAxis.Pos F)
     (hG : ResToImagAxis.Pos G) : ResToImagAxis.Pos (F * G) := by
   rw [Pos]
   refine ⟨Real.mul hF.1 hG.1, fun t ht ↦ ?_⟩
-  have hFreal := hF.1 t ht
-  have hGreal := hG.1 t ht
-  have hFpos := hF.2 t ht
-  have hGpos := hG.2 t ht
-  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFreal hGreal
-  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFpos hGpos
-  simp [ResToImagAxis, ht, hFreal, hGreal, mul_pos hFpos hGpos]
+  rw [Real.re_mul_eq hF.1 hG.1 t]
+  exact mul_pos (hF.2 t ht) (hG.2 t ht)
 
 @[fun_prop]
 theorem ResToImagAxis.Pos.smul {F : ℍ → ℂ} {c : ℝ} (hF : ResToImagAxis.Pos F)
@@ -287,23 +283,9 @@ theorem ResToImagAxis.EventuallyPos.mul {F G : ℍ → ℂ}
   refine ⟨ResToImagAxis.Real.mul hF.1 hG.1, ?_⟩
   obtain ⟨tF, hF0, hFpos⟩ := hF.2
   obtain ⟨tG, hG0, hGpos⟩ := hG.2
-  let t₀ := max tF tG
-  use t₀
-  refine ⟨by positivity, fun t ht ↦ ?_⟩
-  have htpos : 0 < t := by grind
-  have hFreal_t := hF.1 t htpos
-  have hGreal_t := hG.1 t htpos
-  have htF₀ : tF ≤ t₀ := by grind
-  have htG₀ : tG ≤ t₀ := by grind
-  have htF : tF ≤ t := htF₀.trans ht
-  have htG : tG ≤ t := htG₀.trans ht
-  have hFpos_t := hFpos t htF
-  have hGpos_t := hGpos t htG
-  simp only [Function.resToImagAxis, ResToImagAxis, htpos] at hFpos_t hGpos_t
-  simp only [Function.resToImagAxis, ResToImagAxis, htpos, ↓reduceDIte] at hFreal_t hGreal_t
-  simp only [Function.resToImagAxis_apply, ResToImagAxis, htpos, ↓reduceDIte, Pi.mul_apply, mul_re,
-    hFreal_t, hGreal_t, mul_zero, sub_zero]
-  exact mul_pos hFpos_t hGpos_t
+  refine ⟨max tF tG, by positivity, fun t ht ↦ ?_⟩
+  rw [ResToImagAxis.Real.re_mul_eq hF.1 hG.1 t]
+  exact mul_pos (hFpos t ((le_max_left tF tG).trans ht)) (hGpos t ((le_max_right tF tG).trans ht))
 
 @[fun_prop]
 theorem ResToImagAxis.EventuallyPos.pow {F : ℍ → ℂ}

--- a/SpherePacking/ModularForms/ResToImagAxis.lean
+++ b/SpherePacking/ModularForms/ResToImagAxis.lean
@@ -145,6 +145,53 @@ theorem ResToImagAxis.Real.pow {F : ℍ → ℂ} (hF : ResToImagAxis.Real F) (n 
   | zero => exact ResToImagAxis.Real.one
   | succ n hn => exact hn.mul hF
 
+/-- (Relocated from `FG.lean`.) `(a/b).re = a.re/b.re` when `b` is real-valued. -/
+private theorem div_re_of_im_eq_zero {a b : ℂ} (hb : b.im = 0) : (a / b).re = a.re / b.re := by
+  rw [show b = ↑b.re from Complex.ext rfl (by simp [hb])]; exact Complex.div_ofReal_re a b.re
+
+@[fun_prop]
+theorem ResToImagAxis.Real.inv {F : ℍ → ℂ} (hF : ResToImagAxis.Real F) :
+    ResToImagAxis.Real F⁻¹ := by
+  intro t ht
+  have hFreal := hF t ht
+  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFreal
+  simp [ResToImagAxis, ht, Pi.inv_apply, Complex.inv_im, hFreal]
+
+@[fun_prop]
+theorem ResToImagAxis.Real.div {F G : ℍ → ℂ} (hF : ResToImagAxis.Real F)
+    (hG : ResToImagAxis.Real G) : ResToImagAxis.Real (F / G) := by
+  intro t ht
+  have hFreal := hF t ht
+  have hGreal := hG t ht
+  simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hFreal hGreal
+  simp [ResToImagAxis, ht, Pi.div_apply, Complex.div_im, hFreal, hGreal]
+
+/-- Real part of a quotient on the imaginary axis is the quotient of real parts, provided the
+denominator `G` is real-valued there (the numerator's realness is not needed). -/
+theorem ResToImagAxis.Real.re_div_eq {F G : ℍ → ℂ} (hG : ResToImagAxis.Real G) (t : ℝ) :
+    ((F / G).resToImagAxis t).re = (F.resToImagAxis t).re / (G.resToImagAxis t).re := by
+  simp only [Function.resToImagAxis, ResToImagAxis]
+  split_ifs with ht
+  · have hGreal := hG t ht
+    simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hGreal
+    simpa only [Pi.div_apply] using div_re_of_im_eq_zero hGreal
+  · simp
+
+/-- Real part of `F / (G * H)` on the imaginary axis, with `G` and `H` real-valued there. -/
+theorem ResToImagAxis.Real.re_div_mul_eq {F G H : ℍ → ℂ} (hG : ResToImagAxis.Real G)
+    (hH : ResToImagAxis.Real H) (t : ℝ) :
+    ((F / (G * H)).resToImagAxis t).re =
+      (F.resToImagAxis t).re / ((G.resToImagAxis t).re * (H.resToImagAxis t).re) := by
+  rw [ResToImagAxis.Real.re_div_eq (hG.mul hH) t]
+  congr 1
+  simp only [Function.resToImagAxis, ResToImagAxis]
+  split_ifs with ht
+  · have hGreal := hG t ht
+    have hHreal := hH t ht
+    simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte] at hGreal hHreal
+    simp [Pi.mul_apply, Complex.mul_re, hGreal, hHreal]
+  · simp
+
 theorem ResToImagAxis.Pos.const (c : ℝ) (hc : 0 < c) : ResToImagAxis.Pos (fun _ => c) :=
   ⟨ResToImagAxis.Real.const c, fun t ht ↦ by simp [ResToImagAxis, ht, hc]⟩
 
@@ -288,6 +335,16 @@ theorem ResToImagAxis.Real.eq_real_part {F : ℍ → ℂ} (hF : ResToImagAxis.Re
   split_ifs with ht
   exacts [Complex.ext rfl (by simpa [Function.resToImagAxis, ResToImagAxis, ht]
     using (hF t ht)), rfl]
+
+/-- For real-valued `F`, `G`, the complex quotient on the imaginary axis equals the (coerced) real
+quotient of real parts. -/
+theorem ResToImagAxis.Real.div_eq_real_div {F G : ℍ → ℂ} (hF : ResToImagAxis.Real F)
+    (hG : ResToImagAxis.Real G) (t : ℝ) :
+    F.resToImagAxis t / G.resToImagAxis t =
+      ((F.resToImagAxis t).re / (G.resToImagAxis t).re : ℝ) := by
+  rw [hF.eq_real_part t, hG.eq_real_part t]
+  push_cast
+  rw [Complex.ofReal_re, Complex.ofReal_re]
 
 /-!
 ## Polynomial decay of functions with exponential bounds


### PR DESCRIPTION
## Summary

`ResToImagAxis.Real F` ("`F` is real on the positive imaginary axis") had a full `@[fun_prop]` closure suite for `neg/add/sub/mul/smul/pow` but **no `inv`/`div` and no real-part projection** for products/quotients. Because of that gap, several proofs hand-rolled the imaginary-axis quotient/product real-part step (`FG.lean`'s private `div_re_of_im_eq_zero` + an 8-line block; the manual `mul_re` blocks inside `Pos.mul` / `EventuallyPos.mul`). This PR adds the missing reusable API and uses it.

## Changes

**`ResToImagAxis.lean`** — new lemmas beside the existing closure suite:
- `@[fun_prop] Real.inv : Real F → Real F⁻¹` and `@[fun_prop] Real.div : Real F → Real G → Real (F/G)` (the latter now derived from `inv` + `mul`). No `≠ 0` hypothesis is needed — `(w⁻¹).im = -w.im/normSq` is `0` when `w.im = 0` (even at `w = 0`, since `0⁻¹ = 0`).
- `Real.re_mul_eq : ((F*G).resToImagAxis t).re = (F.resToImagAxis t).re * (G.resToImagAxis t).re` (both factors real).
- `Real.re_div_eq : ((F/G).resToImagAxis t).re = (F.resToImagAxis t).re / (G.resToImagAxis t).re` — needs **only** the denominator's realness.
- `Real.re_div_mul_eq` — the `F/(G*H)` version, a two-rewrite corollary of the two above.
- `Real.div_eq_real_div : F(it)/G(it) = ↑((F(it)).re / (G(it)).re)` for real `F`, `G`.
- Relocated the `(a/b).re = a.re/b.re` helper `div_re_of_im_eq_zero` here from `FG.lean`.

Projection lemmas (`re_mul_eq`/`re_div_eq`/`re_div_mul_eq`/`div_eq_real_div`) are intentionally **not** `@[simp]` — they're explicit rewrite tools.

**In-file reuse (demonstrates the API):** `Pos.mul` and `EventuallyPos.mul` each drop their manual `mul_re`/realness block — the product-positivity step is now `rw [Real.re_mul_eq …]; exact mul_pos …`.

**`FG.lean`:**
- Collapsed the quotient block in `L₁₀_div_FG_tendsto` (8 lines manually rebuilding `(F·G)`'s realness) to one `re_div_mul_eq F_imag_axis_real G_imag_axis_real t`; the `filter_upwards` no longer needs `eventually_gt_atTop 0` (the identity holds for all `t`).
- Removed the now-relocated private `div_re_of_im_eq_zero`.
- Removed unneeded `have hGh := G_holo` in `L₁₀_imag_axis_real`.
- **Closed the `FmodG_eq_FmodGReal` sorry** via the new `div_eq_real_div`, and dropped its now-unused (ht : 0 < t) hypothesis — it has no callers (main or any monotonicity branch) and is vacuously true for all t:
  ```lean
  unfold FmodGReal FReal GReal
  exact (ResToImagAxis.Real.div_eq_real_div F_imag_axis_real G_imag_axis_real t).symm
  ```
  (For contrast, the *existing* API already supported it, but in more steps:)
  ```lean
  unfold FmodGReal FReal GReal
  rw [ResToImagAxis.Real.eq_real_part F_imag_axis_real t,
    ResToImagAxis.Real.eq_real_part G_imag_axis_real t]
  simp [Complex.ofReal_div]
  ```
  The lemma is relocated from the early definition block to just after `F`/`G_imag_axis_real` (the proof needs those realness facts; it has no other uses in the file).

## Where this is reusable downstream

This rounds out a small, coherent "real part of an operation on the imaginary axis" API. Concretely:
- `@[fun_prop] Real.inv`/`Real.div` — these complete the `@[fun_prop]` realness closure suite (alongside `neg`/`add`/`sub`/`mul`/`smul`/`pow`). No call site exercises them yet — this PR's callers invoke the projection lemmas (`re_div_eq`, `div_eq_real_div`, …) directly, since they need an equality of real parts rather than just ResToImagAxis.Real (F/G). So they're forward-looking, but they do fire — `fun_prop` discharges each of these from the base realness facts:
```
example : ResToImagAxis.Real (F / G) := by
  have hF := F_imag_axis_real; have hG := G_imag_axis_real; fun_prop
example : ResToImagAxis.Real G⁻¹ := by
  have hG := G_imag_axis_real; fun_prop
example : ResToImagAxis.Real (L₁₀ / (F * G)) := by
  have hL := L₁₀_imag_axis_real; have hF := F_imag_axis_real; have hG := G_imag_axis_real; fun_prop
```
- **`re_mul_eq`/`re_div_eq`/`re_div_mul_eq`** — wherever a real part of a product/quotient on the imaginary axis is computed by hand. Already applied here to `Pos.mul`, `EventuallyPos.mul`, and the `L₁₀` block.
- **`div_eq_real_div`** — the bridge between a complex quotient `F(it)/G(it)` and the real quotient `FReal/GReal`. Beyond `FmodG_eq_FmodGReal` (closed here), this is the natural tool for the `FmodGReal` monotonicity / `F`-over-`G` work (PR #331, branch `monotonicity-of-F-div-G`), e.g. `FReal = FmodGReal * GReal`-style identities.

Caveat: #331's functional-equation realification mostly rewrites individual values with `eq_real_part` and then does coercion/ring work, so `re_mul_eq` helps it only where expressions are kept in `(F * G).resToImagAxis` product form — a real but partial win there.

## Test plan
- [x] `lake build` passes — one **fewer** sorry (`FmodG_eq_FmodGReal`); the unrelated WIP sorries in `FG`/`PolyFourierCoeffBound` are untouched.

## Note re PR #331
#331 (FG inequalities) adds only S-action lemmas to `ResToImagAxis.lean` (no overlap with this quotient/product API) and leaves the `L₁₀` block / `FmodG_eq_FmodGReal` as-is, so these rebase cleanly — verify against the live #331 head at merge time.
