### PR TITLE
chore: drop redundant ge_iff_le/gt_iff_lt simp args

### DIFF
--- a/SpherePacking/Basic/PeriodicPacking.lean
+++ b/SpherePacking/Basic/PeriodicPacking.lean
@@ -834,7 +834,7 @@ private lemma aux_bhavik {d : ℝ} {ε : ℝ≥0∞} (hd : 0 ≤ d) (hε : 0 < �
     case ha => simp
     obtain ⟨k, hk⟩ := this ε hε
     refine ⟨max 0 k, by simp, ?_⟩
-    simp only [ge_iff_le, max_le_iff, and_imp]
+    simp only [max_le_iff, and_imp]
     intro k' hk₀ hk₁
     have := hk k' hk₁
     rwa [sub_zero, ofReal_one, one_rpow, ←one_div, one_sub_div, add_sub_cancel_right,

--- a/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
+++ b/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
@@ -50,7 +50,7 @@ lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero
   simp only [NormedAddGroup.tendsto_nhds_zero, eventually_atTop]
   intro ε hε
   obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) <| by
-    simp only [one_div, gt_iff_lt, inv_pos, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
+    simp only [one_div, inv_pos, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
     exact (div_pos hε (abs_sub_pos.mpr hne.symm))
   use M
   intro y hy

--- a/SpherePacking/ForMathlib/InvPowSummability.lean
+++ b/SpherePacking/ForMathlib/InvPowSummability.lean
@@ -92,7 +92,7 @@ theorem Summable_of_Inv_Pow_Summable'
     let k := d + 1
     have hk' : 0 < k := by positivity
     rw [Inv_Pow_Norm_Summable_Over_Set_Euclidean] at hX
-    simp only [one_div, summable_iff_vanishing_norm, gt_iff_lt, Real.norm_eq_abs] at hX
+    simp only [one_div, summable_iff_vanishing_norm, Real.norm_eq_abs] at hX
     obtain ⟨C, hC⟩ := hf k
     simp only [Real.norm_eq_abs] at hC
     have hC_nonneg : 0 ≤ C := by
@@ -239,7 +239,7 @@ theorem Summable_Inverse_Powers_of_Finite_Orbits
   [Finite (Quotient ρ.orbitRel)]
   : Inv_Pow_Norm_Summable_Over_Set_Euclidean X := by
   rw [Inv_Pow_Norm_Summable_Over_Set_Euclidean]
-  simp only [one_div, summable_iff_vanishing_norm, gt_iff_lt, Real.norm_eq_abs]
+  simp only [one_div, summable_iff_vanishing_norm, Real.norm_eq_abs]
   intro ε hε
   -- Translating and scaling fundamental domains could be a good idea - discussion with Bhavik
   let bℤ : Basis _ ℤ Λ :=

--- a/SpherePacking/MagicFunction/IntegralParametrisations.lean
+++ b/SpherePacking/MagicFunction/IntegralParametrisations.lean
@@ -57,7 +57,7 @@ open scoped UpperHalfPlane
 lemma im_z₁'_pos {t : ℝ} (ht : t ∈ Ioc 0 1) : 0 < (z₁' t).im := by
   have ht' : t ∈ Icc 0 1 := mem_Icc_of_Ioc ht
   simp only [z₁', IccExtend_of_mem zero_le_one z₁ ht', z₁, add_im, neg_im, one_im, neg_zero, mul_im,
-    I_re, ofReal_im, mul_zero, I_im, ofReal_re, one_mul, zero_add, gt_iff_lt]
+    I_re, ofReal_im, mul_zero, I_im, ofReal_re, one_mul, zero_add]
   exact ht.1
 
 lemma im_z₂'_pos {t : ℝ} (ht : t ∈ Icc 0 1) : 0 < (z₂' t).im := by
