### PR TITLE
feat(MagicFunction): Schwartzness of the eight-dimensional integrals Iⱼ and Jⱼ via smooth cutoff

### DIFF
--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -19,6 +19,7 @@ public import SpherePacking.ForMathlib.InnerProductSpace
 public import SpherePacking.ForMathlib.InvPowSummability
 public import SpherePacking.ForMathlib.MDifferentiableFunProp
 public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
+public import SpherePacking.ForMathlib.RadialSchwartz.SmoothCutoff
 public import SpherePacking.ForMathlib.Real
 public import SpherePacking.ForMathlib.SlashActions
 public import SpherePacking.ForMathlib.SpecificLimits

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -42,7 +42,11 @@ open scoped ContDiff Topology
 
 /-- There exists a smooth transition function that is identically `0` on `(-∞, -1]` and
 identically `1` on `[0, ∞)`. This is the statement of PR #316 (Matt Cushman), obtained here from
-mathlib's `Real.smoothTransition`. -/
+mathlib's `Real.smoothTransition`.
+
+This is a standalone existence result recording the connection to PR #316; it is *not* used by
+`ofNonnegDecay`, which builds the rescaled transition `smoothTransition (1 - 2 * x / a)` directly
+(recovering this `f` when `a = -2`). -/
 theorem exists_smooth_cutoff :
     ∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x : ℝ, x ≤ -1 → f x = 0) ∧ ∀ x : ℝ, x ≥ 0 → f x = 1 :=
   ⟨fun x ↦ smoothTransition (x + 1),

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -59,7 +59,12 @@ section TransitionLemmas
 
 /- The rescaled transition function `x ↦ Real.smoothTransition (1 - 2 * x / a)` (for `a < 0`)
 vanishes on `(-∞, a/2]`, is identically `1` on `[0, ∞)` and transitions smoothly in between.
-For `a = -2` this is exactly `x ↦ Real.smoothTransition (x + 1)`, transitioning on `[-1, 0]`. -/
+For `a = -2` this is exactly `x ↦ Real.smoothTransition (x + 1)`, transitioning on `[-1, 0]`.
+
+The pointwise facts are `private`; the two substantive lemmas `contDiff_transition_smul` and
+`decay_transition_smul` — the two Schwartz conditions for the cutoff product — must be `public`,
+since `ofNonnegDecay` is `@[expose]`d (so that its `*_apply*` lemmas are provable downstream) and
+an exposed definition may not reference `private` declarations in its proof fields. -/
 
 private lemma transition_eq_zero (ha : a < 0) {x : ℝ} (hx : x ≤ a / 2) :
     smoothTransition (1 - 2 * x / a) = 0 :=
@@ -97,33 +102,29 @@ lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a))
     (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) (k n : ℕ) :
     ∃ C, ∀ x, ‖x‖ ^ k *
       ‖iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x‖ ≤ C := by
-  obtain ⟨C₁, hC₁⟩ := (isCompact_Icc (a := a / 2) (b := 1)).exists_bound_of_continuousOn
-    (((contDiff_transition_smul ha hf).continuous_iteratedFDeriv
-      (mod_cast le_top)).continuousOn)
+  -- Split `ℝ` at the endpoints `a/2` and `0` of the transition interval: the product vanishes
+  -- below `a/2`, equals `f` above `0`, and lives on the compact `[a/2, 0]` in between.
+  obtain ⟨C₁, hC₁⟩ := (isCompact_Icc (a := a / 2) (b := 0)).exists_bound_of_continuousOn
+    (((contDiff_transition_smul ha hf).continuous_iteratedFDeriv (mod_cast le_top)).continuousOn)
   obtain ⟨C₂, hC₂⟩ := hdecay k n
-  have hC₁0 : (0 : ℝ) ≤ C₁ := (norm_nonneg _).trans (hC₁ 0 ⟨by linarith, zero_le_one⟩)
-  refine ⟨max ((1 + |a|) ^ k * C₁) C₂, fun x ↦ ?_⟩
+  have hC₁0 : (0 : ℝ) ≤ C₁ := (norm_nonneg _).trans (hC₁ 0 ⟨by linarith, le_refl 0⟩)
+  refine ⟨max (|a| ^ k * C₁) C₂, fun x ↦ ?_⟩
   rcases lt_or_ge x (a / 2) with hx | hx
-  · -- On `(-∞, a/2)` the product vanishes identically, so all its derivatives vanish.
+  · -- Below `a/2` the product vanishes identically, so all its derivatives vanish.
     have h0 : iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x = 0 := by
       rw [((eventuallyEq_zero ha hx).iteratedFDeriv ℝ n).eq_of_nhds, iteratedFDeriv_fun_zero,
         Pi.zero_apply]
     rw [h0, norm_zero, mul_zero]
     exact le_max_of_le_left (mul_nonneg (by positivity) hC₁0)
-  rcases le_or_gt x 1 with hx1 | hx1
-  · -- On the compact interval `[a/2, 1]` we use continuity of the iterated derivatives.
-    refine le_max_of_le_left ?_
-    have hxa : ‖x‖ ≤ 1 + |a| := by
-      rw [Real.norm_eq_abs, abs_le]
-      exact ⟨by linarith [neg_abs_le a, abs_nonneg a], by linarith [abs_nonneg a]⟩
-    exact mul_le_mul (pow_le_pow_left₀ (norm_nonneg _) hxa _) (hC₁ x ⟨hx, hx1⟩) (norm_nonneg _)
-      (by positivity)
-  · -- On `(1, ∞)` the product agrees with `f` near `x`, so the decay hypothesis applies.
-    have heq : iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x
-        = iteratedFDeriv ℝ n f x :=
-      ((eventuallyEq_self ha (one_pos.trans hx1)).iteratedFDeriv ℝ n).eq_of_nhds
-    rw [heq]
-    exact le_max_of_le_right (hC₂ x (by linarith))
+  rcases le_or_gt x 0 with hx0 | hx0
+  · -- On the transition interval `[a/2, 0]` we use continuity of the iterated derivatives.
+    refine le_max_of_le_left (mul_le_mul (pow_le_pow_left₀ (norm_nonneg _) ?_ _)
+      (hC₁ x ⟨hx, hx0⟩) (norm_nonneg _) (by positivity))
+    rw [Real.norm_eq_abs, abs_le]
+    exact ⟨by linarith [neg_abs_le a, abs_nonneg a], by linarith [abs_nonneg a]⟩
+  · -- Above `0` the product agrees with `f` near `x`, so the decay hypothesis applies.
+    rw [((eventuallyEq_self ha hx0).iteratedFDeriv ℝ n).eq_of_nhds]
+    exact le_max_of_le_right (hC₂ x hx0.le)
 
 end TransitionLemmas
 
@@ -139,16 +140,18 @@ noncomputable def ofNonnegDecay (f : ℝ → E) (a : ℝ) (ha : a < 0)
   smooth' := contDiff_transition_smul ha hf
   decay' := decay_transition_smul ha hf hdecay
 
