### PR TITLE
refactor(FG): extract log-derivative-at-infinity keystone

### DIFF
--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -762,16 +762,11 @@ lemma logderiv_tendsto_of_div_exp_tendsto {F : ℍ → ℂ} (hF : MDiff F) {a C 
   have hq_ne : ∀ w : ℍ, q w ≠ 0 := fun w ↦ Complex.exp_ne_zero _
   have hq_md : MDiff q := by
     intro τ
-    have h_diff : DifferentiableAt ℂ (fun t : ℂ ↦ cexp (a * t)) (τ : ℂ) :=
-      (differentiableAt_id.const_mul a).cexp
-    simpa [hq, Function.comp] using
-      DifferentiableAt_MDifferentiableAt (G := fun t : ℂ ↦ cexp (a * t)) (z := τ) h_diff
+    simpa [hq, Function.comp] using DifferentiableAt_MDifferentiableAt
+      (G := fun t : ℂ ↦ cexp (a * t)) (z := τ) ((differentiableAt_id.const_mul a).cexp)
   have hg_md : MDiff g := MDifferentiable_div hF hq_md hq_ne
-  have hg_lim : Filter.Tendsto g atImInfty (nhds C) := hlim
-  have hDg_tendsto : Filter.Tendsto (D g) atImInfty (nhds 0) :=
-    D_tendsto_zero_of_isBoundedAtImInfty hg_md (hg_lim.isBigO_one ℝ)
   have hDg_div_g : Filter.Tendsto (fun z ↦ D g z / g z) atImInfty (nhds 0) := by
-    tendsto_cont
+    simpa using (D_tendsto_zero_of_isBoundedAtImInfty hg_md (hlim.isBigO_one ℝ)).div hlim hC
   have hF_eq : F = q * g := by ext w; simp only [hg, Pi.mul_apply, mul_div_cancel₀ _ (hq_ne w)]
   have hDq_div_q : ∀ z : ℍ, D q z / q z = a / (2 * π * I) :=
     fun z ↦ by rw [hq]; exact D_cexp_div a z
@@ -779,8 +774,7 @@ lemma logderiv_tendsto_of_div_exp_tendsto {F : ℍ → ℂ} (hF : MDiff F) {a C 
     filter_upwards [hlim.eventually_ne hC] with z hz
     rw [hF_eq, Pi.mul_apply, logderiv_mul_eq q g hq_md hg_md z (hq_ne z) hz, hDq_div_q z]
   have hsum : Filter.Tendsto (fun z ↦ a / (2 * π * I) + D g z / g z) atImInfty
-      (nhds (a / (2 * π * I))) := by
-    tendsto_cont
+      (nhds (a / (2 * π * I))) := by tendsto_cont
   exact hsum.congr' (by filter_upwards [h_logderiv] with z hz; exact hz.symm)
 
 /-- The vanishing order of F at infinity is 2.

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -740,8 +740,44 @@ private theorem H₂_div_exp_tendsto :
     simp only [H₂, div_pow, ← Complex.exp_nat_mul]; congr 2; ring
   simp_rw [h_eq]; convert Θ₂_div_exp_tendsto.pow 4; norm_num
 
-private lemma H₂_eventually_ne_zero : ∀ᶠ z : ℍ in atImInfty, H₂ z ≠ 0 :=
-  eventually_ne_zero_of_tendsto_div (by norm_num : (16 : ℂ) ≠ 0) H₂_div_exp_tendsto
+/-- D(exp(c*z))/exp(c*z) = c/(2πi) for any coefficient c. -/
+theorem D_cexp_div (c : ℂ) (z : ℍ) :
+    D (fun w => cexp (c * w)) z / cexp (c * z) = c / (2 * π * I) := by
+  simp only [D]
+  have h_deriv : deriv ((fun w : ℍ => cexp (c * w)) ∘ ⇑ofComplex) (z : ℂ) =
+      c * cexp (c * z) :=
+    ((eventuallyEq_coe_comp_ofComplex z.2).fun_comp (fun w => cexp (c * w))).deriv_eq.trans
+      ((Complex.hasDerivAt_exp (c * (z : ℂ))).scomp (z : ℂ)
+        (by simpa using (hasDerivAt_id (z : ℂ)).const_mul c)).deriv
+  rw [h_deriv]; field_simp [Complex.exp_ne_zero]
+
+/-- If `F z / exp(a·z) → C ≠ 0` at `i∞`, then `D F / F → a/(2πi)`: the exponential contributes
+`a/(2πi)` and the bounded limit factor's log-derivative vanishes. Public so downstream files
+(e.g. #331's Θ₂ analysis) can reuse it. -/
+lemma logderiv_tendsto_of_div_exp_tendsto {F : ℍ → ℂ} (hF : MDiff F) {a C : ℂ} (hC : C ≠ 0)
+    (hlim : Filter.Tendsto (fun z : ℍ => F z / cexp (a * z)) atImInfty (nhds C)) :
+    Filter.Tendsto (fun z : ℍ => D F z / F z) atImInfty (nhds (a / (2 * π * I))) := by
+  set q : ℍ → ℂ := fun w => cexp (a * w) with hq
+  set g : ℍ → ℂ := fun w => F w / q w with hg
+  have hq_ne : ∀ w : ℍ, q w ≠ 0 := fun w => Complex.exp_ne_zero _
+  have hq_md : MDiff q := by
+    intro τ
+    have h_diff : DifferentiableAt ℂ (fun t : ℂ => cexp (a * t)) (τ : ℂ) :=
+      (differentiableAt_id.const_mul a).cexp
+    simpa [hq, Function.comp] using
+      DifferentiableAt_MDifferentiableAt (G := fun t : ℂ => cexp (a * t)) (z := τ) h_diff
+  have hg_md : MDiff g := MDifferentiable_div hF hq_md hq_ne
+  have hDg_div_g : Filter.Tendsto (fun z => D g z / g z) atImInfty (nhds 0) := by
+    simpa using (D_tendsto_zero_of_isBoundedAtImInfty hg_md (hlim.isBigO_one ℝ)).div hlim hC
+  have hF_eq : F = q * g := by ext w; simp only [hg, Pi.mul_apply, mul_div_cancel₀ _ (hq_ne w)]
+  have hDq_div_q : ∀ z : ℍ, D q z / q z = a / (2 * π * I) :=
+    fun z => by rw [hq]; exact D_cexp_div a z
+  have h_logderiv : ∀ᶠ z : ℍ in atImInfty, D F z / F z = a / (2 * π * I) + D g z / g z := by
+    filter_upwards [hlim.eventually_ne hC] with z hz
+    rw [hF_eq, Pi.mul_apply, logderiv_mul_eq q g hq_md hg_md z (hq_ne z) hz, hDq_div_q z]
+  rw [show a / (2 * π * I) = a / (2 * π * I) + 0 from (add_zero _).symm]
+  refine (tendsto_const_nhds.add hDg_div_g).congr' ?_
+  filter_upwards [h_logderiv] with z hz; exact hz.symm
 
 /-- The vanishing order of F at infinity is 2.
 Blueprint: F = 720² * q² * (1 + O(q)), so F / q² → 720² as im(z) → ∞. -/
@@ -799,89 +835,12 @@ theorem D_diff_qexp (z : ℍ) :
     _ = 720 * ∑' (n : ℕ+), (n : ℂ) ^ 2 * ↑(σ 3 n) * cexp (2 * π * I * ↑n * z) := by
         simp only [b, ← tsum_mul_left, sq]; congr 1; funext n; ring
 
-/-- D(E₂E₄ - E₆) / q → 720. -/
-private theorem D_diff_div_q_tendsto :
-    Filter.Tendsto (fun z : ℍ => D (fun w => E₂ w * E₄ w - E₆ w) z /
-      cexp (2 * π * Complex.I * z))
-      atImInfty (nhds (720 : ℂ)) := by
-  have h_rw : ∀ z : ℍ, D (fun w => E₂ w * E₄ w - E₆ w) z =
-      720 * ∑' n : ℕ+, (↑↑n : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) ↑n) *
-        cexp (2 * ↑Real.pi * Complex.I * ↑n * z) := D_diff_qexp
-  simp_rw [h_rw]
-  have h_eq : ∀ z : ℍ,
-      (720 * ∑' n : ℕ+, (↑↑n : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) ↑n) *
-        cexp (2 * ↑Real.pi * Complex.I * ↑n * z)) / cexp (2 * π * I * z) =
-      720 * (∑' n : ℕ+, (↑↑n : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) ↑n) *
-        cexp (2 * π * I * (↑n - 1) * z)) := by
-    intro z
-    rw [mul_div_assoc, ← tsum_div_const]
-    congr 1; apply tsum_congr; intro n
-    rw [mul_div_assoc, ← Complex.exp_sub]
-    congr 2; ring
-  simp_rw [h_eq]
-  have h_reindex : ∀ z : ℍ,
-      ∑' n : ℕ+, (↑↑n : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) ↑n) *
-        cexp (2 * π * I * (↑n - 1) * z) =
-      ∑' m : ℕ, (↑(m + 1) : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) (m + 1)) *
-        cexp (2 * π * I * m * z) := by
-    intro z
-    rw [← Equiv.tsum_eq (Equiv.pnatEquivNat)]
-    apply tsum_congr; intro m
-    simp only [Equiv.pnatEquivNat_apply, PNat.natPred_add_one]
-    congr 2
-    simp only [← PNat.natPred_add_one m, Nat.cast_add, Nat.cast_one, add_sub_cancel_right]
-  simp_rw [h_reindex]
-  set a : ℕ → ℂ := fun m =>
-    (↑(m + 1) : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) (m + 1)) with ha_def
-  have ha0 : a 0 = 1 := by simp [ha_def, ArithmeticFunction.sigma_one]
-  have hbound : ∀ m, ‖a m‖ ≤ ((m + 1 : ℕ) : ℝ) ^ 6 := fun m => by
-    simp only [ha_def, norm_mul, Complex.norm_natCast, Complex.norm_pow]
-    calc (↑(m + 1) : ℝ) ^ 2 * ↑(ArithmeticFunction.sigma 3 (m + 1))
-        ≤ (↑(m + 1) : ℝ) ^ 2 * (↑(m + 1) : ℝ) ^ 4 :=
-          mul_le_mul_of_nonneg_left (mod_cast ArithmeticFunction.sigma_le_pow_succ 3 (m + 1))
-            (pow_nonneg (Nat.cast_nonneg _) _)
-      _ = _ := by ring
-  have h_eq2 : ∀ z : ℍ,
-      ∑' m : ℕ, (↑(m + 1) : ℂ) ^ 2 * ↑((ArithmeticFunction.sigma 3) (m + 1)) *
-        cexp (2 * π * I * m * z) =
-      ∑' m : ℕ, a m * cexp (2 * π * I * z * m) := fun z => by
-    simpa [ha_def] using tsum_congr (fun m => by ring_nf)
-  simp_rw [h_eq2]
-  simpa [ha0] using (qexp_tendsto_of_poly_bound hbound).const_mul (720 : ℂ)
-
 /-- `(D F)/F → 2` as `im(z) → ∞`.
 The log-derivative limit, following from F having vanishing order 2. -/
 theorem D_F_div_F_tendsto :
     Filter.Tendsto (fun z : ℍ => D F z / F z) atImInfty (nhds (2 : ℂ)) := by
-  set f : ℍ → ℂ := fun z => E₂ z * E₄.toFun z - E₆.toFun z with hf_def
-  have hF_eq : ∀ z, F z = (f z) ^ 2 := fun z => by
-    simp only [F, hf_def, sq, Pi.mul_apply, Pi.sub_apply, ModularForm.toFun_eq_coe]
-  have hf_holo : MDiff f := by
-    apply MDifferentiable.sub
-    · exact MDifferentiable.mul E₂_holo' E₄.holo'
-    · exact E₆.holo'
-  have hDF_eq : ∀ z, D F z = 2 * f z * D f z := fun z => by
-    have hF_eq' : F = f ^ 2 := funext fun w => by simp [F, hf_def, sq]
-    rw [hF_eq']
-    exact congr_fun (D_sq f hf_holo) z
-  have hDF_div_eq : ∀ z, F z ≠ 0 → D F z / F z = 2 * (D f z / f z) := fun z hFz => by
-    have hfz : f z ≠ 0 := fun h => hFz (by simp [hF_eq, h])
-    rw [hDF_eq z, hF_eq z, sq]; field_simp [hfz]
-  have hf_div_q : Filter.Tendsto (fun z : ℍ => f z / cexp (2 * π * Complex.I * z))
-      atImInfty (nhds (720 : ℂ)) :=
-    E₂E₄_sub_E₆_div_q_tendsto.congr fun z => by simp only [hf_def, ModularForm.toFun_eq_coe]
-  have hDf_div_q : Filter.Tendsto (fun z : ℍ => D f z / cexp (2 * π * Complex.I * z))
-      atImInfty (nhds (720 : ℂ)) := D_diff_div_q_tendsto
-  have h_720_ne : (720 : ℂ) ≠ 0 := by norm_num
-  have hDf_div_f : Filter.Tendsto (fun z : ℍ => D f z / f z) atImInfty (nhds 1) := by
-    have h_eq : ∀ z : ℍ, D f z / f z = (D f z / cexp (2 * π * Complex.I * z)) /
-        (f z / cexp (2 * π * Complex.I * z)) := fun z => by field_simp [Complex.exp_ne_zero]
-    simp_rw [h_eq, show (1 : ℂ) = 720 / 720 from by norm_num]
-    exact hDf_div_q.div hf_div_q h_720_ne
-  have h_F_ne := eventually_ne_zero_of_tendsto_div
-    (by norm_num : (720^2 : ℂ) ≠ 0) F_vanishing_order
-  simpa using (hDf_div_f.const_mul (2 : ℂ)).congr' (by
-    filter_upwards [h_F_ne] with z hFz; exact (hDF_div_eq z hFz).symm)
+  have h := logderiv_tendsto_of_div_exp_tendsto F_holo (by norm_num) F_vanishing_order
+  rwa [show (2 * π * I * 2) / (2 * π * I) = 2 from by field_simp] at h
 
 /-!
 ### G-Side Asymptotic Analysis
@@ -912,115 +871,16 @@ theorem G_vanishing_order :
   convert (H₂_div_exp_tendsto.pow 3).mul h_poly
   norm_num
 
-/-- D(exp(c*z))/exp(c*z) = c/(2πi) for any coefficient c. -/
-theorem D_cexp_div (c : ℂ) (z : ℍ) :
-    D (fun w => cexp (c * w)) z / cexp (c * z) = c / (2 * π * I) := by
-  simp only [D]
-  have h_deriv : deriv ((fun w : ℍ => cexp (c * w)) ∘ ⇑ofComplex) (z : ℂ) =
-      c * cexp (c * z) :=
-    ((eventuallyEq_coe_comp_ofComplex z.2).fun_comp (fun w => cexp (c * w))).deriv_eq.trans
-      ((Complex.hasDerivAt_exp (c * (z : ℂ))).scomp (z : ℂ)
-        (by simpa using (hasDerivAt_id (z : ℂ)).const_mul c)).deriv
-  rw [h_deriv]; field_simp [Complex.exp_ne_zero]
-
-private theorem D_exp_pi_div_exp_pi (z : ℍ) :
-    D (fun w => cexp (π * Complex.I * w)) z / cexp (π * Complex.I * z) = 1 / 2 := by
-  simpa [show π * I / (2 * π * I) = (1 : ℂ) / 2 by field_simp] using D_cexp_div (π * I) z
-
 private theorem D_H₂_div_H₂_tendsto :
     Filter.Tendsto (fun z : ℍ => D H₂ z / H₂ z) atImInfty (nhds ((1 : ℂ) / 2)) := by
-  -- Decompose H₂ = f * h where f = exp(πiz) and h = H₂/exp(πiz) → 16
-  let f : ℍ → ℂ := fun w => cexp (π * I * w)
-  let h : ℍ → ℂ := fun w => H₂ w / f w
-  have hf_ne : ∀ z : ℍ, f z ≠ 0 := fun z => Complex.exp_ne_zero _
-  have hf_md : MDiff f := by
-    intro τ
-    have h_diff : DifferentiableAt ℂ (fun t : ℂ => cexp (π * I * t)) (τ : ℂ) :=
-      (differentiableAt_id.const_mul (π * I)).cexp
-    simpa [f, Function.comp] using
-      DifferentiableAt_MDifferentiableAt (G := fun t : ℂ => cexp (π * I * t)) (z := τ) h_diff
-  have hh_md : MDiff h :=
-    MDifferentiable_div H₂_SIF_MDifferentiable hf_md hf_ne
-  have hh_tendsto : Filter.Tendsto h atImInfty (nhds (16 : ℂ)) := H₂_div_exp_tendsto
-  have hDh_tendsto : Filter.Tendsto (D h) atImInfty (nhds 0) :=
-    D_tendsto_zero_of_isBoundedAtImInfty hh_md (hh_tendsto.isBigO_one ℝ)
-  have hDh_div_h : Filter.Tendsto (fun z => D h z / h z) atImInfty (nhds 0) := by
-    simpa using hDh_tendsto.div hh_tendsto (by norm_num : (16 : ℂ) ≠ 0)
-  have h_H₂_eq : H₂ = f * h := by
-    ext w; simp only [h, Pi.mul_apply, mul_div_cancel₀ _ (hf_ne w)]
-  have h_logderiv_eq : ∀ᶠ z : ℍ in atImInfty, D H₂ z / H₂ z = D f z / f z + D h z / h z := by
-    have h_ne_zero : ∀ᶠ z : ℍ in atImInfty, h z ≠ 0 :=
-      hh_tendsto.eventually_ne (by norm_num : (16 : ℂ) ≠ 0)
-    filter_upwards [h_ne_zero] with z hz
-    rw [h_H₂_eq]; exact logderiv_mul_eq f h hf_md hh_md z (hf_ne z) hz
-  have h_sum : Filter.Tendsto (fun z => D f z / f z + D h z / h z) atImInfty
-      (nhds ((1 : ℂ) / 2)) := by
-    have hf_const : Filter.Tendsto (fun z => D f z / f z) atImInfty (nhds ((1 : ℂ) / 2)) := by
-      have hf_eq : ∀ z : ℍ, D f z / f z = 1 / 2 := D_exp_pi_div_exp_pi
-      simp_rw [hf_eq]; exact tendsto_const_nhds
-    simpa using hf_const.add hDh_div_h
-  exact h_sum.congr' (by filter_upwards [h_logderiv_eq] with z hz; exact hz.symm)
-
-private theorem D_H₂_tendsto_zero :
-    Filter.Tendsto (D H₂) atImInfty (nhds 0) :=
-  D_tendsto_zero_of_isBoundedAtImInfty H₂_SIF_MDifferentiable isBoundedAtImInfty_H₂
-
-private theorem D_H₄_tendsto_zero :
-    Filter.Tendsto (D H₄) atImInfty (nhds 0) :=
-  D_tendsto_zero_of_isBoundedAtImInfty H₄_SIF_MDifferentiable isBoundedAtImInfty_H₄
-
-/-- `D(2H₂² + 5H₂H₄ + 5H₄²) → 0` as `im(z) → ∞`, by the Cauchy estimate. -/
-private theorem D_B_tendsto_zero :
-    Filter.Tendsto (D ((2 : ℂ) • H₂ ^ 2 + (5 : ℂ) • H₂ * H₄ + (5 : ℂ) • H₄ ^ 2))
-      atImInfty (nhds 0) := by
-  apply D_tendsto_zero_of_isBoundedAtImInfty (by fun_prop)
-  have := H₂_tendsto_atImInfty
-  have := H₄_tendsto_atImInfty
-  have h : Tendsto (fun z => 2 * H₂ z ^ 2 + 5 * H₂ z * H₄ z + 5 * H₄ z ^ 2)
-      atImInfty (nhds 5) := by tendsto_cont
-  exact (h.congr' (by filter_upwards with z; simp [Pi.add_apply, Pi.mul_apply, Pi.pow_apply,
-    Pi.smul_apply, smul_eq_mul]; ring)).isBigO_one ℝ
+  have h := logderiv_tendsto_of_div_exp_tendsto H₂_MDifferentiable (by norm_num) H₂_div_exp_tendsto
+  rwa [show (π * I) / (2 * π * I) = (1 : ℂ) / 2 from by field_simp] at h
 
 /-- `(D G)/G → 3/2` as `im(z) → ∞`. -/
 theorem D_G_div_G_tendsto :
     Filter.Tendsto (fun z : ℍ => D G z / G z) atImInfty (nhds ((3 : ℂ) / 2)) := by