@@ -66,7 +66,7 @@ lemma im_z₂'_pos {t : ℝ} (ht : t ∈ Icc 0 1) : 0 < (z₂' t).im := by
 lemma im_z₃'_pos {t : ℝ} (ht : t ∈ Ioc 0 1) : 0 < (z₃' t).im := by
   have ht' : t ∈ Icc 0 1 := mem_Icc_of_Ioc ht
   simp only [z₃', IccExtend_of_mem zero_le_one z₃ ht', z₃, add_im, one_im, mul_im, I_re, ofReal_im,
-    mul_zero, I_im, ofReal_re, one_mul, zero_add, gt_iff_lt]
+    mul_zero, I_im, ofReal_re, one_mul, zero_add]
   exact ht.1
 
 lemma im_z₄'_pos {t : ℝ} (ht : t ∈ Icc 0 1) : 0 < (z₄' t).im := by
@@ -75,7 +75,7 @@ lemma im_z₄'_pos {t : ℝ} (ht : t ∈ Icc 0 1) : 0 < (z₄' t).im := by
 lemma im_z₅'_pos {t : ℝ} (ht : t ∈ Ioc 0 1) : 0 < (z₅' t).im := by
   have ht' : t ∈ Icc 0 1 := mem_Icc_of_Ioc ht
   simp only [z₅', IccExtend_of_mem zero_le_one z₅ ht', z₅, mul_im, I_re, ofReal_im, mul_zero, I_im,
-    ofReal_re, one_mul, zero_add, gt_iff_lt]
+    ofReal_re, one_mul, zero_add]
   exact ht.1
 
 lemma im_z₆'_pos {t : ℝ} (ht : t ∈ Ici (1 : ℝ)) : 0 < (z₆' t).im := by

--- a/SpherePacking/ModularForms/clog_arg_lems.lean
+++ b/SpherePacking/ModularForms/clog_arg_lems.lean
@@ -37,13 +37,13 @@ lemma arg_pow_aux (n : ℕ) (x : ℂ) (hx : x ≠ 0) (hna : |arg x| < π / n) :
           rw [← neg_div] at hnal
           rw [div_lt_iff₀' ] at hnal
           · rw [Nat.cast_add, add_mul] at hnal
-            simpa only [gt_iff_lt, Nat.cast_one, one_mul] using hnal
+            simpa only [Nat.cast_one, one_mul] using hnal
           · norm_cast
             omega
         · have hnal := hna.2
           rw [lt_div_iff₀', Nat.cast_add] at hnal
           · rw [add_mul] at hnal
-            simpa only [ge_iff_le, Nat.cast_one, one_mul] using hnal.le
+            simpa only [Nat.cast_one, one_mul] using hnal.le
           · norm_cast
             omega
       apply lt_trans hna
@@ -67,7 +67,7 @@ lemma arg_pow (n : ℕ) (f : ℕ → ℂ) (hf : Tendsto f atTop (𝓝 0)) : ∀�
     have h3 := h2.comp hf1
     simp only [arg_one] at h3
     rw [Metric.tendsto_nhds] at *
-    simp only [gt_iff_lt, dist_zero_right, eventually_atTop,
+    simp only [dist_zero_right, eventually_atTop,
       dist_self_add_left, arg_one, Real.norm_eq_abs, comp_apply] at *
     by_cases hn0 : n = 0
     · rw [hn0]
@@ -99,7 +99,7 @@ lemma arg_pow2 (n : ℕ) (f : ℍ → ℂ) (hf : Tendsto f atImInfty (𝓝 0)) :
     have h3 := h2.comp hf1
     simp only [arg_one] at h3
     rw [Metric.tendsto_nhds] at *
-    simp only [gt_iff_lt, dist_zero_right, dist_self_add_left, arg_one, Real.norm_eq_abs,
+    simp only [dist_zero_right, dist_self_add_left, arg_one, Real.norm_eq_abs,
       comp_apply] at *
     by_cases hn0 : n = 0
     · simp_rw [hn0]


### PR DESCRIPTION
These are Iff.rfl lemmas over reducible ≥/> notation, so simp already sees through them; listing them in `simp only`/`simpa only` is flagged by the unused-simp-args linter. Removes the remaining occurrences, leaving the load-bearing `rw [ge_iff_le]`/`rw [gt_iff_lt]` sites intact.