-theorem ofNonnegDecay_apply_of_nonneg {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
-    {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
-    {x : ℝ} (hx : 0 ≤ x) : ofNonnegDecay f a ha hf hdecay x = f x := by
-  change smoothTransition (1 - 2 * x / a) • f x = f x
-  rw [transition_eq_one ha hx, one_smul]
+variable {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
+  {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C} {x : ℝ}
 
-theorem ofNonnegDecay_apply_of_le_half {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
-    {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
-    {x : ℝ} (hx : x ≤ a / 2) : ofNonnegDecay f a ha hf hdecay x = 0 := by
-  change smoothTransition (1 - 2 * x / a) • f x = 0
-  rw [transition_eq_zero ha hx, zero_smul]
+@[simp]
+theorem ofNonnegDecay_apply :
+    ofNonnegDecay f a ha hf hdecay x = smoothTransition (1 - 2 * x / a) • f x :=
+  rfl
+
+theorem ofNonnegDecay_apply_of_nonneg (hx : 0 ≤ x) : ofNonnegDecay f a ha hf hdecay x = f x := by
+  rw [ofNonnegDecay_apply, transition_eq_one ha hx, one_smul]
+
+theorem ofNonnegDecay_apply_of_le_half (hx : x ≤ a / 2) : ofNonnegDecay f a ha hf hdecay x = 0 := by
+  rw [ofNonnegDecay_apply, transition_eq_zero ha hx, zero_smul]
 
 end SchwartzMap

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -9,8 +9,6 @@ module
 public import Mathlib.Analysis.SpecialFunctions.SmoothTransition
 public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 
-@[expose] public section
-
 /-! # Schwartz functions from smoothness and decay on a right half-line
 
 The radial components `I₁', …, I₆', J₁', …, J₆' : ℝ → ℂ` of the integrals defining Viazovska's
@@ -36,6 +34,8 @@ the original function on `[0, ∞)`.
 * `SchwartzMap.ofNonnegDecay_apply_of_nonneg`: `SchwartzMap.ofNonnegDecay` agrees with `f` on
   `[0, ∞)`.
 -/
+
+@[expose] public section
 
 open Real Set Filter
 open scoped ContDiff Topology
@@ -81,7 +81,7 @@ private lemma eventuallyEq_self (ha : a < 0) {x : ℝ} (hx : 0 < x) :
   filter_upwards [Ioi_mem_nhds hx] with y hy
   rw [transition_eq_one ha hy.le, one_smul]
 
-private lemma contDiff_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a)) :
+lemma contDiff_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a)) :
     ContDiff ℝ ∞ fun x ↦ smoothTransition (1 - 2 * x / a) • f x := by
   rw [contDiff_iff_contDiffAt]
   intro x
@@ -93,7 +93,7 @@ private lemma contDiff_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (
   · exact contDiffAt_const.congr_of_eventuallyEq
       (eventuallyEq_zero ha (hx.trans_lt (by linarith)))
 
-private lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a))
+lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a))
     (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) (k n : ℕ) :
     ∃ C, ∀ x, ‖x‖ ^ k *
       ‖iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x‖ ≤ C := by
@@ -110,7 +110,7 @@ private lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi
         Pi.zero_apply]
     rw [h0, norm_zero, mul_zero]
     exact le_max_of_le_left (mul_nonneg (by positivity) hC₁0)
-  rcases le_or_lt x 1 with hx1 | hx1
+  rcases le_or_gt x 1 with hx1 | hx1
   · -- On the compact interval `[a/2, 1]` we use continuity of the iterated derivatives.
     refine le_max_of_le_left ?_
     have hxa : ‖x‖ ≤ 1 + |a| := by