-  let A := H₂ ^ 3
-  let B := (2 : ℂ) • H₂ ^ 2 + (5 : ℂ) • H₂ * H₄ + (5 : ℂ) • H₄ ^ 2
-  have hG_eq : G = A * B := G_eq
-  have hA : MDiff A := by fun_prop
-  have hB : MDiff B := by fun_prop
-  have h_DA_A : ∀ z, H₂ z ≠ 0 → D A z / A z = 3 * (D H₂ z / H₂ z) := by
-    intro z hH₂_ne
-    change D (H₂ ^ 3) z / (H₂ z ^ 3) = 3 * (D H₂ z / H₂ z)
-    rw [show D (H₂ ^ 3) z = 3 * H₂ z ^ 2 * D H₂ z from by
-      simpa [Pi.mul_apply, Pi.pow_apply] using congrFun (D_cube H₂ H₂_MDifferentiable) z]
-    field_simp [pow_ne_zero 3 hH₂_ne, pow_ne_zero 2 hH₂_ne]
-  have h_DA_A_tendsto : Filter.Tendsto (fun z => D A z / A z) atImInfty (nhds ((3 : ℂ) / 2)) := by
-    rw [show (3 : ℂ) / 2 = 3 * (1 / 2) from by norm_num]
-    apply (D_H₂_div_H₂_tendsto.const_mul 3).congr'
-    filter_upwards [H₂_eventually_ne_zero] with z hz
-    exact (h_DA_A z hz).symm
-  have h_B_tendsto : Filter.Tendsto B atImInfty (nhds 5) := by
-    have := H₂_tendsto_atImInfty
-    have := H₄_tendsto_atImInfty
-    change Tendsto (fun z => 2 * H₂ z ^ 2 + 5 * H₂ z * H₄ z + 5 * H₄ z ^ 2) atImInfty (nhds 5)
-    tendsto_cont
-  have h_DB_B_tendsto : Filter.Tendsto (fun z => D B z / B z) atImInfty (nhds 0) := by
-    have h := D_B_tendsto_zero.div h_B_tendsto (by norm_num : (5 : ℂ) ≠ 0)
-    simp only [zero_div] at h; exact h
-  have h_DG_G : ∀ z, A z ≠ 0 → B z ≠ 0 → D G z / G z = D A z / A z + D B z / B z := by
-    intro z hA_ne hB_ne
-    rw [hG_eq]
-    exact logderiv_mul_eq A B hA hB z hA_ne hB_ne
-  have hA_ne : ∀ᶠ z in atImInfty, A z ≠ 0 := by
-    filter_upwards [H₂_eventually_ne_zero] with z hz
-    exact pow_ne_zero 3 hz
-  have hB_ne : ∀ᶠ z in atImInfty, B z ≠ 0 :=
-    h_B_tendsto.eventually_ne (by norm_num : (5 : ℂ) ≠ 0)
-  rw [show (3 : ℂ) / 2 = 3 / 2 + 0 from by norm_num]
-  apply (h_DA_A_tendsto.add h_DB_B_tendsto).congr'
-  filter_upwards [hA_ne, hB_ne] with z hA hB
-  exact (h_DG_G z hA hB).symm
+  have h := logderiv_tendsto_of_div_exp_tendsto G_holo (by norm_num) G_vanishing_order
+  rwa [show (2 * π * I * (3 / 2)) / (2 * π * I) = (3 : ℂ) / 2 from by field_simp] at h
 
 /-- `L₁,₀(it)` is real for all `t > 0`. -/
 theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -879,7 +879,6 @@ theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by
   unfold L₁₀
   have hF := F_imag_axis_real
   have hG := G_imag_axis_real
