### PR TITLE
golf(RamanujanIdentities): inline tendsto_cont argument

### DIFF
--- a/SpherePacking/ModularForms/RamanujanIdentities.lean
+++ b/SpherePacking/ModularForms/RamanujanIdentities.lean
@@ -118,7 +118,7 @@ theorem ramanujan_E₆' : serre_D 6 E₆.toFun = - 2⁻¹ * E₄.toFun * E₄.to
     simp at this
     convert this using 2
   have hc_val : c = -(1/2 : ℂ) := scalar_eq_of_tendsto hfun serre_DE₆_tendsto_atImInfty
-    (by have := E₄_tendsto_one_atImInfty; tendsto_cont)
+    (by tendsto_cont [E₄_tendsto_one_atImInfty])
   ext z
   simp only [hfun z, hc_val, Pi.mul_apply]
   ring_nf


### PR DESCRIPTION
## Summary

One-line style cleanup matching PR #422's `tendsto_cont` convention.

In `RamanujanIdentities.lean`, replace the older throwaway-`have` form with the inline-argument form:

```lean
-- before
(by have := E₄_tendsto_one_atImInfty; tendsto_cont)
-- after
(by tendsto_cont [E₄_tendsto_one_atImInfty])
```

`E₄_tendsto_one_atImInfty` is a *global* theorem fact, so passing it inline is the correct spelling — not the redundant-local-argument case that #384's tests warn about (those are for named local hypotheses already in context, where bare `tendsto_cont` stays right).

## Test plan
- [x] `lake build` passes.