@@ -142,13 +142,13 @@ noncomputable def ofNonnegDecay (f : ℝ → E) (a : ℝ) (ha : a < 0)
 theorem ofNonnegDecay_apply_of_nonneg {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
     {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
     {x : ℝ} (hx : 0 ≤ x) : ofNonnegDecay f a ha hf hdecay x = f x := by
-  show smoothTransition (1 - 2 * x / a) • f x = f x
+  change smoothTransition (1 - 2 * x / a) • f x = f x
   rw [transition_eq_one ha hx, one_smul]
 
 theorem ofNonnegDecay_apply_of_le_half {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
     {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
     {x : ℝ} (hx : x ≤ a / 2) : ofNonnegDecay f a ha hf hdecay x = 0 := by
-  show smoothTransition (1 - 2 * x / a) • f x = 0
+  change smoothTransition (1 - 2 * x / a) • f x = 0
   rw [transition_eq_zero ha hx, zero_smul]
 
 end SchwartzMap

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 Sidharth Hariharan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sidharth Hariharan
+-/
+module
+
+
+public import Mathlib.Analysis.SpecialFunctions.SmoothTransition
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
+
+@[expose] public section
+
+/-! # Schwartz functions from smoothness and decay on a right half-line
+
+The radial components `I₁', …, I₆', J₁', …, J₆' : ℝ → ℂ` of the integrals defining Viazovska's
+magic function are only well-behaved on a right half-line: each is smooth on `(a, ∞)` for a
+suitable `a < 0` and decays rapidly (together with all derivatives) on `[0, ∞)`, but grows
+exponentially (or is a junk value) far to the left of the origin. They are therefore *not*
+Schwartz functions as stated. However, only their values on `[0, ∞)` matter, because the
+corresponding functions on `ℝ⁸` are obtained by composing with `‖·‖ ^ 2 ≥ 0`.
+
+This file provides the bridge: multiplying by a smooth transition function that vanishes on
+`(-∞, a/2]` and is identically `1` on `[0, ∞)` produces a genuine Schwartz function agreeing with
+the original function on `[0, ∞)`.
+
+## Main definitions and results
+
+* `exists_smooth_cutoff`: there is a smooth `f : ℝ → ℝ` with `f = 0` on `(-∞, -1]` and `f = 1` on
+  `[0, ∞)`. This is the statement of PR #316 (Matt Cushman); here it is obtained directly from
+  mathlib's `Real.smoothTransition`.
+* `SchwartzMap.ofNonnegDecay`: the Schwartz function obtained from `f : ℝ → E` (smooth on
+  `(a, ∞)`, `a < 0`, with Schwartz-type decay on `[0, ∞)`) by multiplying with the smooth
+  transition function `x ↦ Real.smoothTransition (1 - 2 * x / a)`, which vanishes on `(-∞, a/2]`
+  and equals `1` on `[0, ∞)`.
+* `SchwartzMap.ofNonnegDecay_apply_of_nonneg`: `SchwartzMap.ofNonnegDecay` agrees with `f` on
+  `[0, ∞)`.
+-/
+
+open Real Set Filter
+open scoped ContDiff Topology
+
+/-- There exists a smooth transition function that is identically `0` on `(-∞, -1]` and
+identically `1` on `[0, ∞)`. This is the statement of PR #316 (Matt Cushman), obtained here from
+mathlib's `Real.smoothTransition`. -/
+theorem exists_smooth_cutoff :
+    ∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x : ℝ, x ≤ -1 → f x = 0) ∧ ∀ x : ℝ, x ≥ 0 → f x = 1 :=
+  ⟨fun x ↦ smoothTransition (x + 1),
+    smoothTransition.contDiff.comp (contDiff_id.add contDiff_const),
+    fun _ hx ↦ smoothTransition.zero_of_nonpos (by linarith),
+    fun _ hx ↦ smoothTransition.one_of_one_le (by linarith)⟩
+
+namespace SchwartzMap
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {f : ℝ → E} {a : ℝ}
+
+section TransitionLemmas
+
+/- The rescaled transition function `x ↦ Real.smoothTransition (1 - 2 * x / a)` (for `a < 0`)
+vanishes on `(-∞, a/2]`, is identically `1` on `[0, ∞)` and transitions smoothly in between.
+For `a = -2` this is exactly `x ↦ Real.smoothTransition (x + 1)`, transitioning on `[-1, 0]`. -/
+
+private lemma transition_eq_zero (ha : a < 0) {x : ℝ} (hx : x ≤ a / 2) :
+    smoothTransition (1 - 2 * x / a) = 0 :=
+  smoothTransition.zero_of_nonpos <| by rw [sub_nonpos, le_div_iff_of_neg ha]; linarith
+
+private lemma transition_eq_one (ha : a < 0) {x : ℝ} (hx : 0 ≤ x) :
+    smoothTransition (1 - 2 * x / a) = 1 :=
+  smoothTransition.one_of_one_le <| by
+    have h2 : 2 * x / a ≤ 0 := div_nonpos_iff.2 (.inl ⟨by linarith, ha.le⟩)
+    linarith
+
+private lemma eventuallyEq_zero (ha : a < 0) {x : ℝ} (hx : x < a / 2) :
+    (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) =ᶠ[𝓝 x] fun _ ↦ (0 : E) := by
+  filter_upwards [Iio_mem_nhds hx] with y hy
+  rw [transition_eq_zero ha hy.le, zero_smul]
+
+private lemma eventuallyEq_self (ha : a < 0) {x : ℝ} (hx : 0 < x) :
+    (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) =ᶠ[𝓝 x] f := by
+  filter_upwards [Ioi_mem_nhds hx] with y hy
+  rw [transition_eq_one ha hy.le, one_smul]
+
+private lemma contDiff_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a)) :
+    ContDiff ℝ ∞ fun x ↦ smoothTransition (1 - 2 * x / a) • f x := by
+  rw [contDiff_iff_contDiffAt]
+  intro x
+  rcases lt_or_ge a x with hx | hx
+  · have h1 : ContDiffAt ℝ ∞ (fun x : ℝ ↦ smoothTransition (1 - 2 * x / a)) x :=
+      (smoothTransition.contDiff.comp
+        (by fun_prop : ContDiff ℝ ∞ fun x : ℝ ↦ 1 - 2 * x / a)).contDiffAt
+    exact h1.smul (hf.contDiffAt (isOpen_Ioi.mem_nhds hx))
+  · exact contDiffAt_const.congr_of_eventuallyEq
+      (eventuallyEq_zero ha (hx.trans_lt (by linarith)))
+
+private lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a))
+    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) (k n : ℕ) :
+    ∃ C, ∀ x, ‖x‖ ^ k *
+      ‖iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x‖ ≤ C := by
+  obtain ⟨C₁, hC₁⟩ := (isCompact_Icc (a := a / 2) (b := 1)).exists_bound_of_continuousOn
+    (((contDiff_transition_smul ha hf).continuous_iteratedFDeriv
+      (mod_cast le_top)).continuousOn)
+  obtain ⟨C₂, hC₂⟩ := hdecay k n
+  have hC₁0 : (0 : ℝ) ≤ C₁ := (norm_nonneg _).trans (hC₁ 0 ⟨by linarith, zero_le_one⟩)
+  refine ⟨max ((1 + |a|) ^ k * C₁) C₂, fun x ↦ ?_⟩
+  rcases lt_or_ge x (a / 2) with hx | hx
+  · -- On `(-∞, a/2)` the product vanishes identically, so all its derivatives vanish.
+    have h0 : iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x = 0 := by
+      rw [((eventuallyEq_zero ha hx).iteratedFDeriv ℝ n).eq_of_nhds, iteratedFDeriv_fun_zero,
+        Pi.zero_apply]
+    rw [h0, norm_zero, mul_zero]
+    exact le_max_of_le_left (mul_nonneg (by positivity) hC₁0)
+  rcases le_or_lt x 1 with hx1 | hx1
+  · -- On the compact interval `[a/2, 1]` we use continuity of the iterated derivatives.
+    refine le_max_of_le_left ?_
+    have hxa : ‖x‖ ≤ 1 + |a| := by
+      rw [Real.norm_eq_abs, abs_le]
+      exact ⟨by linarith [neg_abs_le a, abs_nonneg a], by linarith [abs_nonneg a]⟩
+    exact mul_le_mul (pow_le_pow_left₀ (norm_nonneg _) hxa _) (hC₁ x ⟨hx, hx1⟩) (norm_nonneg _)
+      (by positivity)
+  · -- On `(1, ∞)` the product agrees with `f` near `x`, so the decay hypothesis applies.
+    have heq : iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x
+        = iteratedFDeriv ℝ n f x :=
+      ((eventuallyEq_self ha (one_pos.trans hx1)).iteratedFDeriv ℝ n).eq_of_nhds
+    rw [heq]
+    exact le_max_of_le_right (hC₂ x (by linarith))
+
+end TransitionLemmas
+
+/-- The Schwartz function obtained from a function `f : ℝ → E` that is smooth on `(a, ∞)` for
+some `a < 0` and has Schwartz-type decay on `[0, ∞)`, by multiplying with a smooth transition
+function that vanishes on `(-∞, a/2]` and is identically `1` on `[0, ∞)`. It agrees with `f` on
+`[0, ∞)`: see `SchwartzMap.ofNonnegDecay_apply_of_nonneg`. -/
+noncomputable def ofNonnegDecay (f : ℝ → E) (a : ℝ) (ha : a < 0)
+    (hf : ContDiffOn ℝ ∞ f (Ioi a))
+    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) :
+    𝓢(ℝ, E) where
+  toFun x := smoothTransition (1 - 2 * x / a) • f x
+  smooth' := contDiff_transition_smul ha hf
+  decay' := decay_transition_smul ha hf hdecay
+
+theorem ofNonnegDecay_apply_of_nonneg {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
+    {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
+    {x : ℝ} (hx : 0 ≤ x) : ofNonnegDecay f a ha hf hdecay x = f x := by
+  show smoothTransition (1 - 2 * x / a) • f x = f x
+  rw [transition_eq_one ha hx, one_smul]
+
+theorem ofNonnegDecay_apply_of_le_half {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
+    {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C}
+    {x : ℝ} (hx : x ≤ a / 2) : ofNonnegDecay f a ha hf hdecay x = 0 := by
+  show smoothTransition (1 - 2 * x / a) • f x = 0
+  rw [transition_eq_zero ha hx, zero_smul]
+
+end SchwartzMap

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -24,9 +24,9 @@ the original function on `[0, ∞)`.
 
 ## Main definitions and results
 
-* `exists_smooth_cutoff`: there is a smooth `f : ℝ → ℝ` with `f = 0` on `(-∞, -1]` and `f = 1` on
-  `[0, ∞)`. This is the statement of PR #316 (Matt Cushman); here it is obtained directly from
-  mathlib's `Real.smoothTransition`.
+* `Real.exists_smooth_cutoff`: there is a smooth `f : ℝ → ℝ` with `f = 0` on `(-∞, -1]` and
+  `f = 1` on `[0, ∞)`. This is the statement of PR #316 (Matt Cushman); here it is obtained
+  directly from mathlib's `Real.smoothTransition`.
 * `SchwartzMap.ofNonnegDecay`: the Schwartz function obtained from `f : ℝ → E` (smooth on
   `(a, ∞)`, `a < 0`, with Schwartz-type decay on `[0, ∞)`) by multiplying with the smooth
   transition function `x ↦ Real.smoothTransition (1 - 2 * x / a)`, which vanishes on `(-∞, a/2]`
@@ -47,7 +47,7 @@ mathlib's `Real.smoothTransition`.
 This is a standalone existence result recording the connection to PR #316; it is *not* used by
 `ofNonnegDecay`, which builds the rescaled transition `smoothTransition (1 - 2 * x / a)` directly
 (recovering this `f` when `a = -2`). -/
-theorem exists_smooth_cutoff :
+theorem Real.exists_smooth_cutoff :
     ∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x : ℝ, x ≤ -1 → f x = 0) ∧ ∀ x : ℝ, x ≥ 0 → f x = 1 :=
   ⟨fun x ↦ smoothTransition (x + 1),
     smoothTransition.contDiff.comp (contDiff_id.add contDiff_const),

--- a/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/SmoothCutoff.lean
@@ -37,7 +37,7 @@ the original function on `[0, ∞)`.
 
 @[expose] public section
 
-open Real Set Filter
+open Real Set
 open scoped ContDiff Topology
 
 /-- There exists a smooth transition function that is identically `0` on `(-∞, -1]` and
@@ -48,7 +48,7 @@ This is a standalone existence result recording the connection to PR #316; it is
 `ofNonnegDecay`, which builds the rescaled transition `smoothTransition (1 - 2 * x / a)` directly
 (recovering this `f` when `a = -2`). -/
 theorem Real.exists_smooth_cutoff :
-    ∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x : ℝ, x ≤ -1 → f x = 0) ∧ ∀ x : ℝ, x ≥ 0 → f x = 1 :=
+    ∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x : ℝ, x ≤ -1 → f x = 0) ∧ ∀ x : ℝ, 0 ≤ x → f x = 1 :=
   ⟨fun x ↦ smoothTransition (x + 1),
     smoothTransition.contDiff.comp (contDiff_id.add contDiff_const),
     fun _ hx ↦ smoothTransition.zero_of_nonpos (by linarith),
@@ -103,7 +103,7 @@ lemma contDiff_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a)) 
       (eventuallyEq_zero ha (hx.trans_lt (by linarith)))
 
 lemma decay_transition_smul (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a))
-    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) (k n : ℕ) :
+    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x, (0 : ℝ) ≤ x → ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) (k n : ℕ) :
     ∃ C, ∀ x, ‖x‖ ^ k *
       ‖iteratedFDeriv ℝ n (fun x ↦ smoothTransition (1 - 2 * x / a) • f x) x‖ ≤ C := by
   -- Split `ℝ` at the endpoints `a/2` and `0` of the transition interval: the product vanishes
@@ -138,14 +138,14 @@ function that vanishes on `(-∞, a/2]` and is identically `1` on `[0, ∞)`. It
 `[0, ∞)`: see `SchwartzMap.ofNonnegDecay_apply_of_nonneg`. -/
 noncomputable def ofNonnegDecay (f : ℝ → E) (a : ℝ) (ha : a < 0)
     (hf : ContDiffOn ℝ ∞ f (Ioi a))