-  have hGh := G_holo
   fun_prop
 
 /-- `lim_{t→∞} L₁,₀(it)/(F(it)G(it)) = 1/2`. -/

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -767,17 +767,21 @@ lemma logderiv_tendsto_of_div_exp_tendsto {F : ℍ → ℂ} (hF : MDiff F) {a C 
     simpa [hq, Function.comp] using
       DifferentiableAt_MDifferentiableAt (G := fun t : ℂ => cexp (a * t)) (z := τ) h_diff
   have hg_md : MDiff g := MDifferentiable_div hF hq_md hq_ne
+  have hg_lim : Filter.Tendsto g atImInfty (nhds C) := hlim
+  have hDg_tendsto : Filter.Tendsto (D g) atImInfty (nhds 0) :=
+    D_tendsto_zero_of_isBoundedAtImInfty hg_md (hg_lim.isBigO_one ℝ)
   have hDg_div_g : Filter.Tendsto (fun z => D g z / g z) atImInfty (nhds 0) := by
-    simpa using (D_tendsto_zero_of_isBoundedAtImInfty hg_md (hlim.isBigO_one ℝ)).div hlim hC
+    tendsto_cont
   have hF_eq : F = q * g := by ext w; simp only [hg, Pi.mul_apply, mul_div_cancel₀ _ (hq_ne w)]
   have hDq_div_q : ∀ z : ℍ, D q z / q z = a / (2 * π * I) :=
     fun z => by rw [hq]; exact D_cexp_div a z
   have h_logderiv : ∀ᶠ z : ℍ in atImInfty, D F z / F z = a / (2 * π * I) + D g z / g z := by
     filter_upwards [hlim.eventually_ne hC] with z hz
     rw [hF_eq, Pi.mul_apply, logderiv_mul_eq q g hq_md hg_md z (hq_ne z) hz, hDq_div_q z]
-  rw [show a / (2 * π * I) = a / (2 * π * I) + 0 from (add_zero _).symm]
-  refine (tendsto_const_nhds.add hDg_div_g).congr' ?_
-  filter_upwards [h_logderiv] with z hz; exact hz.symm
+  have hsum : Filter.Tendsto (fun z => a / (2 * π * I) + D g z / g z) atImInfty
+      (nhds (a / (2 * π * I))) := by
+    tendsto_cont
+  exact hsum.congr' (by filter_upwards [h_logderiv] with z hz; exact hz.symm)
 
 /-- The vanishing order of F at infinity is 2.
 Blueprint: F = 720² * q² * (1 + O(q)), so F / q² → 720² as im(z) → ∞. -/

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -726,10 +726,7 @@ theorem E₂E₄_sub_E₆_div_q_tendsto :
 private theorem Θ₂_div_exp_tendsto :
     Filter.Tendsto (fun z : ℍ => Θ₂ z / cexp (π * Complex.I * z / 4))
       atImInfty (nhds (2 : ℂ)) := by
-  convert jacobiTheta₂_half_mul_apply_tendsto_atImInfty using 1
-  ext z
-  rw [Θ₂_as_jacobiTheta₂]
-  field_simp [Complex.exp_ne_zero]
+  simpa [Θ₂_as_jacobiTheta₂] using jacobiTheta₂_half_mul_apply_tendsto_atImInfty
 
 /-- `H₂(z) / exp(πiz) → 16` as `im(z) → ∞`. -/
 private theorem H₂_div_exp_tendsto :

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -742,11 +742,11 @@ private theorem H₂_div_exp_tendsto :
 
 /-- D(exp(c*z))/exp(c*z) = c/(2πi) for any coefficient c. -/
 theorem D_cexp_div (c : ℂ) (z : ℍ) :
-    D (fun w => cexp (c * w)) z / cexp (c * z) = c / (2 * π * I) := by
+    D (fun w ↦ cexp (c * w)) z / cexp (c * z) = c / (2 * π * I) := by
   simp only [D]
-  have h_deriv : deriv ((fun w : ℍ => cexp (c * w)) ∘ ⇑ofComplex) (z : ℂ) =
+  have h_deriv : deriv ((fun w : ℍ ↦ cexp (c * w)) ∘ ⇑ofComplex) (z : ℂ) =
       c * cexp (c * z) :=
-    ((eventuallyEq_coe_comp_ofComplex z.2).fun_comp (fun w => cexp (c * w))).deriv_eq.trans
+    ((eventuallyEq_coe_comp_ofComplex z.2).fun_comp (fun w ↦ cexp (c * w))).deriv_eq.trans
       ((Complex.hasDerivAt_exp (c * (z : ℂ))).scomp (z : ℂ)
         (by simpa using (hasDerivAt_id (z : ℂ)).const_mul c)).deriv
   rw [h_deriv]; field_simp [Complex.exp_ne_zero]
@@ -755,30 +755,30 @@ theorem D_cexp_div (c : ℂ) (z : ℍ) :
 `a/(2πi)` and the bounded limit factor's log-derivative vanishes. Public so downstream files
 (e.g. #331's Θ₂ analysis) can reuse it. -/
 lemma logderiv_tendsto_of_div_exp_tendsto {F : ℍ → ℂ} (hF : MDiff F) {a C : ℂ} (hC : C ≠ 0)
-    (hlim : Filter.Tendsto (fun z : ℍ => F z / cexp (a * z)) atImInfty (nhds C)) :
-    Filter.Tendsto (fun z : ℍ => D F z / F z) atImInfty (nhds (a / (2 * π * I))) := by
-  set q : ℍ → ℂ := fun w => cexp (a * w) with hq
-  set g : ℍ → ℂ := fun w => F w / q w with hg
-  have hq_ne : ∀ w : ℍ, q w ≠ 0 := fun w => Complex.exp_ne_zero _
+    (hlim : Filter.Tendsto (fun z : ℍ ↦ F z / cexp (a * z)) atImInfty (nhds C)) :
+    Filter.Tendsto (fun z : ℍ ↦ D F z / F z) atImInfty (nhds (a / (2 * π * I))) := by
+  set q : ℍ → ℂ := fun w ↦ cexp (a * w) with hq
+  set g : ℍ → ℂ := fun w ↦ F w / q w with hg
+  have hq_ne : ∀ w : ℍ, q w ≠ 0 := fun w ↦ Complex.exp_ne_zero _
   have hq_md : MDiff q := by
     intro τ
-    have h_diff : DifferentiableAt ℂ (fun t : ℂ => cexp (a * t)) (τ : ℂ) :=
+    have h_diff : DifferentiableAt ℂ (fun t : ℂ ↦ cexp (a * t)) (τ : ℂ) :=
       (differentiableAt_id.const_mul a).cexp
     simpa [hq, Function.comp] using
-      DifferentiableAt_MDifferentiableAt (G := fun t : ℂ => cexp (a * t)) (z := τ) h_diff
+      DifferentiableAt_MDifferentiableAt (G := fun t : ℂ ↦ cexp (a * t)) (z := τ) h_diff
   have hg_md : MDiff g := MDifferentiable_div hF hq_md hq_ne
   have hg_lim : Filter.Tendsto g atImInfty (nhds C) := hlim
   have hDg_tendsto : Filter.Tendsto (D g) atImInfty (nhds 0) :=
     D_tendsto_zero_of_isBoundedAtImInfty hg_md (hg_lim.isBigO_one ℝ)
-  have hDg_div_g : Filter.Tendsto (fun z => D g z / g z) atImInfty (nhds 0) := by
+  have hDg_div_g : Filter.Tendsto (fun z ↦ D g z / g z) atImInfty (nhds 0) := by
     tendsto_cont
   have hF_eq : F = q * g := by ext w; simp only [hg, Pi.mul_apply, mul_div_cancel₀ _ (hq_ne w)]
   have hDq_div_q : ∀ z : ℍ, D q z / q z = a / (2 * π * I) :=
-    fun z => by rw [hq]; exact D_cexp_div a z
+    fun z ↦ by rw [hq]; exact D_cexp_div a z
   have h_logderiv : ∀ᶠ z : ℍ in atImInfty, D F z / F z = a / (2 * π * I) + D g z / g z := by
     filter_upwards [hlim.eventually_ne hC] with z hz
     rw [hF_eq, Pi.mul_apply, logderiv_mul_eq q g hq_md hg_md z (hq_ne z) hz, hDq_div_q z]
-  have hsum : Filter.Tendsto (fun z => a / (2 * π * I) + D g z / g z) atImInfty
+  have hsum : Filter.Tendsto (fun z ↦ a / (2 * π * I) + D g z / g z) atImInfty
       (nhds (a / (2 * π * I))) := by
     tendsto_cont
   exact hsum.congr' (by filter_upwards [h_logderiv] with z hz; exact hz.symm)

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -861,8 +861,7 @@ theorem G_vanishing_order :
   have h_poly : Filter.Tendsto (fun z : ℍ ↦ 2 * H₂ z ^ 2 + 5 * H₂ z * H₄ z + 5 * H₄ z ^ 2)
       atImInfty (nhds 5) := by
     tendsto_cont [H₂_tendsto_atImInfty, H₄_tendsto_atImInfty]
-  convert (H₂_div_exp_tendsto.pow 3).mul h_poly
-  norm_num
+  convert (H₂_div_exp_tendsto.pow 3).mul h_poly <;> norm_num
 
 private theorem D_H₂_div_H₂_tendsto :
     Filter.Tendsto (fun z : ℍ => D H₂ z / H₂ z) atImInfty (nhds ((1 : ℂ) / 2)) := by

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -867,11 +867,9 @@ theorem G_vanishing_order :
     push_cast
     field_simp [Complex.exp_ne_zero]
   simp_rw [h_eq]
-  have h_poly : Filter.Tendsto (fun z : ℍ => 2 * H₂ z ^ 2 + 5 * H₂ z * H₄ z + 5 * H₄ z ^ 2)
+  have h_poly : Filter.Tendsto (fun z : ℍ ↦ 2 * H₂ z ^ 2 + 5 * H₂ z * H₄ z + 5 * H₄ z ^ 2)
       atImInfty (nhds 5) := by
-    have := H₂_tendsto_atImInfty
-    have := H₄_tendsto_atImInfty
-    tendsto_cont
+    tendsto_cont [H₂_tendsto_atImInfty, H₄_tendsto_atImInfty]
   convert (H₂_div_exp_tendsto.pow 3).mul h_poly
   norm_num
 

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -834,8 +834,8 @@ theorem D_diff_qexp (z : ℍ) :
 The log-derivative limit, following from F having vanishing order 2. -/
 theorem D_F_div_F_tendsto :
     Filter.Tendsto (fun z : ℍ => D F z / F z) atImInfty (nhds (2 : ℂ)) := by
-  have h := logderiv_tendsto_of_div_exp_tendsto F_holo (by norm_num) F_vanishing_order
-  rwa [show (2 * π * I * 2) / (2 * π * I) = 2 by field_simp] at h
+  simpa [show (2 * π * I * 2) / (2 * π * I) = (2 : ℂ) by field_simp] using
+    logderiv_tendsto_of_div_exp_tendsto F_holo (by norm_num) F_vanishing_order
 
 /-!
 ### G-Side Asymptotic Analysis
@@ -866,14 +866,14 @@ theorem G_vanishing_order :
 
 private theorem D_H₂_div_H₂_tendsto :
     Filter.Tendsto (fun z : ℍ => D H₂ z / H₂ z) atImInfty (nhds ((1 : ℂ) / 2)) := by
-  have h := logderiv_tendsto_of_div_exp_tendsto H₂_MDifferentiable (by norm_num) H₂_div_exp_tendsto
-  rwa [show (π * I) / (2 * π * I) = (1 : ℂ) / 2 by field_simp] at h
+  simpa [show (π * I) / (2 * π * I) = (1 : ℂ) / 2 by field_simp] using
+    logderiv_tendsto_of_div_exp_tendsto H₂_MDifferentiable (by norm_num) H₂_div_exp_tendsto
 
 /-- `(D G)/G → 3/2` as `im(z) → ∞`. -/
 theorem D_G_div_G_tendsto :
     Filter.Tendsto (fun z : ℍ => D G z / G z) atImInfty (nhds ((3 : ℂ) / 2)) := by
-  have h := logderiv_tendsto_of_div_exp_tendsto G_holo (by norm_num) G_vanishing_order
-  rwa [show (2 * π * I * (3 / 2)) / (2 * π * I) = (3 : ℂ) / 2 by field_simp] at h
+  simpa [show (2 * π * I * (3 / 2)) / (2 * π * I) = (3 : ℂ) / 2 by field_simp] using
+    logderiv_tendsto_of_div_exp_tendsto G_holo (by norm_num) G_vanishing_order
 
 /-- `L₁,₀(it)` is real for all `t > 0`. -/
 theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -844,7 +844,7 @@ The log-derivative limit, following from F having vanishing order 2. -/
 theorem D_F_div_F_tendsto :
     Filter.Tendsto (fun z : ℍ => D F z / F z) atImInfty (nhds (2 : ℂ)) := by
   have h := logderiv_tendsto_of_div_exp_tendsto F_holo (by norm_num) F_vanishing_order
-  rwa [show (2 * π * I * 2) / (2 * π * I) = 2 from by field_simp] at h
+  rwa [show (2 * π * I * 2) / (2 * π * I) = 2 by field_simp] at h
 
 /-!
 ### G-Side Asymptotic Analysis
@@ -878,13 +878,13 @@ theorem G_vanishing_order :
 private theorem D_H₂_div_H₂_tendsto :
     Filter.Tendsto (fun z : ℍ => D H₂ z / H₂ z) atImInfty (nhds ((1 : ℂ) / 2)) := by
   have h := logderiv_tendsto_of_div_exp_tendsto H₂_MDifferentiable (by norm_num) H₂_div_exp_tendsto
-  rwa [show (π * I) / (2 * π * I) = (1 : ℂ) / 2 from by field_simp] at h
+  rwa [show (π * I) / (2 * π * I) = (1 : ℂ) / 2 by field_simp] at h
 
 /-- `(D G)/G → 3/2` as `im(z) → ∞`. -/
 theorem D_G_div_G_tendsto :
     Filter.Tendsto (fun z : ℍ => D G z / G z) atImInfty (nhds ((3 : ℂ) / 2)) := by
   have h := logderiv_tendsto_of_div_exp_tendsto G_holo (by norm_num) G_vanishing_order
-  rwa [show (2 * π * I * (3 / 2)) / (2 * π * I) = (3 : ℂ) / 2 from by field_simp] at h
+  rwa [show (2 * π * I * (3 / 2)) / (2 * π * I) = (3 : ℂ) / 2 by field_simp] at h
 
 /-- `L₁,₀(it)` is real for all `t > 0`. -/
 theorem L₁₀_imag_axis_real : ResToImagAxis.Real L₁₀ := by


### PR DESCRIPTION
## Summary

Three "log-derivative at infinity" limits in `FG.lean` — `D_F_div_F_tendsto`, `D_G_div_G_tendsto`, `D_H₂_div_H₂_tendsto` — each had a bespoke ~30–40-line proof rebuilding the same idea: a modular form `F` behaves like `exp(a·z) · (nonzero limit factor)` near i∞, so the log-derivative `D F / F → a/(2πi)`. With `Derivative.lean`'s `D_tendsto_zero_of_isBoundedAtImInfty` now available, the vanishing bounded-factor term is a one-call fact, so the whole pattern packages into a single keystone.

## Changes

- **Add `logderiv_tendsto_of_div_exp_tendsto`** (public): if `F z / exp(a·z) → C ≠ 0` at i∞, then `D F / F → a/(2πi)`. The exponential contributes `a/(2πi)`; the bounded limit factor's log-derivative vanishes.
- **Golf the three theorems** to a keystone call + a uniform `a/(2πi)` reduction, consuming the existing `F_vanishing_order` / `G_vanishing_order` / `H₂_div_exp_tendsto` facts directly. Statements are unchanged (`D_F_div_F_tendsto` / `D_G_div_G_tendsto` are still consumed by `L₁₀_div_FG_tendsto`).
- **Move `D_cexp_div`** above `F_vanishing_order` so the keystone can use it.
- **Delete the now-orphaned scaffolding**: `D_diff_div_q_tendsto`, `D_exp_pi_div_exp_pi`, `D_B_tendsto_zero`, `D_H₂_tendsto_zero`, `D_H₄_tendsto_zero`, `H₂_eventually_ne_zero`.
- **Second commit — golf**: the keystone's two continuity-of-limit steps (the quotient `D g / g → 0` and adding the constant exponential contribution) are discharged by `tendsto_cont`; the genuinely-pointwise algebraic part (`logderiv_mul_eq` + eventual equality) is unchanged.

Net **−140 lines** in `FG.lean`. (`D_diff_qexp` is kept though now unused — a public q-expansion-of-`D` lemma; happy to drop it if preferred.)

## Reusability

The keystone is **public**, so any file importing `FG.lean` can reuse the same proof pattern once they have a normalized exponential asymptotic.
- **#331** gets the concrete fourth site: `D_Θ₂_div_Θ₂_tendsto`. On rebase, its current bounded-factor proof should collapse to the same call, using its `Θ₂_div_exp_tendsto : Θ₂ z /  exp(πiz/4) → 2`:  `logderiv_tendsto_of_div_exp_tendsto Θ₂_MDifferentiable (by norm_num) Θ₂_div_exp_tendsto`, followed by `(πI/4)/(2πI) = 1/8`.
- The lemma also covers the `a = 0` case: if `F → C ≠ 0`, then `D F / F → 0`. So future `D H₃ / H₃` or `D H₄ / H₄` limits would be one-call consequences of `H₃_tendsto_atImInfty` / `H₄_tendsto_atImInfty` plus the existing MDiff facts, if those goals ever appear.
- Not direct targets: `EisensteinAsymptotics.lean` uses `D_tendsto_zero_of_isBoundedAtImInfty`, but its current goals are Serre-derivative/asymptotic limits rather than log-derivative quotients; the `MagicFunction` files do not have this exponential-main-term log-derivative shape.

Lower-level files such as `JacobiTheta/JacobiIdentity.lean` cannot call this helper while it lives in `FG.lean`, because `FG.lean` already imports them. If theta-product/Delta log-derivative limits are later needed there, that is the reason to move the helper, together with `D_cexp_div` / `logderiv_mul_eq`, to `Derivative.lean`.



## Test plan
- [x] `lake build` passes; `L₁₀_div_FG_tendsto` and `JacobiIdentity.lean` still compile; no new sorries.

## Note re overlap
This and the open `restoimagaxis-real-div` PR both touch `FG.lean` (different regions — the asymptotics block here vs the L₁₀/FmodG block there). Rebase on whichever of that PR / main lands first.
