### PR TITLE
refactor(Delta): replace project discriminant with mathlib's, Δ as notation

### DIFF
--- a/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
+++ b/SpherePacking/MagicFunction/PolyFourierCoeffBound.lean
@@ -109,7 +109,7 @@ lemma aux_5 (z : ℍ) : norm (∏' (n : ℕ+), (1 - cexp (2 * ↑π * I * ↑↑
   ∏' (n : ℕ+), norm (1 - cexp (2 * ↑π * I * ↑↑n * z)) ^ 24 := by
   simp only [← norm_pow]
   apply Multipliable.norm_tprod -- ℕ+ (fun n => (1 - cexp (2 * ↑π * I * n * z)) ^ 24)
-  apply MultipliableDeltaProductExpansion_pnat z
+  exact (MultipliableEtaProductExpansion_pnat z).pow 24
 
 
 lemma aux_6 (z : ℍ) : 0 ≤ ∏' (n : ℕ+), norm (1 - cexp (2 * ↑π * I * ↑↑n * z)) ^ 24 := by

--- a/SpherePacking/MagicFunction/a/Integrability/ComplexIntegrands.lean
+++ b/SpherePacking/MagicFunction/a/Integrability/ComplexIntegrands.lean
@@ -63,13 +63,14 @@ section Holo_Lemmas
 
 theorem φ₀''_holo : Holo(φ₀'') := by
   have hF := UpperHalfPlane.mdifferentiable_iff.mp F_holo
-  have hΔ := UpperHalfPlane.mdifferentiable_iff.mp Delta.holo'
+  have hΔ := UpperHalfPlane.mdifferentiable_iff.mp CuspForm.discriminant.holo'
   have h_eq :
       EqOn φ₀'' (fun z => (F ∘ UpperHalfPlane.ofComplex) z / (Δ ∘ UpperHalfPlane.ofComplex) z) ℍ₀ :=
     fun z hz => by simp [φ₀''_def hz, F, φ₀, UpperHalfPlane.ofComplex_apply_of_im_pos hz]
   refine DifferentiableOn.congr ?_ h_eq
   exact hF.div hΔ fun z hz => by
-    simp [Function.comp_apply, UpperHalfPlane.ofComplex_apply_of_im_pos hz, Δ_ne_zero]
+    simp [Function.comp_apply, UpperHalfPlane.ofComplex_apply_of_im_pos hz,
+      ModularForm.discriminant_ne_zero]
 
 theorem Φ₁'_holo : Holo(Φ₁' r) := by
   refine DifferentiableOn.mul ?_ ((Complex.differentiable_exp.comp <| (differentiable_const _).mul

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -5,17 +5,17 @@ Authors: Sphere Packing Contributors
 -/
 module
 
-public import SpherePacking.ModularForms.SlashActionAuxil
+public import Mathlib.Analysis.SpecialFunctions.Log.Summable
+public import Mathlib.NumberTheory.ModularForms.Discriminant
+public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import SpherePacking.ForMathlib.Cusps
 public import SpherePacking.ModularForms.clog_arg_lems
 public import SpherePacking.ModularForms.E2
-public import Mathlib.NumberTheory.ModularForms.Discriminant
 public import SpherePacking.ModularForms.exp_lems
-public import Mathlib.Analysis.SpecialFunctions.Log.Summable
 public import SpherePacking.ModularForms.ResToImagAxis
-public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import SpherePacking.ModularForms.SlashActionAuxil
 public import SpherePacking.Tactic.NormNumI
 
-public import SpherePacking.ForMathlib.Cusps
 
 /-! # The modular discriminant `Δ`
 
@@ -46,7 +46,9 @@ lemma MultipliableEtaProductExpansion_pnat (z : ℍ) :
   rw [multipliable_pnat_iff_multipliable_succ
     (f := fun n : ℕ ↦ 1 - cexp (2 * π * Complex.I * n * z))]
   exact (ModularForm.multipliableLocallyUniformlyOn_eta.multipliable z.2).congr fun n ↦ by
-    rw [ModularForm.eta_q_eq_cexp]; push_cast; ring_nf
+    rw [ModularForm.eta_q_eq_cexp]
+    push_cast
+    ring_nf
 
 /-- The discriminant as a `q`-product with explicit complex exponentials. -/
 lemma Δ_eq_cexp_prod (z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' n : ℕ,
@@ -82,12 +84,6 @@ theorem Δ_boundedfactor :
 
 open Real
 
-/-- The imaginary part of a natural power vanishes when the base is real. -/
-lemma Complex.im_pow_eq_zero_of_im_eq_zero {z : ℂ} (hz : z.im = 0) (m : ℕ) : (z ^ m).im = 0 := by
-  induction m with
-  | zero => simp
-  | succ m ih => simp [pow_succ, Complex.mul_im, *]
-
 /-- On the positive imaginary axis, `Δ (i t)` is the real quantity
 `e ^ (-2 π t) * ∏' (1 - e ^ (-2 π (n + 1) t)) ^ 24`. -/
 private lemma resToImagAxis_Δ_eq (t : ℝ) (ht : 0 < t) :
@@ -111,41 +107,29 @@ private lemma resToImagAxis_Δ_eq (t : ℝ) (ht : 0 < t) :
         (hg' := Complex.continuous_re) (hgg' := by intro x; simp))
   simp [ResToImagAxis, ht, Δ_eq_cexp_prod, h1, h2, hMap', fR]
 
-private lemma Δ_imag_axis_real : ResToImagAxis.Real Δ := by
-  intro t ht
-  rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_im]
-
-private lemma re_resToImagAxis_Δ_eq_real_prod (t : ℝ) (ht : 0 < t) :
-    (Function.resToImagAxis Δ t).re =
-      Real.exp (-2 * π * t) * ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := by
-  rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_re]
-
-private lemma tprod_pos_nat_im (z : ℍ) :
-    0 < ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 := by
-  have hpos_pow : ∀ n : ℕ, 0 < (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 := fun n =>
+private lemma tprod_pos (t : ℝ) (ht : 0 < t) :
+    0 < ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := by
+  have hpos_pow : ∀ n : ℕ, 0 < (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := fun n =>
     pow_pos (sub_pos.mpr (exp_lt_one_iff.mpr (neg_lt_zero.mpr (by positivity)))) _
   have hsum_log : Summable fun n : ℕ =>
-      Real.log ((1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24) := by
+      Real.log ((1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24) := by
     simp only [Real.log_pow, Nat.cast_ofNat, ← smul_eq_mul]
     apply Summable.const_smul
     simp [sub_eq_add_neg]
     apply Real.summable_log_one_add_of_summable
     apply Summable.neg
-    have h0 : Summable fun n : ℕ => Real.exp (n * (-(2 * π * z.im))) :=
+    have h0 : Summable fun n : ℕ => Real.exp (n * (-(2 * π * t))) :=
       Real.summable_exp_nat_mul_iff.mpr
-        (by simpa using neg_lt_zero.mpr (by positivity : 0 < 2 * π * z.im))
+        (by simpa using neg_lt_zero.mpr (by positivity : 0 < 2 * π * t))
     simpa [Nat.cast_add, Nat.cast_one, mul_comm, mul_left_comm, mul_assoc] using
       (summable_nat_add_iff 1).2 h0
   rw [← Real.rexp_tsum_eq_tprod
-        (f := fun n : ℕ => (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24) hpos_pow hsum_log]
+        (f := fun n : ℕ => (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24) hpos_pow hsum_log]
   exact Real.exp_pos _
 
 /-- `Δ` is real and positive on the positive imaginary axis. -/
 lemma Δ_imag_axis_pos : ResToImagAxis.Pos Δ := by
-  rw [ResToImagAxis.Pos]
-  refine And.intro Δ_imag_axis_real fun t ht => ?_
-  rw [re_resToImagAxis_Δ_eq_real_prod t ht]
-  refine mul_pos (Real.exp_pos _) ?_
-  let z : ℍ := ⟨Complex.I * t, by simp [ht]⟩
-  have hz : z.im = t := by simp [UpperHalfPlane.im, z]
-  simpa [hz] using tprod_pos_nat_im z
+  refine ⟨fun t ht => ?_, fun t ht => ?_⟩
+  · rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_im]
+  · rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_re]
+    exact mul_pos (Real.exp_pos _) (tprod_pos t ht)

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -91,14 +91,10 @@ private lemma resToImagAxis_Δ_eq (t : ℝ) (ht : 0 < t) :
       ((Real.exp (-2 * π * t) *
         ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 : ℝ) : ℂ) := by
   have h1 : cexp (2 * ↑π * Complex.I * (Complex.I * t)) = rexp (-2 * π * t) := by
-    calc
-      _ = cexp (2 * ↑π * (Complex.I * Complex.I) * t) := by ring_nf
-      _ = rexp (-2 * π * t) := by simp
+    push_cast; congr 1; linear_combination (2 * (π : ℂ) * t) * Complex.I_sq
   have h2 (n : ℕ) :
       cexp (2 * π * Complex.I * (n + 1) * (Complex.I * t)) = rexp (-(2 * π * (n + 1) * t)) := by
-    calc
-      _ = cexp (2 * ↑π * (n + 1) * (Complex.I * Complex.I) * t) := by ring_nf
-      _ = rexp (-(2 * π * (n + 1) * t)) := by simp
+    push_cast; congr 1; linear_combination (2 * (π : ℂ) * (n + 1) * t) * Complex.I_sq
   set fR : ℕ → ℝ := fun n => (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24
   have hMap' : Complex.ofReal (∏' n : ℕ, fR n) = ∏' n : ℕ, ((fR n : ℝ) : ℂ) := by
     simpa using

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2024 The Sphere Packing Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sphere Packing Contributors
+-/
 module
 
 public import SpherePacking.ModularForms.SlashActionAuxil
@@ -12,6 +17,20 @@ public import SpherePacking.Tactic.NormNumI
 
 public import SpherePacking.ForMathlib.Cusps
 
+/-! # The modular discriminant `Δ`
+
+Mathlib's `ModularForm.discriminant` provides the modular discriminant together with its
+fundamental properties: non-vanishing (`ModularForm.discriminant_ne_zero`), invariance under the
+generators of `SL(2, ℤ)`, decay at `i∞`, and the associated cusp form `CuspForm.discriminant` of
+weight `12` for `𝒮ℒ`. This file introduces the notation `Δ` for it and provides the complements
+used in this project:
+
+* `Δ_eq_cexp_prod`, `DiscriminantProductFormula`: the `q`-product for `Δ` written with explicit
+  complex exponentials, indexed by `ℕ` and `ℕ+` respectively.
+* `Δ_periodic`, `Δ_S_transform`: pointwise transformation laws under the generators.
+* `Δ_imag_axis_pos`: `Δ` is real and positive on the positive imaginary axis.
+-/
+
 @[expose] public section
 
 open ModularForm EisensteinSeries UpperHalfPlane TopologicalSpace Set MeasureTheory intervalIntegral
@@ -19,294 +38,114 @@ open ModularForm EisensteinSeries UpperHalfPlane TopologicalSpace Set MeasureThe
 
 open scoped Interval Real NNReal ENNReal Topology BigOperators Nat ModularForm
 
-open ArithmeticFunction
-
-theorem term_ne_zero (z : ℍ) (n : ℕ) : 1 - cexp (2 * ↑π * Complex.I * (↑n + 1) * ↑z) ≠ 0 := by
-  rw [sub_ne_zero]
-  intro h
-  have := exp_upperHalfPlane_lt_one_nat z n
-  rw [← h] at this
-  simp only [norm_one, lt_self_iff_false] at *
-
-lemma MultipliableEtaProductExpansion (z : ℍ) :
-    Multipliable (fun (n : ℕ) => (1 - cexp (2 * π * Complex.I * (n + 1) * z))) := by
-  apply (ModularForm.multipliable_one_sub_pow
-    (UpperHalfPlane.norm_exp_two_pi_I_lt_one z)).congr
-  intro n
-  congr 1
-  rw [← Complex.exp_nat_mul]
-  push_cast
-  ring_nf
+/-- `Δ` is mathlib's modular discriminant `ModularForm.discriminant`. -/
+notation "Δ" => ModularForm.discriminant
 
 lemma MultipliableEtaProductExpansion_pnat (z : ℍ) :
-    Multipliable (fun (n : ℕ+) => (1 - cexp (2 * π * Complex.I * n * z))) := by
-  conv =>
-    enter [1]
-    ext n
-    rw [sub_eq_add_neg]
-  let g := (fun (n : ℕ) => (1 - cexp (2 * π * Complex.I * n * z)) )
-  have := MultipliableEtaProductExpansion z
-  conv at this =>
-    enter [1]
-    ext n
-    rw [show (n : ℂ) + 1 = (((n + 1) : ℕ) : ℂ) by simp]
-  rw [← multipliable_pnat_iff_multipliable_succ (f := g)] at this
-  apply this.congr
-  intro b
-  rfl
+    Multipliable fun n : ℕ+ ↦ 1 - cexp (2 * π * Complex.I * n * z) := by
+  rw [multipliable_pnat_iff_multipliable_succ
+    (f := fun n : ℕ ↦ 1 - cexp (2 * π * Complex.I * n * z))]
+  exact (ModularForm.multipliableLocallyUniformlyOn_eta.multipliable z.2).congr fun n ↦ by
+    rw [ModularForm.eta_q_eq_cexp]; push_cast; ring_nf
 
-lemma MultipliableDeltaProductExpansion_pnat (z : ℍ) :
-    Multipliable (fun (n : ℕ+) => (1 - cexp (2 * π * Complex.I * n * z))^24) :=
-  (MultipliableEtaProductExpansion_pnat z).pow 24
+/-- The discriminant as a `q`-product with explicit complex exponentials. -/
+lemma Δ_eq_cexp_prod (z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' n : ℕ,
+    (1 - cexp (2 * π * Complex.I * (n + 1) * z)) ^ 24 := by
+  simp only [ModularForm.discriminant_eq_q_prod, ModularForm.eta_q_eq_cexp, Periodic.qParam,
+    ofReal_one, div_one]
 
-noncomputable section Definitions
+lemma DiscriminantProductFormula (z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' n : ℕ+,
+    (1 - cexp (2 * π * Complex.I * n * z)) ^ 24 := by
+  rw [Δ_eq_cexp_prod]
+  congr 1
+  rw [tprod_pnat_eq_tprod_succ (f := fun n : ℕ ↦ (1 - cexp (2 * π * Complex.I * n * z)) ^ 24)]
+  exact tprod_congr fun n ↦ by push_cast; ring_nf
 
-/- The discriminant form -/
-def Δ (z : UpperHalfPlane) := cexp (2 * π * Complex.I * z) * ∏' (n : ℕ),
-    (1 - cexp (2 * π * Complex.I * (n + 1) * z)) ^ 24
+/-- `Δ` is 1-periodic: `Δ (z + 1) = Δ z`. -/
+lemma Δ_periodic (z : ℍ) : Δ ((1 : ℝ) +ᵥ z) = Δ z :=
+  SlashInvariantForm.vAdd_apply_of_mem_strictPeriods CuspForm.discriminant z
+    one_mem_strictPeriods_SL
 
-lemma DiscriminantProductFormula (z : ℍ) : Δ z = cexp (2 * π * Complex.I * z) * ∏' (n : ℕ+),
-    (1 - cexp (2 * π * Complex.I * (n) * z)) ^ 24 := by
-    simp [Δ]
-    conv =>
-      enter [1,1]
-      ext n
-      rw [show (n : ℂ) + 1 = ((n + 1) : ℕ) by simp]
-    have := tprod_pnat_eq_tprod_succ (f := (fun n => (1 - cexp (2 * π * Complex.I * (n) * z)) ^ 24))
-    rw [this]
-
-
-lemma Delta_eq_eta_pow (z : ℍ) : Δ z = (η z) ^ 24 := by
-  have hm : Multipliable (fun n : ℕ => 1 - ModularForm.eta_q n z) := by
-    refine (MultipliableEtaProductExpansion z).congr ?_
-    intro n
-    simp [ModularForm.eta_q_eq_cexp]
-  rw [ModularForm.eta, Δ, mul_pow, ← hm.tprod_pow 24]
-  congr
-  · rw [Periodic.qParam]
-    rw [← Complex.exp_nat_mul]
-    congr 1
-    simp [field]
-  · ext n
-    simp [ModularForm.eta_q_eq_cexp]
-
-
-/-This should be easy from the definition and the Mulitpliable bit. -/
-/-- The project's `Δ` agrees with mathlib's `ModularForm.discriminant`. -/
-lemma Δ_eq_discriminant : Δ = ModularForm.discriminant :=
-  funext fun z => Delta_eq_eta_pow z
-
-lemma Δ_ne_zero (z : UpperHalfPlane) : Δ z ≠ 0 := by
-  rw [Delta_eq_eta_pow]
-  exact pow_ne_zero 24 (ModularForm.eta_ne_zero (z := (z : ℂ)) z.2)
-
-lemma Discriminant_T_invariant : (Δ ∣[(12 : ℤ)] ModularGroup.T) = Δ := by
-  rw [Δ_eq_discriminant]
-  exact ModularForm.discriminant_T_invariant
-
-lemma Discriminant_S_invariant : (Δ ∣[(12 : ℤ)] ModularGroup.S) = Δ := by
-  rw [Δ_eq_discriminant]
-  exact ModularForm.discriminant_S_invariant
-
-/-- Δ as a SlashInvariantForm of weight 12 -/
-def Discriminant_SIF : SlashInvariantForm (CongruenceSubgroup.Gamma 1) 12 where
-  toFun := Δ
-  slash_action_eq' :=
-    slashaction_generators_GL2R Δ 12 Discriminant_S_invariant Discriminant_T_invariant
-
-/-- Δ is 1-periodic: Δ(z + 1) = Δ(z) -/
-lemma Δ_periodic (z : ℍ) : Δ ((1 : ℝ) +ᵥ z) = Δ z := by
-  change (Discriminant_SIF : ℍ → ℂ) ((1 : ℝ) +ᵥ z) = (Discriminant_SIF : ℍ → ℂ) z
-  simpa only [Int.cast_one, Nat.cast_one, one_mul, mul_one] using
-    SlashInvariantForm.vAdd_width_periodic 1 12 1 Discriminant_SIF z
-
-/-- Δ transforms under S as: Δ(-1/z) = z¹² · Δ(z) -/
+/-- `Δ` transforms under `S` as `Δ (-1 / z) = z ^ 12 * Δ z`. -/
 lemma Δ_S_transform (z : ℍ) : Δ (ModularGroup.S • z) = z ^ (12 : ℕ) * Δ z := by
-  have h := Discriminant_S_invariant
-  simp only [funext_iff] at h
-  specialize h z
+  have h := congrFun ModularForm.discriminant_S_invariant z
   rw [SL_slash_apply] at h
   simp only [ModularGroup.denom_S, zpow_neg] at h
   field_simp [ne_zero z] at h
   rw [h, mul_comm]
 
-theorem Delta_boundedfactor :
-  Tendsto (fun x : ℍ ↦ ∏' (n : ℕ), (1 - cexp (2 * ↑π * Complex.I * (↑n + 1) * ↑x)) ^ 24) atImInfty
-    (𝓝 1) := by
+theorem Δ_boundedfactor :
+    Tendsto (fun x : ℍ ↦ ∏' n : ℕ, (1 - cexp (2 * ↑π * Complex.I * (↑n + 1) * ↑x)) ^ 24) atImInfty
+      (𝓝 1) := by
   apply ModularForm.tendsto_atImInfty_tprod_one_sub_eta_q_pow.congr
-  exact fun x => tprod_congr fun n => by rw [ModularForm.eta_q_eq_cexp]
+  exact fun x ↦ tprod_congr fun n ↦ by rw [ModularForm.eta_q_eq_cexp]
 
 open Real
 
-lemma Discriminant_zeroAtImInfty :
-    ∀ γ ∈ 𝒮ℒ, IsZeroAtImInfty (Discriminant_SIF ∣[(12 : ℤ)] (γ : GL (Fin 2) ℝ)) := by
-  intro γ ⟨γ', hγ⟩
-  rw [IsZeroAtImInfty, ZeroAtFilter]
-  have := Discriminant_SIF.slash_action_eq' γ ⟨γ', CongruenceSubgroup.mem_Gamma_one γ', hγ⟩
-  simp at *
-  rw [this]
-  have h0 : Tendsto Δ atImInfty (𝓝 0) := by
-    rw [Δ_eq_discriminant]
-    exact ModularForm.discriminant_isZeroAtImInfty
-  simpa [Discriminant_SIF] using h0
-
-def Delta : CuspForm (CongruenceSubgroup.Gamma 1) 12 where
-  toFun := Discriminant_SIF
-  slash_action_eq' := Discriminant_SIF.slash_action_eq'
-  holo' := by
-    rw [mdifferentiable_iff]
-    simp only [SlashInvariantForm.coe_mk]
-    have he2 : DifferentiableOn ℂ (fun z => (η z) ^ 24) {z | 0 < z.im} := by
-      apply DifferentiableOn.pow
-      intro x hx
-      apply DifferentiableAt.differentiableWithinAt
-      simpa using (ModularForm.differentiableAt_eta_of_mem_upperHalfPlaneSet (z := x) hx)
-    rw [Discriminant_SIF]
-    simp only [SlashInvariantForm.coe_mk]
-    apply he2.congr
-    intro z hz
-    have := Delta_eq_eta_pow (⟨z, hz⟩ : ℍ)
-    simp only [comp_apply] at *
-    rw [ofComplex_apply_of_im_pos hz]
-    exact this
-  zero_at_cusps' hc := zero_at_cusps_of_zero_at_infty hc Discriminant_zeroAtImInfty
-
-lemma Delta_apply (z : ℍ) : Delta z = Δ z := by rfl
-
-lemma Delta_isTheta_rexp : Delta =Θ[atImInfty] (fun τ => Real.exp (-2 * π * τ.im)) := by
-  rw [Asymptotics.IsTheta]
-  refine ⟨by simpa using CuspFormClass.exp_decay_atImInfty (h := 1) Delta, ?_⟩
-  have := ModularForm.exp_isBigO_discriminant
-  rw [← Δ_eq_discriminant] at this
-  exact this.congr_right fun z => (Delta_apply z).symm
-
-lemma cexp_aux1 (t : ℝ) : cexp (2 * ↑π * Complex.I * (Complex.I * t)) = rexp (-2 * π * t) := by
-  calc
-    _ = cexp (2 * ↑π * (Complex.I * Complex.I) * t) := by ring_nf
-    _ = rexp (-2 * π * t) := by simp
-
-lemma cexp_aux2 (t : ℝ) (n : ℕ)
-    : cexp (2 * π * Complex.I * (n + 1) * (Complex.I * t)) = rexp (-(2 * π * (n + 1) * t)) := by
-  calc
-    _ = cexp (2 * ↑π * (n + 1) * (Complex.I * Complex.I) * t) := by ring_nf
-    _ = rexp (-(2 * π * (n + 1) * t)) := by simp
-
-lemma cexp_aux3 (t : ℝ) (n : ℕ) (ht : 0 < t) : 0 < 1 - rexp (-(2 * π * (n + 1) * t)) := by
-  have _ : rexp (-(2 * π * (n + 1) * t)) < 1 := exp_lt_one_iff.mpr (by simp; positivity)
-  linarith
-
-lemma cexp_aux4 (t : ℝ) (n : ℕ) : (cexp (-2 * π * (n + 1) * t)).im = 0 := by
-  simpa [Complex.ofReal_mul, Complex.ofReal_neg] using exp_ofReal_im (-2 * π * (n + 1) * t)
-
-lemma cexp_aux5 (t : ℝ) : (cexp (-(2 * π * t))).im = 0 := by
-  simpa [Complex.ofReal_mul, Complex.ofReal_neg] using exp_ofReal_im (-(2 * π * t))
-
-/- Auxiliary lemmas for imaginary part of products and powers -/
-lemma Complex.im_finset_prod_eq_zero_of_im_eq_zero {ι : Type*} (s : Finset ι)
-    (f : ι → ℂ) (h : ∀ i ∈ s, (f i).im = 0) :
-    (∏ i ∈ s, f i).im = 0 := by
-  classical
-  revert h; refine Finset.induction_on s (fun _ => by simp) ?_; intro a s ha ih h
-  simp [Finset.prod_insert, ha, Complex.mul_im, h a (by simp),
-    ih (fun i hi => h i (by simp [hi]))]
-
-lemma Complex.im_pow_eq_zero_of_im_eq_zero {z : ℂ} (hz : z.im = 0) (m : ℕ) :
-    (z ^ m).im = 0 := by
+/-- The imaginary part of a natural power vanishes when the base is real. -/
+lemma Complex.im_pow_eq_zero_of_im_eq_zero {z : ℂ} (hz : z.im = 0) (m : ℕ) : (z ^ m).im = 0 := by
   induction m with
   | zero => simp
   | succ m ih => simp [pow_succ, Complex.mul_im, *]
 
-lemma Complex.im_tprod_eq_zero_of_im_eq_zero (f : ℕ → ℂ)
-    (hf : Multipliable f) (him : ∀ n, (f n).im = 0) :
-    (∏' n : ℕ, f n).im = 0 := by
-  classical
-  have hz : ∀ n, (∏ i ∈ Finset.range n, f i).im = 0 := fun n =>
-    Complex.im_finset_prod_eq_zero_of_im_eq_zero (s := Finset.range n) (f := f)
-      (by intro i _; simpa using him i)
-  have h1 := ((Complex.continuous_im.tendsto _).comp hf.hasProd.tendsto_prod_nat)
-  have h2 : Tendsto (fun n => (∏ i ∈ Finset.range n, f i).im) atTop (𝓝 (0 : ℝ)) := by simp [hz]
-  exact tendsto_nhds_unique h1 h2
-
-/- Δ(it) is real on the (positive) imaginary axis. -/
-lemma Delta_imag_axis_real : ResToImagAxis.Real Δ := by
-  intro t ht
-  simp [ResToImagAxis, ht, Δ]
-  set g : ℕ → ℂ := fun n => (1 - cexp (2 * π * Complex.I * (n + 1) * (Complex.I * t))) ^ 24
-  have hArg (n : ℕ) :
-      2 * (π : ℂ) * Complex.I * (n + 1) * (Complex.I * t) = -(2 * (π : ℂ) * (n + 1) * t) := by
+/-- On the positive imaginary axis, `Δ (i t)` is the real quantity
+`e ^ (-2 π t) * ∏' (1 - e ^ (-2 π (n + 1) t)) ^ 24`. -/
+private lemma resToImagAxis_Δ_eq (t : ℝ) (ht : 0 < t) :
+    Function.resToImagAxis Δ t =
+      ((Real.exp (-2 * π * t) *
+        ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 : ℝ) : ℂ) := by
+  have h1 : cexp (2 * ↑π * Complex.I * (Complex.I * t)) = rexp (-2 * π * t) := by
     calc
-      2 * (π : ℂ) * Complex.I * (n + 1) * (Complex.I * t)
-        = 2 * (π : ℂ) * (Complex.I * Complex.I) * (n + 1) * t := by ring
-      _ = -(2 * (π : ℂ) * (n + 1) * t) := by simp
-  have him_g : ∀ n, (g n).im = 0 := fun n => by
-    have : (cexp (-(2 * (π : ℂ) * ((n + 1) : ℂ) * t))).im = 0 := by
-      simpa [mul_comm, mul_left_comm, mul_assoc] using (cexp_aux4 t n)
-    have : ((1 - cexp (2 * (π : ℂ) * Complex.I * (n + 1) * (Complex.I * t))) : ℂ).im = 0 := by
-      simpa [Complex.sub_im, hArg n] using this
-    simpa [g] using Complex.im_pow_eq_zero_of_im_eq_zero this 24
-  let z : ℍ := ⟨Complex.I * t, by simp [ht]⟩
-  have hmul : Multipliable g := by
-    have hz : (z : ℂ) = Complex.I * t := rfl
-    simpa [g, hz] using
-      (Multipliable.pow (by simpa using MultipliableEtaProductExpansion z) 24)
-  have htprod_im : (∏' n : ℕ, g n).im = 0 :=
-    Complex.im_tprod_eq_zero_of_im_eq_zero g hmul him_g
-  have him_pref : (cexp (2 * π * Complex.I * (Complex.I * t))).im = 0 := by
-    have : (cexp (-(2 * (π : ℂ) * t))).im = 0 := by simpa using cexp_aux5 t
-    simpa [by simpa using hArg 0] using this
-  simp [g, him_pref, htprod_im]
-
-lemma re_ResToImagAxis_Delta_eq_real_prod (t : ℝ) (ht : 0 < t) :
-  (Δ.resToImagAxis t).re =
-    Real.exp (-2 * π * t) *
-      ∏' (n : ℕ), (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := by
+      _ = cexp (2 * ↑π * (Complex.I * Complex.I) * t) := by ring_nf
+      _ = rexp (-2 * π * t) := by simp
+  have h2 (n : ℕ) :
+      cexp (2 * π * Complex.I * (n + 1) * (Complex.I * t)) = rexp (-(2 * π * (n + 1) * t)) := by
+    calc
+      _ = cexp (2 * ↑π * (n + 1) * (Complex.I * Complex.I) * t) := by ring_nf
+      _ = rexp (-(2 * π * (n + 1) * t)) := by simp
   set fR : ℕ → ℝ := fun n => (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24
-  have hMap' :
-      Complex.ofReal (∏' n : ℕ, fR n) = ∏' n : ℕ, ((fR n : ℝ) : ℂ) := by
+  have hMap' : Complex.ofReal (∏' n : ℕ, fR n) = ∏' n : ℕ, ((fR n : ℝ) : ℂ) := by
     simpa using
-      (Function.LeftInverse.map_tprod (f := fR)
-        (g := Complex.ofRealHom.toMonoidHom)
-        (hg := by
-          change Continuous (fun x : ℝ => (x : ℂ))
-          exact Complex.continuous_ofReal)
-        (hg' := Complex.continuous_re)
-        (hgg' := by intro x; simp))
-  simpa [ResToImagAxis, ht, Delta_apply, Δ, cexp_aux1, cexp_aux2, hMap', fR] using
-    Complex.ofReal_re (Real.exp (-2 * π * t) * ∏' n : ℕ, fR n)
+      (Function.LeftInverse.map_tprod (f := fR) (g := Complex.ofRealHom.toMonoidHom)
+        (hg := by change Continuous (fun x : ℝ => (x : ℂ)); exact Complex.continuous_ofReal)
+        (hg' := Complex.continuous_re) (hgg' := by intro x; simp))
+  simp [ResToImagAxis, ht, Δ_eq_cexp_prod, h1, h2, hMap', fR]
 
-lemma tprod_pos_nat_im (z : ℍ) :
-  0 < ∏' (n : ℕ), (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 := by
-  have hpos_pow : ∀ n : ℕ, 0 < (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 :=
-    fun n =>
-      pow_pos (by simpa [mul_comm, mul_left_comm, mul_assoc] using cexp_aux3 (t := z.im) n z.2) _
-  have hsum_log :
-      Summable (fun n : ℕ =>
-        Real.log ((1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24)) := by
+private lemma Δ_imag_axis_real : ResToImagAxis.Real Δ := by
+  intro t ht
+  rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_im]
+
+private lemma re_resToImagAxis_Δ_eq_real_prod (t : ℝ) (ht : 0 < t) :
+    (Function.resToImagAxis Δ t).re =
+      Real.exp (-2 * π * t) * ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := by
+  rw [resToImagAxis_Δ_eq t ht, Complex.ofReal_re]
+
+private lemma tprod_pos_nat_im (z : ℍ) :
+    0 < ∏' n : ℕ, (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 := by
+  have hpos_pow : ∀ n : ℕ, 0 < (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24 := fun n =>
+    pow_pos (sub_pos.mpr (exp_lt_one_iff.mpr (neg_lt_zero.mpr (by positivity)))) _
+  have hsum_log : Summable fun n : ℕ =>
+      Real.log ((1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24) := by
     simp only [Real.log_pow, Nat.cast_ofNat, ← smul_eq_mul]
     apply Summable.const_smul
     simp [sub_eq_add_neg]
     apply Real.summable_log_one_add_of_summable
     apply Summable.neg
-    have h0 : Summable (fun n : ℕ => Real.exp (n * (-(2 * π * z.im)))) :=
-      (Real.summable_exp_nat_mul_iff.mpr
-        (by simpa using (neg_lt_zero.mpr (by positivity : 0 < 2 * π * z.im))))
+    have h0 : Summable fun n : ℕ => Real.exp (n * (-(2 * π * z.im))) :=
+      Real.summable_exp_nat_mul_iff.mpr
+        (by simpa using neg_lt_zero.mpr (by positivity : 0 < 2 * π * z.im))
     simpa [Nat.cast_add, Nat.cast_one, mul_comm, mul_left_comm, mul_assoc] using
-      ((summable_nat_add_iff 1).2 h0)
+      (summable_nat_add_iff 1).2 h0
   rw [← Real.rexp_tsum_eq_tprod
-        (f := fun n : ℕ =>
-          (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24)
-        hpos_pow hsum_log]
+        (f := fun n : ℕ => (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * z.im))) ^ 24) hpos_pow hsum_log]
   exact Real.exp_pos _
 
-/- Δ(it) is positive on the (positive) imaginary axis. -/
-lemma Delta_imag_axis_pos : ResToImagAxis.Pos Δ := by
+/-- `Δ` is real and positive on the positive imaginary axis. -/
+lemma Δ_imag_axis_pos : ResToImagAxis.Pos Δ := by
   rw [ResToImagAxis.Pos]
-  refine And.intro Delta_imag_axis_real ?_
-  intro t ht
-  have hprod :
-      0 < ∏' (n : ℕ), (1 - Real.exp (-(2 * π * ((n + 1) : ℝ) * t))) ^ 24 := by
-    let z : ℍ := ⟨Complex.I * t, by simp [ht]⟩
-    have hz : z.im = t := by simp [UpperHalfPlane.im, z]
-    simpa [hz] using tprod_pos_nat_im z
-  rw [re_ResToImagAxis_Delta_eq_real_prod t ht]
-  exact mul_pos (Real.exp_pos _) hprod
+  refine And.intro Δ_imag_axis_real fun t ht => ?_
+  rw [re_resToImagAxis_Δ_eq_real_prod t ht]
+  refine mul_pos (Real.exp_pos _) ?_
+  let z : ℍ := ⟨Complex.I * t, by simp [ht]⟩
+  have hz : z.im = t := by simp [UpperHalfPlane.im, z]
+  simpa [hz] using tprod_pos_nat_im z

--- a/SpherePacking/ModularForms/Delta.lean
+++ b/SpherePacking/ModularForms/Delta.lean
@@ -71,10 +71,9 @@ lemma Δ_periodic (z : ℍ) : Δ ((1 : ℝ) +ᵥ z) = Δ z :=
 /-- `Δ` transforms under `S` as `Δ (-1 / z) = z ^ 12 * Δ z`. -/
 lemma Δ_S_transform (z : ℍ) : Δ (ModularGroup.S • z) = z ^ (12 : ℕ) * Δ z := by
   have h := congrFun ModularForm.discriminant_S_invariant z
-  rw [SL_slash_apply] at h
-  simp only [ModularGroup.denom_S, zpow_neg] at h
+  rw [modular_slash_S_apply, ← modular_S_smul] at h
   field_simp [ne_zero z] at h
-  rw [h, mul_comm]
+  exact h
 
 theorem Δ_boundedfactor :
     Tendsto (fun x : ℍ ↦ ∏' n : ℕ, (1 - cexp (2 * ↑π * Complex.I * (↑n + 1) * ↑x)) ^ 24) atImInfty

--- a/SpherePacking/ModularForms/DimensionFormulas.lean
+++ b/SpherePacking/ModularForms/DimensionFormulas.lean
@@ -65,34 +65,6 @@ lemma IsCuspForm_weight_lt_eq_zero (k : ℤ) (hk : k < 12) (f : ModularForm Γ(1
   rw [this]
   simp only [CuspForm.zero_apply]
 
-lemma Delta_E4_E6_eq : ModForm_mk _ _ Delta_E4_E6_aux =
-  ((1/ 1728 : ℂ) • (((DirectSum.of _ 4 E₄)^3 - (DirectSum.of _ 6 E₆)^2) 12 )) := by
-  ext
-  rfl
-
-theorem Delta_E4_eqn : Delta = Delta_E4_E6_aux := by
-  ext z
-  have hE4 : ModularForm.E₄ z = E₄ z := rfl
-  have hE6 : ModularForm.E₆ z = E₆ z := rfl
-  have hl : Delta z = (E₄ z ^ 3 - E₆ z ^ 2) / 1728 := by
-    rw [Delta_apply, show Δ = ModularForm.discriminant from Δ_eq_discriminant, ← hE4, ← hE6]
-    exact ModularForm.discriminant_eq_E₄_cube_sub_E₆_sq z
-  have hr : Delta_E4_E6_aux z =
-      ((1 / 1728 : ℂ) • (((DirectSum.of _ 4 E₄) ^ 3 - (DirectSum.of _ 6 E₆) ^ 2) 12)) z :=
-    congr_fun (congr_arg (fun (f : ModularForm Γ(1) 12) => (f : ℍ → ℂ)) Delta_E4_E6_eq) z
-  have h3 : (((DirectSum.of (fun k : ℤ => ModularForm Γ(1) k) 4 E₄) ^ 3) 12) z = E₄ z ^ 3 := by
-    rw [show (12 : ℤ) = 4 + (4 + 4) by norm_num, pow_three, DirectSum.of_mul_of,
-      DirectSum.of_mul_of, DirectSum.of_eq_same]
-    change E₄ z * (E₄ z * E₄ z) = E₄ z ^ 3
-    ring
-  have h2 : (((DirectSum.of (fun k : ℤ => ModularForm Γ(1) k) 6 E₆) ^ 2) 12) z = E₆ z ^ 2 := by
-    rw [show (12 : ℤ) = 6 + 6 by norm_num, pow_two, DirectSum.of_mul_of, DirectSum.of_eq_same]
-    change E₆ z * E₆ z = E₆ z ^ 2
-    ring
-  rw [hl, hr]
-  simp only [IsGLPos.smul_apply, DirectSum.sub_apply, ModularForm.sub_apply, h3, h2, smul_eq_mul]
-  ring
-
 lemma weight_six_one_dimensional : Module.rank ℂ (ModularForm Γ(1) 6) = 1 :=
   (rank_modularForm_congr CongruenceSubgroup.Gamma_one_coe_eq_SL).trans
     ModularForm.levelOne_weight_six_rank_one

--- a/SpherePacking/ModularForms/Eisenstein.lean
+++ b/SpherePacking/ModularForms/Eisenstein.lean
@@ -192,18 +192,6 @@ theorem E4E6_coeff_zero_eq_zero :
     simpa [PowerSeries.coeff_zero_eq_constantCoeff] using hq6
   exact sub_eq_zero.mpr (hcoeff4.trans hcoeff6.symm)
 
-def Delta_E4_E6_aux : CuspForm (CongruenceSubgroup.Gamma 1) 12 :=
-  let F := DirectSum.of _ 4 E₄
-  let G := DirectSum.of _ 6 E₆
-  cuspFormOfCoeffZero ((1 / 1728 : ℂ) • (F ^ 3 - G ^ 2) 12) E4E6_coeff_zero_eq_zero
-
-
-lemma Delta_ne_zero : Delta ≠ 0 := by
-  have := Δ_ne_zero UpperHalfPlane.I
-  rw [@DFunLike.ne_iff]
-  refine ⟨UpperHalfPlane.I, this⟩
-
-
 lemma Ek_ne_zero (k : ℕ) (hk : 3 ≤ (k : ℤ)) (hk2 : Even k) : E k hk ≠ 0 := by
   have h := EisensteinSeries.E_ne_zero (k := k) (by exact_mod_cast hk) hk2
   rw [DFunLike.ne_iff] at h ⊢

--- a/SpherePacking/ModularForms/FG.lean
+++ b/SpherePacking/ModularForms/FG.lean
@@ -41,7 +41,7 @@ lemma Δ_fun_eq_Δ : Δ_fun = Δ := by
   have hE4 : ModularForm.E₄ z = E₄ z := rfl
   have hE6 : ModularForm.E₆ z = E₆ z := rfl
   have hΔ : Δ z = (E₄ z ^ 3 - E₆ z ^ 2) / 1728 := by
-    rw [show Δ = ModularForm.discriminant from Δ_eq_discriminant, ← hE4, ← hE6]
+    rw [← hE4, ← hE6]
     exact ModularForm.discriminant_eq_E₄_cube_sub_E₆_sq z
   calc
     Δ_fun z = 1728⁻¹ * (E₄ z ^ 3 - E₆ z ^ 2) := by
@@ -136,7 +136,7 @@ theorem MLDE_F : serre_D 12 (serre_D 10 F) =
 private lemma Δ_fun_theta :
     Δ_fun = (1 / 256 : ℂ) • ((H₂ * (H₂ + H₄) * H₄) ^ 2) := by
   ext z
-  rw [congrFun Δ_fun_eq_Δ z, ← Delta_apply, Delta_eq_H₂_H₃_H₄ z, ← jacobi_identity]
+  rw [congrFun Δ_fun_eq_Δ z, Δ_eq_H₂_H₃_H₄ z, ← jacobi_identity]
   simp [Pi.add_apply, Pi.mul_apply, Pi.pow_apply, Pi.smul_apply, smul_eq_mul]
   ring
 
@@ -168,7 +168,7 @@ private lemma logderiv_mul_eq (f h : ℍ → ℂ)
 
 /- Positivity of (quasi)modular forms on the imaginary axis. -/
 
-lemma Δ_fun_imag_axis_pos : ResToImagAxis.Pos Δ_fun := Δ_fun_eq_Δ ▸ Delta_imag_axis_pos
+lemma Δ_fun_imag_axis_pos : ResToImagAxis.Pos Δ_fun := Δ_fun_eq_Δ ▸ Δ_imag_axis_pos
 
 /-- The q-expansion exponent argument on imaginary axis z=it with ℕ+ index.
 Simplifies `2πi * n * z` where z=it to `-2πnt`. -/
@@ -630,7 +630,7 @@ private theorem serre_D_L₁₀_pos_imag_axis : ResToImagAxis.Pos SerreDer_22_L�
     ext z; simp only [Pi.mul_apply, Pi.add_apply, Pi.smul_apply, Pi.neg_apply,
       Complex.real_smul, serre_D_L₁₀_eq z, negDE₂]; push_cast; ring
   rw [h_eq]
-  have := Delta_imag_axis_pos
+  have := Δ_imag_axis_pos
   have := negDE₂_imag_axis_pos
   have := G_imag_axis_pos
   have := H₂_imag_axis_pos

--- a/SpherePacking/ModularForms/JacobiTheta/Basic.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/Basic.lean
@@ -675,6 +675,11 @@ lemma Θ₄_imag_axis_real (t : ℝ) (ht : 0 < t) :
   intro n
   exact Θ₄_term_imag_axis_real n t ht
 
+/-- The imaginary part of a natural power vanishes when the base is real. -/
+lemma Complex.im_pow_eq_zero_of_im_eq_zero {z : ℂ} (hz : z.im = 0) (m : ℕ) : (z ^ m).im = 0 := by
+  rw [← Complex.conj_eq_iff_im] at hz ⊢
+  rw [map_pow, hz]
+
 /--
 `H₂(it)` is real for all `t > 0`.
 Blueprint: Follows from the q-expansion having real coefficients.

--- a/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
+++ b/SpherePacking/ModularForms/JacobiTheta/JacobiIdentity.lean
@@ -8,14 +8,14 @@ public import SpherePacking.ModularForms.JacobiTheta.MDifferentiable
 # Jacobi theta identities
 
 This file proves the Jacobi identity `H₂ + H₄ = H₃` and the discriminant identity
-`Delta = (H₂ * H₃ * H₄)^2 / 256`.
+`Δ = (H₂ * H₃ * H₄)^2 / 256`.
 
 The proof strategy:
 1. Define `g := H₂ + H₄ - H₃` and `f := g²`.
 2. Show `f` is a weight-4 level-1 modular form.
 3. Show `f` vanishes at `i∞` using the asymptotic lemmas from `Basic.lean`.
 4. Apply cusp form vanishing in weight 4 to deduce `f = 0`, hence `g = 0`.
-5. Use the weight-12 analogue for `(H₂ * H₃ * H₄)^2` to identify `Delta`.
+5. Use the weight-12 analogue for `(H₂ * H₃ * H₄)^2` to identify `Δ`.
 -/
 
 open scoped Real MatrixGroups ModularForm
@@ -194,22 +194,15 @@ private noncomputable def theta_prod_sq_CF : CuspForm (CongruenceSubgroup.Gamma 
 private lemma theta_prod_sq_CF_apply (z : ℍ) :
     theta_prod_sq_CF z = theta_prod_sq z := rfl
 
-/-- `Module.rank` of a `CuspForm` space is invariant under equality of the underlying subgroup,
-bridging the project's `Γ(1)`-indexed spaces to mathlib's `𝒮ℒ`-indexed level-one lemmas. -/
-private lemma rank_cuspForm_congr {k : ℤ} {G₁ G₂ : Subgroup (GL (Fin 2) ℝ)}
-    [G₁.HasDetOne] [G₂.HasDetOne] (h : G₁ = G₂) :
-    Module.rank ℂ (CuspForm G₁ k) = Module.rank ℂ (CuspForm G₂ k) := by
-  subst h; rfl
-
-private lemma finrank_cuspform_12 :
-    Module.finrank ℂ (CuspForm (CongruenceSubgroup.Gamma 1) 12) = 1 :=
-  Module.finrank_eq_of_rank_eq
-    ((rank_cuspForm_congr CongruenceSubgroup.Gamma_one_coe_eq_SL).trans
-      CuspForm.rank_eq_one_of_weight_eq_twelve)
-
 private lemma theta_prod_sq_proportional :
-    ∃ c : ℂ, c • Delta = theta_prod_sq_CF :=
-  (finrank_eq_one_iff_of_nonzero' Delta Delta_ne_zero).mp finrank_cuspform_12 theta_prod_sq_CF
+    ∃ c : ℂ, ∀ z : ℍ, c * Δ z = theta_prod_sq z := by
+  suffices h : ∀ f : CuspForm (CongruenceSubgroup.Gamma 1) 12, ∃ c : ℂ, ∀ z : ℍ, c * Δ z = f z by
+    obtain ⟨c, hc⟩ := h theta_prod_sq_CF
+    exact ⟨c, fun z ↦ (hc z).trans (theta_prod_sq_CF_apply z)⟩
+  rw [CongruenceSubgroup.Gamma_one_coe_eq_SL]
+  intro f
+  obtain ⟨c, hc⟩ := CuspForm.exists_smul_discriminant_of_weight_eq_twelve f
+  exact ⟨c, fun z ↦ by simpa using DFunLike.congr_fun hc z⟩
 
 private lemma Θ₂_div_exp_tendsto :
     Tendsto (fun z : ℍ ↦ Θ₂ z / cexp (π * I * ↑z / 4)) atImInfty (nhds 2) := by
@@ -231,24 +224,19 @@ private lemma H₂_div_exp_tendsto :
   rw [← h16]
   exact jacobiTheta₂_half_mul_apply_tendsto_atImInfty.pow 4
 
-lemma Delta_eq_H₂_H₃_H₄ (τ : ℍ) :
-    Delta τ = ((H₂ τ) * (H₃ τ) * (H₄ τ))^2 / (256 : ℂ) := by
-  obtain ⟨c, hc⟩ := theta_prod_sq_proportional
-  have hc_pw : ∀ z : ℍ, c * Delta z = theta_prod_sq z := by
-    intro z
-    have h := DFunLike.congr_fun hc z
-    rw [show (c • Delta : CuspForm _ _) z = c * Delta z from rfl] at h
-    rwa [theta_prod_sq_CF_apply] at h
+lemma Δ_eq_H₂_H₃_H₄ (τ : ℍ) :
+    Δ τ = ((H₂ τ) * (H₃ τ) * (H₄ τ))^2 / (256 : ℂ) := by
+  obtain ⟨c, hc_pw⟩ := theta_prod_sq_proportional
   have hc_eq : c = 256 := by
-    have hD_asymp : Tendsto (fun z : ℍ ↦ Delta z / cexp (2 * ↑π * I * ↑z))
+    have hD_asymp : Tendsto (fun z : ℍ ↦ Δ z / cexp (2 * ↑π * I * ↑z))
         atImInfty (nhds 1) := by
-      have h_eq : ∀ z : ℍ, Delta z / cexp (2 * ↑π * I * ↑z) =
+      have h_eq : ∀ z : ℍ, Δ z / cexp (2 * ↑π * I * ↑z) =
           ∏' (n : ℕ), (1 - cexp (2 * ↑π * I * (↑n + 1) * ↑z)) ^ 24 := by
         intro z
-        rw [Delta_apply, Δ]
+        rw [Δ_eq_cexp_prod]
         rw [mul_div_cancel_left₀ _ (Complex.exp_ne_zero _)]
       simp_rw [h_eq]
-      exact Delta_boundedfactor
+      exact Δ_boundedfactor
     have hP_asymp : Tendsto (fun z : ℍ ↦ theta_prod_sq z / cexp (2 * ↑π * I * ↑z))
         atImInfty (nhds 256) := by
       have h_rewrite : ∀ z : ℍ, theta_prod_sq z / cexp (2 * ↑π * I * ↑z) =
@@ -265,11 +253,11 @@ lemma Delta_eq_H₂_H₃_H₄ (τ : ℍ) :
       rw [this]
       exact ((H₂_div_exp_tendsto.pow 2).mul (H₃_tendsto_atImInfty.pow 2)).mul
         (H₄_tendsto_atImInfty.pow 2)
-    have h_eq_fns : ∀ z : ℍ, c * (Delta z / cexp (2 * ↑π * I * ↑z)) =
+    have h_eq_fns : ∀ z : ℍ, c * (Δ z / cexp (2 * ↑π * I * ↑z)) =
         theta_prod_sq z / cexp (2 * ↑π * I * ↑z) := by
       intro z
       rw [← mul_div_assoc, hc_pw]
-    have hc_lim : Tendsto (fun z : ℍ ↦ c * (Delta z / cexp (2 * ↑π * I * ↑z)))
+    have hc_lim : Tendsto (fun z : ℍ ↦ c * (Δ z / cexp (2 * ↑π * I * ↑z)))
         atImInfty (nhds c) := by
       have := hD_asymp.const_mul c
       rwa [mul_one] at this

--- a/blueprint/src/subsections/modular-forms.tex
+++ b/blueprint/src/subsections/modular-forms.tex
@@ -221,7 +221,7 @@ $$
 \end{proof}
 
 
-\begin{lemma}\label{lemma:disc-cuspform}\uses{def:disc-definition, lemma:dedekind_eta_transformation}\leanok\lean{Delta}
+\begin{lemma}\label{lemma:disc-cuspform}\uses{def:disc-definition, lemma:dedekind_eta_transformation}\leanok\lean{CuspForm.discriminant}
 $\Delta(z) \in M_{12}(\Gamma_1)$.
 Especially, we have
 \begin{equation}\label{eqn:disc-trans-S}
@@ -236,7 +236,7 @@ Also, it vanishes at the unique cusp, i.e. it is a cusp form of level $\Gamma_1$
 
 
 
-\begin{lemma}\label{lemma:disc-E4E6}\uses{def:disc-definition}\lean{Delta_E4_eqn}\leanok
+\begin{lemma}\label{lemma:disc-E4E6}\uses{def:disc-definition}\lean{ModularForm.discriminant_eq_E₄_cube_sub_E₆_sq}\leanok
 We have
 \begin{equation}
 \Delta(z) = (E_4^3-E_6^2)/1728.
@@ -252,7 +252,7 @@ We have
 %As a side note, we can also consider defining $\Delta$ as \eqref{eqn:disc-prodformula}, and prove that it coincides with \eqref{eqn:disc-definition}.
 %Such an argument can be found in \cite[Section 2.4]{Bruinier}.
 
-\begin{corollary}\label{cor:disc-pos}\uses{def:disc-definition}\lean{Delta_imag_axis_pos}\leanok
+\begin{corollary}\label{cor:disc-pos}\uses{def:disc-definition}\lean{Δ_imag_axis_pos}\leanok
 $\Delta(it) > 0$ for all $t > 0$.
 \end{corollary}
 \begin{proof}\leanok
@@ -263,7 +263,7 @@ $$
 \end{proof}
 
 The following nonvanishing result, which directly follows from \Cref{def:disc-definition}, will be used in the construction of the magic function.
-\begin{corollary}\label{cor:disc-nonvanishing}\uses{def:disc-definition}\leanok\lean{Δ_ne_zero}
+\begin{corollary}\label{cor:disc-nonvanishing}\uses{def:disc-definition}\leanok\lean{ModularForm.discriminant_ne_zero}
 $\Delta(z) \neq 0$ for all $z \in \h$.
 \end{corollary}
 \begin{proof}

--- a/blueprint/src/subsections/modular-forms.tex
+++ b/blueprint/src/subsections/modular-forms.tex
@@ -158,7 +158,7 @@ On the other hand, the expression \eqref{eqn:Ek-Fourier} converges to a holomorp
 
 
 The discriminant form is a unique normalized cusp form of weight 12, which can be defined as:
-\begin{definition}\label{def:disc-definition}\lean{Δ}\leanok\uses{def:dedekind_eta}
+\begin{definition}\label{def:disc-definition}\lean{ModularForm.discriminant, Δ_eq_cexp_prod}\leanok\uses{def:dedekind_eta}
 The \emph{discriminant form} $\Delta(z)$ is given by
 \begin{equation}\label{eqn:disc-definition}
 \Delta(z) = e^{2 \pi i z} \prod_{n \ge 1} (1 - e^{2 \pi i n z})^{24}.


### PR DESCRIPTION
tl;dr: use upstreamed `ModularForm.Discriminant` in `Discriminant.lean`, and remove dead code. Essential remaining things are `Δ` (merely just a notation), realness and positivity result. Also, there are some duplicates, `Delta` and `Δ`, and the former (and downstream usage) are all removed/replaced.

By the way, I think the functional equations `Δ_periodic` and `Δ_S_transform` need to be upstreamed.

Below is Claude's summary:

---

## Summary

Mathlib now provides the modular discriminant with all its fundamental properties (`Mathlib.NumberTheory.ModularForms.Discriminant`, `LevelOne/DimensionFormula`), so `Delta.lean` no longer re-derives them. `Delta.lean` goes **313 → 151 lines**; project-wide **+125 / −337**.

### `Δ` is now mathlib's discriminant
- `notation "Δ" => ModularForm.discriminant` — every `Δ z` in the project is literally `ModularForm.discriminant z`, so all mathlib `discriminant_*` lemmas apply directly.
- The old q-product definition survives as the lemma `Δ_eq_cexp_prod`; `DiscriminantProductFormula` (ℕ⁺-indexed) is derived from it.

### Deleted (all were re-derivations or renamings of mathlib facts)
- `def Δ`, `Δ_eq_discriminant`, `Δ_ne_zero`, `Discriminant_S/T_invariant`, `Discriminant_SIF`, `Discriminant_zeroAtImInfty`, `term_ne_zero`, `Delta_eq_eta_pow`, `Delta_isTheta_rexp`, `cexp_aux1/2/3` (inlined), and two of the three multipliability lemmas (merged into `MultipliableEtaProductExpansion_pnat`).
- **The `Delta : CuspForm (Gamma 1) 12` bundle**: JacobiIdentity's dimension-one argument now uses mathlib's `CuspForm.exists_smul_discriminant_of_weight_eq_twelve`, bridging `Γ(1)` to `𝒮ℒ` with a single `rw [CongruenceSubgroup.Gamma_one_coe_eq_SL]` under the `∀ f` binder. This also removes `rank_cuspForm_congr`, `finrank_cuspform_12` (JacobiIdentity) and `Delta_ne_zero` (Eisenstein); `ComplexIntegrands` uses `CuspForm.discriminant.holo'`.
- Dead code: `Delta_E4_eqn` (no consumers) and its orphaned chain `Delta_E4_E6_eq`, `Delta_E4_E6_aux`.

### Kept in `Delta.lean` (each with verified downstream consumers)
`MultipliableEtaProductExpansion_pnat`, `Δ_eq_cexp_prod`, `DiscriminantProductFormula`, pointwise `Δ_periodic`/`Δ_S_transform` (used by PhiTransform; absent from mathlib — upstreaming candidates), `Δ_boundedfactor`, `Complex.im_pow_eq_zero_of_im_eq_zero`, `Δ_imag_axis_pos`. `Δ_periodic` is now a one-term proof via `SlashInvariantForm.vAdd_apply_of_mem_strictPeriods`.

### Renames
`Delta_eq_H₂_H₃_H₄` → `Δ_eq_H₂_H₃_H₄`, `Delta_boundedfactor` → `Δ_boundedfactor`, `Delta_imag_axis_pos` → `Δ_imag_axis_pos`.

### Notes
- `E4E6_coeff_zero_eq_zero` (Eisenstein) is now consumer-less; left for the Eisenstein cleanup PR.
- Full `lake build` green (3492 jobs), no new `sorry`, style-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