-    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) :
+    (hdecay : ∀ k n : ℕ, ∃ C, ∀ x, (0 : ℝ) ≤ x → ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C) :
     𝓢(ℝ, E) where
   toFun x := smoothTransition (1 - 2 * x / a) • f x
   smooth' := contDiff_transition_smul ha hf
   decay' := decay_transition_smul ha hf hdecay
 
 variable {ha : a < 0} {hf : ContDiffOn ℝ ∞ f (Ioi a)}
-  {hdecay : ∀ k n : ℕ, ∃ C, ∀ x ≥ (0 : ℝ), ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C} {x : ℝ}
+  {hdecay : ∀ k n : ℕ, ∃ C, ∀ x, (0 : ℝ) ≤ x → ‖x‖ ^ k * ‖iteratedFDeriv ℝ n f x‖ ≤ C} {x : ℝ}
 
 @[simp]
 theorem ofNonnegDecay_apply :

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -101,27 +101,27 @@ restricted to `[0, ∞)`: they are *false* on all of `ℝ`, since the `Iⱼ'` gr
 and the higher-order bounds from the same estimates after differentiating under the integral sign.
 -/
 
-theorem I₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₁' x‖ ≤ C := by
   sorry
 
-theorem I₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₂' x‖ ≤ C := by
   sorry
 
-theorem I₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₃' x‖ ≤ C := by
   sorry
 
-theorem I₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₄' x‖ ≤ C := by
   sorry
 
-theorem I₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₅' x‖ ≤ C := by
   sorry
 
-theorem I₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem I₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₆' x‖ ≤ C := by
   sorry
 

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -212,7 +212,6 @@ end MagicFunction.a.SchwartzIntegrals
 namespace MagicFunction.FourierEigenfunctions
 
 /-- The radial component of the +1-Fourier Eigenfunction of Viazovska's Magic Function. -/
-@[simps!]
 def a' : 𝓢(ℝ, ℂ) :=
     MagicFunction.a.SchwartzIntegrals.I₁'
   + MagicFunction.a.SchwartzIntegrals.I₂'
@@ -222,7 +221,6 @@ def a' : 𝓢(ℝ, ℂ) :=
   + MagicFunction.a.SchwartzIntegrals.I₆'
 
 /-- The +1-Fourier Eigenfunction of Viazovska's Magic Function. -/
-@[simps!]
 def a : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) := schwartzMap_multidimensional_of_schwartzMap_real
   (EuclideanSpace ℝ (Fin 8)) a'
 

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -21,9 +21,8 @@ converge for `x > -2`). Only their restrictions to `[0, ∞)` matter, since the 
 functions on `ℝ⁸` are obtained by composing with `‖·‖ ^ 2 ≥ 0`. We therefore multiply each
 `Iⱼ'` by a smooth transition function that vanishes on `(-∞, -1]` and is identically `1` on
 `[0, ∞)` (via `SchwartzMap.ofNonnegDecay` with `a = -2`): the products are Schwartz functions
-which agree with
-the `Iⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to Schwartz functions
-on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.I₁, …, I₆`.
+which agree with the `Iⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to
+Schwartz functions on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.I₁, …, I₆`.
 -/
 
 @[expose] public section
@@ -97,9 +96,9 @@ section Decay
 
 We follow the proof of Proposition 7.8 in the blueprint. Note that the decay statements are
 restricted to `[0, ∞)`: they are *false* on all of `ℝ`, since the `Iⱼ'` grow exponentially as
-`x → -∞`. The zeroth-order bounds (the case `k = n = 0`) are provided (up to integration of the
-bounding function) by `MagicFunction.a.IntegralEstimates.Iⱼ.Iⱼ'_bounding`; the higher-order
-bounds are obtained by the same estimates after differentiating under the integral sign.
+`x → -∞`. The zeroth-order bounds (the case `k = n = 0`) should follow from the already-proven
+`MagicFunction.a.IntegralEstimates.Iⱼ.Iⱼ'_bounding` (after integrating the bounding function),
+and the higher-order bounds from the same estimates after differentiating under the integral sign.
 -/
 
 theorem I₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -8,9 +8,8 @@ M4R File
 module
 
 
--- import Mathlib
-
 public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
+public import SpherePacking.ForMathlib.RadialSchwartz.SmoothCutoff
 public import SpherePacking.MagicFunction.a.Basic
 
 @[expose] public section
@@ -19,12 +18,16 @@ public import SpherePacking.MagicFunction.a.Basic
 
 The purpose of this file is to prove that `a` is a Schwartz function. It collects results stated
 elsewhere and presents them concisely.
+
+The one-dimensional integrals `RealIntegrals.I₁', …, I₆' : ℝ → ℂ` are *not* Schwartz functions:
+they grow exponentially as `x → -∞` (and the defining integral of `I₆' x` is only known to
+converge for `x > -2`). Only their restrictions to `[0, ∞)` matter, since the corresponding
+functions on `ℝ⁸` are obtained by composing with `‖·‖ ^ 2 ≥ 0`. We therefore multiply each `Iⱼ'` by a smooth
+transition function that vanishes on `(-∞, -1]` and is identically `1` on `[0, ∞)` (via
+`SchwartzMap.ofNonnegDecay` with `a = -2`): the products are Schwartz functions which agree with
+the `Iⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to Schwartz functions
+on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.I₁, …, I₆`.
 -/
-
--- NOTE: We are not ready for the contents of this file. We first need to fix
--- the dimension bridge for Schwartz functions.
-
--- #exit
 
 open MagicFunction MagicFunction.a MagicFunction.a.RadialFunctions MagicFunction.a.RealIntegrals
   MagicFunction.Parametrisations MagicFunction.a.ComplexIntegrands MagicFunction.a.RealIntegrands
@@ -37,13 +40,19 @@ namespace MagicFunction.a.SchwartzProperties
 
 section Smooth
 
-/-! # `a` is smooth.
+/-! # Smoothness of the `Iⱼ'`
 
 There is no reference for this in the blueprint. The idea is to use integrability to differentiate
 inside the integrals. The proof path I have in mind is the following.
 
 We need to use the Leibniz Integral Rule to differentiate under the integral sign. This is stated as
 `hasDerivAt_integral_of_dominated_loc_of_deriv_le` in `Mathlib.Analysis.Calculus.ParametricIntegral`
+
+The integrals `I₁', …, I₅'` are over the compact interval `[0, 1]`, so they are smooth on all of
+`ℝ`. The integral `I₆'` is over `[1, ∞)` and, by the bound
+`MagicFunction.PolyFourierCoeffBound.norm_φ₀_le`, its integrand is of size `e^{-(2 + x) π t}`;
+convergence — and hence smoothness of `I₆'` — is therefore only guaranteed on `(-2, ∞)`, which
+is all that is needed here.
 -/
 
 theorem I₁'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₁' := by
@@ -75,40 +84,47 @@ theorem I₄'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₄' := by
 theorem I₅'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₅' := by
   sorry
 
-theorem I₆'_smooth' : ContDiff ℝ ∞ RealIntegrals.I₆' := by
+/-- `I₆'` is smooth on `(-2, ∞)`. Unlike `I₁', …, I₅'`, the defining integral of `I₆'` is over
+the unbounded interval `[1, ∞)`, and the bound `MagicFunction.PolyFourierCoeffBound.norm_φ₀_le`
+only controls its integrand, of size `e^{-(2 + x) π t}`, for `x > -2`. -/
+theorem I₆'_smoothOn : ContDiffOn ℝ ∞ RealIntegrals.I₆' (Ioi (-2)) := by
   sorry
 
 end Smooth
 
 section Decay
 
-/-! # `a` decays faster than any inverse power of the norm squared.
+/-! # The `Iⱼ'` decay rapidly on `[0, ∞)`.
 
-We follow the proof of Proposition 7.8 in the blueprint.
+We follow the proof of Proposition 7.8 in the blueprint. Note that the decay statements are
+restricted to `[0, ∞)`: they are *false* on all of `ℝ`, since the `Iⱼ'` grow exponentially as
+`x → -∞`. The zeroth-order bounds (the case `k = n = 0`) are provided (up to integration of the
+bounding function) by `MagicFunction.a.IntegralEstimates.Iⱼ.Iⱼ'_bounding`; the higher-order
+bounds are obtained by the same estimates after differentiating under the integral sign.
 -/
 
-theorem I₁'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem I₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₁' x‖ ≤ C := by
   sorry
 
-theorem I₂'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem I₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₂' x‖ ≤ C := by
   sorry
 
-theorem I₃'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem I₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₃' x‖ ≤ C := by
   sorry
 
-theorem I₄'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n I₄' x‖ ≤ C := by
+theorem I₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₄' x‖ ≤ C := by
   sorry
 
-theorem I₅'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n I₅' x‖ ≤ C := by
+theorem I₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₅' x‖ ≤ C := by
   sorry
 
-theorem I₆'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n I₆' x‖ ≤ C := by
+theorem I₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.I₆' x‖ ≤ C := by
   sorry
 
 end Decay
@@ -119,35 +135,46 @@ noncomputable section SchwartzMap
 
 namespace MagicFunction.a.SchwartzIntegrals
 
-def I₁' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₁'
-  smooth' := MagicFunction.a.SchwartzProperties.I₁'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₁'_decay'
+/-! Each `SchwartzIntegrals.Iⱼ'` is the Schwartz function obtained from `RealIntegrals.Iⱼ'` by
+multiplying with the smooth transition function `x ↦ Real.smoothTransition (x + 1)`, which
+vanishes on `(-∞, -1]` and is identically `1` on `[0, ∞)`. In particular `SchwartzIntegrals.Iⱼ'`
+agrees with `RealIntegrals.Iⱼ'` on `[0, ∞)` (see `Iⱼ'_apply_of_nonneg`). -/
 
-def I₂' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₂'
-  smooth' := MagicFunction.a.SchwartzProperties.I₂'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₂'_decay'
+def I₁' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₁' (-2) (by norm_num)
+  SchwartzProperties.I₁'_smooth'.contDiffOn SchwartzProperties.I₁'_decay_nonneg
 
-def I₃' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₃'
-  smooth' := MagicFunction.a.SchwartzProperties.I₃'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₃'_decay'
+def I₂' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₂' (-2) (by norm_num)
+  SchwartzProperties.I₂'_smooth'.contDiffOn SchwartzProperties.I₂'_decay_nonneg
 
-def I₄' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₄'
-  smooth' := MagicFunction.a.SchwartzProperties.I₄'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₄'_decay'
+def I₃' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₃' (-2) (by norm_num)
+  SchwartzProperties.I₃'_smooth'.contDiffOn SchwartzProperties.I₃'_decay_nonneg
 
-def I₅' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₅'
-  smooth' := MagicFunction.a.SchwartzProperties.I₅'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₅'_decay'
+def I₄' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₄' (-2) (by norm_num)
+  SchwartzProperties.I₄'_smooth'.contDiffOn SchwartzProperties.I₄'_decay_nonneg
 
-def I₆' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.a.RealIntegrals.I₆'
-  smooth' := MagicFunction.a.SchwartzProperties.I₆'_smooth'
-  decay' := MagicFunction.a.SchwartzProperties.I₆'_decay'
+def I₅' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₅' (-2) (by norm_num)
+  SchwartzProperties.I₅'_smooth'.contDiffOn SchwartzProperties.I₅'_decay_nonneg
+
+def I₆' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.I₆' (-2) (by norm_num)
+  SchwartzProperties.I₆'_smoothOn SchwartzProperties.I₆'_decay_nonneg
+
+lemma I₁'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₁' x = RealIntegrals.I₁' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma I₂'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₂' x = RealIntegrals.I₂' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma I₃'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₃' x = RealIntegrals.I₃' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma I₄'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₄' x = RealIntegrals.I₄' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma I₅'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₅' x = RealIntegrals.I₅' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma I₆'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : I₆' x = RealIntegrals.I₆' x :=
+  ofNonnegDecay_apply_of_nonneg hx
 
 def I₁ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
   schwartzMap_multidimensional_of_schwartzMap_real (EuclideanSpace ℝ (Fin 8)) I₁'
@@ -166,6 +193,21 @@ def I₅ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
 
 def I₆ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
   schwartzMap_multidimensional_of_schwartzMap_real (EuclideanSpace ℝ (Fin 8)) I₆'
+
+/-! Since `‖x‖ ^ 2 ≥ 0`, the eight-dimensional Schwartz functions `Iⱼ` are *equal* to the radial
+functions `RadialFunctions.Iⱼ`: this is the Schwartzness of the eight-dimensional integrals. -/
+
+theorem I₁_coe : ⇑I₁ = RadialFunctions.I₁ := funext fun _ ↦ I₁'_apply_of_nonneg (sq_nonneg _)
+
+theorem I₂_coe : ⇑I₂ = RadialFunctions.I₂ := funext fun _ ↦ I₂'_apply_of_nonneg (sq_nonneg _)
+
+theorem I₃_coe : ⇑I₃ = RadialFunctions.I₃ := funext fun _ ↦ I₃'_apply_of_nonneg (sq_nonneg _)
+
+theorem I₄_coe : ⇑I₄ = RadialFunctions.I₄ := funext fun _ ↦ I₄'_apply_of_nonneg (sq_nonneg _)
+
+theorem I₅_coe : ⇑I₅ = RadialFunctions.I₅ := funext fun _ ↦ I₅'_apply_of_nonneg (sq_nonneg _)
+
+theorem I₆_coe : ⇑I₆ = RadialFunctions.I₆ := funext fun _ ↦ I₆'_apply_of_nonneg (sq_nonneg _)
 
 end MagicFunction.a.SchwartzIntegrals
 
@@ -186,14 +228,6 @@ def a' : 𝓢(ℝ, ℂ) :=
 def a : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) := schwartzMap_multidimensional_of_schwartzMap_real
   (EuclideanSpace ℝ (Fin 8)) a'
 
-theorem a_eq_sum_integrals_RadialFunctions : a =
-    MagicFunction.a.RadialFunctions.I₁
-  + MagicFunction.a.RadialFunctions.I₂
-  + MagicFunction.a.RadialFunctions.I₃
-  + MagicFunction.a.RadialFunctions.I₄
-  + MagicFunction.a.RadialFunctions.I₅
-  + MagicFunction.a.RadialFunctions.I₆ := rfl
-
 theorem a_eq_sum_integrals_SchwartzIntegrals : a =
     MagicFunction.a.SchwartzIntegrals.I₁
   + MagicFunction.a.SchwartzIntegrals.I₂
@@ -202,13 +236,26 @@ theorem a_eq_sum_integrals_SchwartzIntegrals : a =
   + MagicFunction.a.SchwartzIntegrals.I₅
   + MagicFunction.a.SchwartzIntegrals.I₆ := rfl
 
-theorem a'_eq_sum_RealIntegrals : a' =
-    MagicFunction.a.RealIntegrals.I₁'
-  + MagicFunction.a.RealIntegrals.I₂'
-  + MagicFunction.a.RealIntegrals.I₃'
-  + MagicFunction.a.RealIntegrals.I₄'
-  + MagicFunction.a.RealIntegrals.I₅'
-  + MagicFunction.a.RealIntegrals.I₆' := rfl
+theorem a'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : a' x = RealIntegrals.a' x := by
+  simp only [a', SchwartzMap.add_apply, SchwartzIntegrals.I₁'_apply_of_nonneg hx,
+    SchwartzIntegrals.I₂'_apply_of_nonneg hx, SchwartzIntegrals.I₃'_apply_of_nonneg hx,
+    SchwartzIntegrals.I₄'_apply_of_nonneg hx, SchwartzIntegrals.I₅'_apply_of_nonneg hx,
+    SchwartzIntegrals.I₆'_apply_of_nonneg hx]
+  rfl
+
+/-- The Schwartz function `a` is equal to the radial function
+`MagicFunction.a.RadialFunctions.a`: this is the Schwartzness of `a`. -/
+theorem a_coe : ⇑a = MagicFunction.a.RadialFunctions.a :=
+  funext fun _ ↦ a'_apply_of_nonneg (sq_nonneg _)
+
+theorem a_eq_sum_integrals_RadialFunctions : a =
+    MagicFunction.a.RadialFunctions.I₁
+  + MagicFunction.a.RadialFunctions.I₂
+  + MagicFunction.a.RadialFunctions.I₃
+  + MagicFunction.a.RadialFunctions.I₄
+  + MagicFunction.a.RadialFunctions.I₅
+  + MagicFunction.a.RadialFunctions.I₆ := by
+  rw [a_coe]; rfl
 
 end MagicFunction.FourierEigenfunctions
 

--- a/SpherePacking/MagicFunction/a/Schwartz.lean
+++ b/SpherePacking/MagicFunction/a/Schwartz.lean
@@ -2,8 +2,6 @@
 Copyright (c) 2025 Sidharth Hariharan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sidharth Hariharan
-
-M4R File
 -/
 module
 
@@ -11,8 +9,6 @@ module
 public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
 public import SpherePacking.ForMathlib.RadialSchwartz.SmoothCutoff
 public import SpherePacking.MagicFunction.a.Basic
-
-@[expose] public section
 
 /-! # `a` is a Schwartz Function
 
@@ -22,12 +18,15 @@ elsewhere and presents them concisely.
 The one-dimensional integrals `RealIntegrals.I₁', …, I₆' : ℝ → ℂ` are *not* Schwartz functions:
 they grow exponentially as `x → -∞` (and the defining integral of `I₆' x` is only known to
 converge for `x > -2`). Only their restrictions to `[0, ∞)` matter, since the corresponding
-functions on `ℝ⁸` are obtained by composing with `‖·‖ ^ 2 ≥ 0`. We therefore multiply each `Iⱼ'` by a smooth
-transition function that vanishes on `(-∞, -1]` and is identically `1` on `[0, ∞)` (via
-`SchwartzMap.ofNonnegDecay` with `a = -2`): the products are Schwartz functions which agree with
+functions on `ℝ⁸` are obtained by composing with `‖·‖ ^ 2 ≥ 0`. We therefore multiply each
+`Iⱼ'` by a smooth transition function that vanishes on `(-∞, -1]` and is identically `1` on
+`[0, ∞)` (via `SchwartzMap.ofNonnegDecay` with `a = -2`): the products are Schwartz functions
+which agree with
 the `Iⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to Schwartz functions
 on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.I₁, …, I₆`.
 -/
+
+@[expose] public section
 
 open MagicFunction MagicFunction.a MagicFunction.a.RadialFunctions MagicFunction.a.RealIntegrals
   MagicFunction.Parametrisations MagicFunction.a.ComplexIntegrands MagicFunction.a.RealIntegrands

--- a/SpherePacking/MagicFunction/b/Schwartz.lean
+++ b/SpherePacking/MagicFunction/b/Schwartz.lean
@@ -85,7 +85,8 @@ section Decay
 
 We follow the proof of Proposition 7.8 in the blueprint (`prop:b-schwartz`). Note that the decay
 statements are restricted to `[0, ∞)`: they are *false* on all of `ℝ`, since the `Jⱼ'` grow
-exponentially as `x → -∞`.
+exponentially as `x → -∞`. As on the `a`-side, the zeroth-order bounds should follow from the
+analogue of the `Iⱼ'_bounding` estimates and the blueprint's `lemma:psi-bound`.
 -/
 
 theorem J₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),

--- a/SpherePacking/MagicFunction/b/Schwartz.lean
+++ b/SpherePacking/MagicFunction/b/Schwartz.lean
@@ -6,9 +6,8 @@ Authors: Sidharth Hariharan
 module
 
 
--- import Mathlib
-
 public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
+public import SpherePacking.ForMathlib.RadialSchwartz.SmoothCutoff
 public import SpherePacking.MagicFunction.b.Basic
 
 @[expose] public section
@@ -17,12 +16,18 @@ public import SpherePacking.MagicFunction.b.Basic
 
 The purpose of this file is to prove that `b` is a Schwartz function. It collects results stated
 elsewhere and presents them concisely.
+
+As with the `Iⱼ'` (see `SpherePacking.MagicFunction.a.Schwartz`), the one-dimensional integrals
+`RealIntegrals.J₁', …, J₆' : ℝ → ℂ` are *not* Schwartz functions: they grow exponentially as
+`x → -∞` (and the defining integral of `J₆' x` is only known to converge for `x > -1`, via the
+bound `‖ψS z‖ ≤ C e^{-π Im z}` of Lemma `lemma:psi-bound` in the blueprint). Only
+their restrictions to `[0, ∞)` matter, since the corresponding functions on `ℝ⁸` are obtained by
+composing with `‖·‖ ^ 2 ≥ 0`. We therefore multiply each `Jⱼ'` by a smooth transition function
+that vanishes on `(-∞, -1/2]` and is identically `1` on `[0, ∞)` (via
+`SchwartzMap.ofNonnegDecay` with `a = -1`): the products are Schwartz functions which agree with
+the `Jⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to Schwartz functions
+on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.J₁, …, J₆`.
 -/
-
--- NOTE: We are not ready for the contents of this file. We first need to fix
--- the dimension bridge for Schwartz functions.
-
--- #exit
 
 open MagicFunction MagicFunction.b MagicFunction.b.RadialFunctions MagicFunction.b.RealIntegrals
   MagicFunction.Parametrisations
@@ -35,13 +40,19 @@ namespace MagicFunction.b.SchwartzProperties
 
 section Smooth
 
-/-! # `b` is smooth.
+/-! # Smoothness of the `Jⱼ'`
 
 There is no reference for this in the blueprint. The idea is to use integrability to differentiate
 inside the integrals. The proof path I have in mind is the following.
 
 We need to use the Leibniz Integral Rule to differentiate under the integral sign. This is stated as
 `hasDerivAt_integral_of_dominated_loc_of_deriv_le` in `Mathlib.Analysis.Calculus.ParametricIntegral`
+
+The integrals `J₁', …, J₅'` are over the compact interval `[0, 1]`, so they are smooth on all of
+`ℝ`. The integral `J₆'` is over `[1, ∞)` and, by the bound `‖ψS z‖ ≤ C e^{-π Im z}` (Lemma
+`lemma:psi-bound` in the blueprint), its integrand is of size `e^{-(1 + x) π t}`; convergence —
+and hence smoothness of `J₆'` — is therefore only guaranteed on `(-1, ∞)`, which is all that is
+needed here.
 -/
 
 theorem J₁'_smooth' : ContDiff ℝ ∞ RealIntegrals.J₁' := by
@@ -59,40 +70,46 @@ theorem J₄'_smooth' : ContDiff ℝ ∞ RealIntegrals.J₄' := by
 theorem J₅'_smooth' : ContDiff ℝ ∞ RealIntegrals.J₅' := by
   sorry
 
-theorem J₆'_smooth' : ContDiff ℝ ∞ RealIntegrals.J₆' := by
+/-- `J₆'` is smooth on `(-1, ∞)`. Unlike `J₁', …, J₅'`, the defining integral of `J₆'` is over
+the unbounded interval `[1, ∞)`, and the bound `‖ψS z‖ ≤ C e^{-π Im z}` (Lemma
+`lemma:psi-bound` in the blueprint) only controls its integrand, of size `e^{-(1 + x) π t}`, for
+`x > -1`. -/
+theorem J₆'_smoothOn : ContDiffOn ℝ ∞ RealIntegrals.J₆' (Ioi (-1)) := by
   sorry
 
 end Smooth
 
 section Decay
 
-/-! # `b` decays faster than any inverse power of the norm squared.
+/-! # The `Jⱼ'` decay rapidly on `[0, ∞)`.
 
-We follow the proof of Proposition 7.8 in the blueprint.
+We follow the proof of Proposition 7.8 in the blueprint (`prop:b-schwartz`). Note that the decay
+statements are restricted to `[0, ∞)`: they are *false* on all of `ℝ`, since the `Jⱼ'` grow
+exponentially as `x → -∞`.
 -/
 
-theorem J₁'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem J₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₁' x‖ ≤ C := by
   sorry
 
-theorem J₂'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem J₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₂' x‖ ≤ C := by
   sorry
 
-theorem J₃'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
+theorem J₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₃' x‖ ≤ C := by
   sorry
 
-theorem J₄'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n J₄' x‖ ≤ C := by
+theorem J₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₄' x‖ ≤ C := by
   sorry
 
-theorem J₅'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n J₅' x‖ ≤ C := by
+theorem J₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₅' x‖ ≤ C := by
   sorry
 
-theorem J₆'_decay' : ∀ (k n : ℕ), ∃ C, ∀ (x : ℝ),
-    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n J₆' x‖ ≤ C := by
+theorem J₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+    ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₆' x‖ ≤ C := by
   sorry
 
 end Decay
@@ -103,35 +120,47 @@ noncomputable section SchwartzMap
 
 namespace MagicFunction.b.SchwartzIntegrals
 
-def J₁' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₁'
-  smooth' := MagicFunction.b.SchwartzProperties.J₁'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₁'_decay'
+/-! Each `SchwartzIntegrals.Jⱼ'` is the Schwartz function obtained from `RealIntegrals.Jⱼ'` by
+multiplying with the smooth transition function `x ↦ Real.smoothTransition (2 * x + 1)`, which
+vanishes on `(-∞, -1/2]` and is identically `1` on `[0, ∞)`. In particular
+`SchwartzIntegrals.Jⱼ'` agrees with `RealIntegrals.Jⱼ'` on `[0, ∞)` (see
+`Jⱼ'_apply_of_nonneg`). -/
 
-def J₂' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₂'
-  smooth' := MagicFunction.b.SchwartzProperties.J₂'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₂'_decay'
+def J₁' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₁' (-1) (by norm_num)
+  SchwartzProperties.J₁'_smooth'.contDiffOn SchwartzProperties.J₁'_decay_nonneg
 
-def J₃' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₃'
-  smooth' := MagicFunction.b.SchwartzProperties.J₃'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₃'_decay'
+def J₂' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₂' (-1) (by norm_num)
+  SchwartzProperties.J₂'_smooth'.contDiffOn SchwartzProperties.J₂'_decay_nonneg
 
-def J₄' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₄'
-  smooth' := MagicFunction.b.SchwartzProperties.J₄'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₄'_decay'
+def J₃' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₃' (-1) (by norm_num)
+  SchwartzProperties.J₃'_smooth'.contDiffOn SchwartzProperties.J₃'_decay_nonneg
 
-def J₅' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₅'
-  smooth' := MagicFunction.b.SchwartzProperties.J₅'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₅'_decay'
+def J₄' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₄' (-1) (by norm_num)
+  SchwartzProperties.J₄'_smooth'.contDiffOn SchwartzProperties.J₄'_decay_nonneg
 
-def J₆' : 𝓢(ℝ, ℂ) where
-  toFun := MagicFunction.b.RealIntegrals.J₆'
-  smooth' := MagicFunction.b.SchwartzProperties.J₆'_smooth'
-  decay' := MagicFunction.b.SchwartzProperties.J₆'_decay'
+def J₅' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₅' (-1) (by norm_num)
+  SchwartzProperties.J₅'_smooth'.contDiffOn SchwartzProperties.J₅'_decay_nonneg
+
+def J₆' : 𝓢(ℝ, ℂ) := .ofNonnegDecay RealIntegrals.J₆' (-1) (by norm_num)
+  SchwartzProperties.J₆'_smoothOn SchwartzProperties.J₆'_decay_nonneg
+
+lemma J₁'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₁' x = RealIntegrals.J₁' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma J₂'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₂' x = RealIntegrals.J₂' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma J₃'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₃' x = RealIntegrals.J₃' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma J₄'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₄' x = RealIntegrals.J₄' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma J₅'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₅' x = RealIntegrals.J₅' x :=
+  ofNonnegDecay_apply_of_nonneg hx
+
+lemma J₆'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : J₆' x = RealIntegrals.J₆' x :=
+  ofNonnegDecay_apply_of_nonneg hx
 
 def J₁ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
   schwartzMap_multidimensional_of_schwartzMap_real (EuclideanSpace ℝ (Fin 8)) J₁'
@@ -150,6 +179,21 @@ def J₅ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
 
 def J₆ : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) :=
   schwartzMap_multidimensional_of_schwartzMap_real (EuclideanSpace ℝ (Fin 8)) J₆'
+
+/-! Since `‖x‖ ^ 2 ≥ 0`, the eight-dimensional Schwartz functions `Jⱼ` are *equal* to the radial
+functions `RadialFunctions.Jⱼ`: this is the Schwartzness of the eight-dimensional integrals. -/
+
+theorem J₁_coe : ⇑J₁ = RadialFunctions.J₁ := funext fun _ ↦ J₁'_apply_of_nonneg (sq_nonneg _)
+
+theorem J₂_coe : ⇑J₂ = RadialFunctions.J₂ := funext fun _ ↦ J₂'_apply_of_nonneg (sq_nonneg _)
+
+theorem J₃_coe : ⇑J₃ = RadialFunctions.J₃ := funext fun _ ↦ J₃'_apply_of_nonneg (sq_nonneg _)
+
+theorem J₄_coe : ⇑J₄ = RadialFunctions.J₄ := funext fun _ ↦ J₄'_apply_of_nonneg (sq_nonneg _)
+
+theorem J₅_coe : ⇑J₅ = RadialFunctions.J₅ := funext fun _ ↦ J₅'_apply_of_nonneg (sq_nonneg _)
+
+theorem J₆_coe : ⇑J₆ = RadialFunctions.J₆ := funext fun _ ↦ J₆'_apply_of_nonneg (sq_nonneg _)
 
 end MagicFunction.b.SchwartzIntegrals
 
@@ -170,14 +214,6 @@ def b' : 𝓢(ℝ, ℂ) :=
 def b : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) := schwartzMap_multidimensional_of_schwartzMap_real
   (EuclideanSpace ℝ (Fin 8)) b'
 
-theorem b_eq_sum_integrals_RadialFunctions : b =
-    MagicFunction.b.RadialFunctions.J₁
-  + MagicFunction.b.RadialFunctions.J₂
-  + MagicFunction.b.RadialFunctions.J₃
-  + MagicFunction.b.RadialFunctions.J₄
-  + MagicFunction.b.RadialFunctions.J₅
-  + MagicFunction.b.RadialFunctions.J₆ := rfl
-
 theorem b_eq_sum_integrals_SchwartzIntegrals : b =
     MagicFunction.b.SchwartzIntegrals.J₁
   + MagicFunction.b.SchwartzIntegrals.J₂
@@ -186,13 +222,26 @@ theorem b_eq_sum_integrals_SchwartzIntegrals : b =
   + MagicFunction.b.SchwartzIntegrals.J₅
   + MagicFunction.b.SchwartzIntegrals.J₆ := rfl
 
-theorem b'_eq_sum_RealIntegrals : b' =
-    MagicFunction.b.RealIntegrals.J₁'
-  + MagicFunction.b.RealIntegrals.J₂'
-  + MagicFunction.b.RealIntegrals.J₃'
-  + MagicFunction.b.RealIntegrals.J₄'
-  + MagicFunction.b.RealIntegrals.J₅'
-  + MagicFunction.b.RealIntegrals.J₆' := rfl
+theorem b'_apply_of_nonneg {x : ℝ} (hx : 0 ≤ x) : b' x = RealIntegrals.b' x := by
+  simp only [b', SchwartzMap.add_apply, SchwartzIntegrals.J₁'_apply_of_nonneg hx,
+    SchwartzIntegrals.J₂'_apply_of_nonneg hx, SchwartzIntegrals.J₃'_apply_of_nonneg hx,
+    SchwartzIntegrals.J₄'_apply_of_nonneg hx, SchwartzIntegrals.J₅'_apply_of_nonneg hx,
+    SchwartzIntegrals.J₆'_apply_of_nonneg hx]
+  rfl
+
+/-- The Schwartz function `b` is equal to the radial function
+`MagicFunction.b.RadialFunctions.b`: this is the Schwartzness of `b`. -/
+theorem b_coe : ⇑b = MagicFunction.b.RadialFunctions.b :=
+  funext fun _ ↦ b'_apply_of_nonneg (sq_nonneg _)
+
+theorem b_eq_sum_integrals_RadialFunctions : b =
+    MagicFunction.b.RadialFunctions.J₁
+  + MagicFunction.b.RadialFunctions.J₂
+  + MagicFunction.b.RadialFunctions.J₃
+  + MagicFunction.b.RadialFunctions.J₄
+  + MagicFunction.b.RadialFunctions.J₅
+  + MagicFunction.b.RadialFunctions.J₆ := by
+  rw [b_coe]; rfl
 
 end MagicFunction.FourierEigenfunctions
 

--- a/SpherePacking/MagicFunction/b/Schwartz.lean
+++ b/SpherePacking/MagicFunction/b/Schwartz.lean
@@ -89,27 +89,27 @@ exponentially as `x → -∞`. As on the `a`-side, the zeroth-order bounds shoul
 analogue of the `Iⱼ'_bounding` estimates and the blueprint's `lemma:psi-bound`.
 -/
 
-theorem J₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₁'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₁' x‖ ≤ C := by
   sorry
 
-theorem J₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₂'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₂' x‖ ≤ C := by
   sorry
 
-theorem J₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₃'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₃' x‖ ≤ C := by
   sorry
 
-theorem J₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₄'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₄' x‖ ≤ C := by
   sorry
 
-theorem J₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₅'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₅' x‖ ≤ C := by
   sorry
 
-theorem J₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x ≥ (0 : ℝ),
+theorem J₆'_decay_nonneg : ∀ (k n : ℕ), ∃ C, ∀ x, (0 : ℝ) ≤ x →
     ‖x‖ ^ k * ‖iteratedFDeriv ℝ n RealIntegrals.J₆' x‖ ≤ C := by
   sorry
 

--- a/SpherePacking/MagicFunction/b/Schwartz.lean
+++ b/SpherePacking/MagicFunction/b/Schwartz.lean
@@ -10,8 +10,6 @@ public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
 public import SpherePacking.ForMathlib.RadialSchwartz.SmoothCutoff
 public import SpherePacking.MagicFunction.b.Basic
 
-@[expose] public section
-
 /-! # `b` is a Schwartz Function
 
 The purpose of this file is to prove that `b` is a Schwartz function. It collects results stated
@@ -28,6 +26,8 @@ that vanishes on `(-∞, -1/2]` and is identically `1` on `[0, ∞)` (via
 the `Jⱼ'` on `[0, ∞)`, and hence give rise, via composition with `‖·‖ ^ 2`, to Schwartz functions
 on `ℝ⁸` that are *equal* to the radial functions `RadialFunctions.J₁, …, J₆`.
 -/
+
+@[expose] public section
 
 open MagicFunction MagicFunction.b MagicFunction.b.RadialFunctions MagicFunction.b.RealIntegrals
   MagicFunction.Parametrisations

--- a/SpherePacking/MagicFunction/b/Schwartz.lean
+++ b/SpherePacking/MagicFunction/b/Schwartz.lean
@@ -201,7 +201,6 @@ end MagicFunction.b.SchwartzIntegrals
 namespace MagicFunction.FourierEigenfunctions
 
 /-- The radial component of the -1-Fourier Eigenfunction of Viazovska's Magic Function. -/
-@[simps!]
 def b' : 𝓢(ℝ, ℂ) :=
     MagicFunction.b.SchwartzIntegrals.J₁'
   + MagicFunction.b.SchwartzIntegrals.J₂'
@@ -211,7 +210,6 @@ def b' : 𝓢(ℝ, ℂ) :=
   + MagicFunction.b.SchwartzIntegrals.J₆'
 
 /-- The -1-Fourier Eigenfunction of Viazovska's Magic Function. -/
-@[simps!]
 def b : 𝓢(EuclideanSpace ℝ (Fin 8), ℂ) := schwartzMap_multidimensional_of_schwartzMap_real
   (EuclideanSpace ℝ (Fin 8)) b'
 


### PR DESCRIPTION
(This is an experimental PR: I wanted to see if Claude could do this in a good way by launching and interacting with independent review agents along the way. This will be done in a much better way in #444.)

# Schwartzness of the eight-dimensional integrals `Iⱼ` and `Jⱼ`

The one-dimensional integrals `RealIntegrals.Iⱼ'`, `Jⱼ' : ℝ → ℂ` are **not** Schwartz functions as currently stated: they grow exponentially as `x → -∞`, and the sixth integrals are not even given by convergent integrals far to the left of the origin. The previous `smooth'`/`decay'` obligations in `a/Schwartz.lean` and `b/Schwartz.lean` were therefore unprovable. Since the eight-dimensional integrals are obtained by composing with `‖·‖² ≥ 0`, only the behaviour on `[0, ∞)` matters — so we multiply by a **smooth transition function** (STF) that is `1` on `[0, ∞)` and vanishes far to the left, and compose *that* with `‖·‖²`.

## What this PR does

### 1. New: `ForMathlib/RadialSchwartz/SmoothCutoff.lean` — fully proved, no sorries
* **`exists_smooth_cutoff`** : `∃ f : ℝ → ℝ, ContDiff ℝ ∞ f ∧ (∀ x ≤ -1, f x = 0) ∧ ∀ x ≥ 0, f x = 1` — this is precisely the statement of **#316** (@mattcushman), obtained here in one term from mathlib's `Real.smoothTransition`. I could not make this PR *depend* on #316 in the git sense: its base branch `schwartzness-dimensions` shares **no merge base** with current `main` (the history was rewritten; 143 files / 12k+ lines and an older toolchain apart), so the statement is included and credited instead. If #316 is rebased and merged first, this lemma can be dropped in favour of it.
* **`SchwartzMap.ofNonnegDecay (f : ℝ → E) (a : ℝ) (ha : a < 0) (hf : ContDiffOn ℝ ∞ f (Ioi a)) (hdecay : …) : 𝓢(ℝ, E)`** — the Schwartz function `x ↦ Real.smoothTransition (1 - 2x/a) • f x`, given smoothness of `f` on `(a, ∞)` and Schwartz-type decay on `[0, ∞)` only. The transition vanishes on `(-∞, a/2]` and is `1` on `[0, ∞)`. For `a = -2` the cutoff is *exactly* `smoothTransition (x + 1)`, i.e. the STF of #316 transitioning on `[-1, 0]`.
* `ofNonnegDecay_apply_of_nonneg` / `ofNonnegDecay_apply_of_le_half`: it agrees with `f` on `[0, ∞)` and vanishes below `a/2`.

`#print axioms`: all three check with `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.

### 2. `a/Schwartz.lean`: `SchwartzIntegrals.Iⱼ' := ofNonnegDecay RealIntegrals.Iⱼ' (-2) …`
* The false global decay obligations are replaced by **provable** ones, `Iⱼ'_decay_nonneg` (decay of all derivatives on `[0, ∞)`); the zeroth-order cases are supplied (up to integrating the bound) by the existing `IntegralEstimates.Iⱼ'_bounding`. The `I₃'` transfer trick of #339 also ports verbatim to these restated bounds.
* `I₆'_smooth'` (false: the integral only converges for `x > -2`, by `norm_φ₀_le`) is replaced by `I₆'_smoothOn : ContDiffOn ℝ ∞ I₆' (Ioi (-2))`. `I₁'…I₅'_smooth'` are kept unchanged (compact contours; the existing conditional proof of `I₃'_smooth'` survives untouched).
* **New main results**: `Iⱼ_coe : ⇑Iⱼ = RadialFunctions.Iⱼ` and `a_coe : ⇑a = RadialFunctions.a` — the eight-dimensional Schwartz functions are *equal* to the radial functions, because the cutoff is invisible after composing with `‖·‖² ≥ 0` (via the existing `schwartzMap_multidimensional_of_schwartzMap_real`, i.e. `SchwartzMap.compCLM` with `‖·‖²`).
* `a'_eq_sum_RealIntegrals` (false as a global function equality under any correct definition) is replaced by `a'_apply_of_nonneg`; `a_eq_sum_integrals_SchwartzIntegrals` remains `rfl`, and `a_eq_sum_integrals_RadialFunctions` keeps its statement with a two-line proof.

### 3. `b/Schwartz.lean`: same treatment for `Jⱼ`/`b`, with `a = -1`
The blueprint's bound `‖ψS z‖ ≤ C e^{-π Im z}` (`lemma:psi-bound`) only guarantees convergence of `J₆'` on `(-1, ∞)`, so a transition on `[-1, 0]` cannot work on the `b`-side; instead the cutoff transitions on `[-1/2, 0]`. This is the only asymmetry with the `a`-side, and is why `ofNonnegDecay` is parametrised by the threshold `a`.

## Status of the remaining hypotheses
The 23 remaining sorries (11 on the `a`-side, 12 on the `b`-side) are exactly the *corrected* one-dimensional smoothness/decay statements — all now believed provable (Leibniz rule + the `IntegralEstimates` bounds, blueprint Prop. 7.8 / `prop:b-schwartz`). Everything built on top of them — the Schwartz structures, the equalities with `RadialFunctions.Iⱼ/Jⱼ/a/b`, and all downstream files (`Eigenfunction`, `SpecialValues`, `g/Basic`) — is fully verified: the sorry count is unchanged, but the statements are now true and the architecture sound.

## Verification
* Full project build from source: **`lake build` succeeds (3453 jobs)**, including all downstream consumers, with no new warnings from the touched files (style linters clean).
* `#print axioms a_coe` / `b_coe`: `sorryAx` enters only through the restated hypotheses above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PgeJjuvzNGKAeHZy9gxUn

---
_Generated by [Claude Code](https://claude.ai/code/session_017PgeJjuvzNGKAeHZy9gxUn)_