### PR TITLE
Add rotation characterization for equal norms in inner product spaces

### DIFF
--- a/SpherePacking/ForMathlib/RadialSchwartz/Basic.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/Basic.lean
@@ -33,15 +33,59 @@ structure RadialSchwartzMap extends SchwartzMap E F where
 
 section Rotation
 
-/- Transitivity of the orthogonal group on spheres requires an inner product: in a general normed
-space, linear isometries need not act transitively on spheres (e.g. `ℝ²` with the sup norm). -/
+open Module
+
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
 
-/-- In a real inner product space, any two vectors of the same norm are related by a rotation,
-formalised here as a linear isometry equivalence. The witness is the reflection through the
-hyperplane orthogonal to `x - y`. -/
-theorem exists_linearIsometryEquiv_apply_eq_of_norm_eq {x y : V} (h : ‖x‖ = ‖y‖) :
-    ∃ T : V ≃ₗᵢ[ℝ] V, T x = y :=
-  ⟨Submodule.reflection (ℝ ∙ (x - y))ᗮ, Submodule.reflection_sub h⟩
+/-- The reflection through the hyperplane orthogonal to a nonzero vector has determinant `-1`. -/
+private theorem det_reflection_orthogonal_span_singleton [FiniteDimensional ℝ V] {v : V}
+    (hv : v ≠ 0) : LinearMap.det (Submodule.reflection (ℝ ∙ v)ᗮ).toLinearMap = -1 := by
+  rw [Submodule.det_reflection, Submodule.orthogonal_orthogonal, finrank_span_singleton hv,
+    pow_one]
+
+/-- In a real inner product space that is not one-dimensional, two vectors have the same norm if
+and only if there is a rotation (a linear isometry equivalence of determinant `1`) mapping one to
+the other.
+
+The hypothesis `finrank ℝ V ≠ 1` is necessary: in `ℝ` the only rotation is the identity, yet
+`‖1‖ = ‖-1‖`. It holds both for finite-dimensional spaces of dimension `≠ 1` and for
+infinite-dimensional spaces, where `finrank` is `0` and the determinant condition is vacuous
+(by convention `LinearMap.det` is `1` there). The inner product structure also matters: in a
+general normed space, linear isometries need not act transitively on spheres (e.g. `ℝ²` with the
+sup norm). -/
+theorem norm_eq_iff_exists_rotation (hV : finrank ℝ V ≠ 1) (x y : V) :
+    ‖x‖ = ‖y‖ ↔ ∃ T : V ≃ₗᵢ[ℝ] V, LinearMap.det T.toLinearMap = 1 ∧ T x = y := by
+  refine ⟨fun h => ?_, fun ⟨T, _, hTx⟩ => by rw [← hTx]; exact (T.norm_map x).symm⟩
+  by_cases hfin : FiniteDimensional ℝ V
+  · rcases eq_or_ne x y with rfl | hxy
+    · exact ⟨.refl ℝ V, LinearMap.det_id, rfl⟩
+    have hy : y ≠ 0 := by
+      rintro rfl
+      exact hxy (norm_eq_zero.mp (h.trans norm_zero))
+    -- Since `V` is not a line, there is a nonzero vector `u` orthogonal to `y`.
+    obtain ⟨u, hu_mem, hu⟩ : ∃ u ∈ (ℝ ∙ y)ᗮ, u ≠ 0 := by
+      rw [← Submodule.ne_bot_iff]
+      intro hbot
+      exact hV (by
+        rw [← finrank_span_singleton hy, Submodule.orthogonal_eq_bot_iff.mp hbot, finrank_top])
+    -- Composing the reflection sending `x` to `y` with a reflection fixing `y` gives a rotation
+    -- sending `x` to `y`.
+    refine ⟨(Submodule.reflection (ℝ ∙ (x - y))ᗮ).trans (Submodule.reflection (ℝ ∙ u)ᗮ), ?_, ?_⟩
+    · rw [show ((Submodule.reflection (ℝ ∙ (x - y))ᗮ).trans
+            (Submodule.reflection (ℝ ∙ u)ᗮ)).toLinearMap =
+          (Submodule.reflection (ℝ ∙ u)ᗮ).toLinearMap ∘ₗ
+            (Submodule.reflection (ℝ ∙ (x - y))ᗮ).toLinearMap from rfl,
+        LinearMap.det_comp, det_reflection_orthogonal_span_singleton hu,
+        det_reflection_orthogonal_span_singleton (sub_ne_zero.mpr hxy)]
+      norm_num
+    · rw [LinearIsometryEquiv.trans_apply, Submodule.reflection_sub h]
+      refine Submodule.reflection_mem_subspace_eq_self ?_
+      rw [Submodule.mem_orthogonal_singleton_iff_inner_left, real_inner_comm]
+      exact Submodule.mem_orthogonal_singleton_iff_inner_left.mp hu_mem
+  · -- In infinite dimension every determinant is `1`, so the reflection sending `x` to `y`
+    -- already counts as a rotation.
+    exact ⟨Submodule.reflection (ℝ ∙ (x - y))ᗮ,
+      LinearMap.det_eq_one_of_finrank_eq_zero (finrank_of_infinite_dimensional hfin) _,
+      Submodule.reflection_sub h⟩
 
 end Rotation

--- a/SpherePacking/ForMathlib/RadialSchwartz/Basic.lean
+++ b/SpherePacking/ForMathlib/RadialSchwartz/Basic.lean
@@ -31,4 +31,17 @@ variable [NormedAddCommGroup F] [NormedSpace ℝ F]
 structure RadialSchwartzMap extends SchwartzMap E F where
   radial : ∀ x y : E, ‖x‖ = ‖y‖ → toSchwartzMap x = toSchwartzMap y
 
+section Rotation
 
+/- Transitivity of the orthogonal group on spheres requires an inner product: in a general normed
+space, linear isometries need not act transitively on spheres (e.g. `ℝ²` with the sup norm). -/
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- In a real inner product space, any two vectors of the same norm are related by a rotation,
+formalised here as a linear isometry equivalence. The witness is the reflection through the
+hyperplane orthogonal to `x - y`. -/
+theorem exists_linearIsometryEquiv_apply_eq_of_norm_eq {x y : V} (h : ‖x‖ = ‖y‖) :
+    ∃ T : V ≃ₗᵢ[ℝ] V, T x = y :=
+  ⟨Submodule.reflection (ℝ ∙ (x - y))ᗮ, Submodule.reflection_sub h⟩
+
+end Rotation


### PR DESCRIPTION
## Summary
This PR adds a theorem characterizing when two vectors in a real inner product space have equal norms in terms of the existence of a rotation (linear isometry of determinant 1) mapping one to the other.

## Key Changes
- Added `norm_eq_iff_exists_rotation`: A theorem stating that in a finite-dimensional inner product space of dimension ≠ 1 (or any infinite-dimensional inner product space), two vectors have equal norm if and only if there exists a rotation mapping one to the other
- Added `det_reflection_orthogonal_span_singleton`: A helper lemma proving that reflection through a hyperplane orthogonal to a nonzero vector has determinant -1
- Implemented the proof by composing two reflections in the finite-dimensional case to construct a rotation with determinant 1
- Handled the infinite-dimensional case separately, where all determinants are conventionally 1

## Notable Implementation Details
- The dimension restriction `finrank ℝ V ≠ 1` is necessary because in 1D spaces (like ℝ), the only rotation is the identity, yet vectors like 1 and -1 have equal norms
- The proof uses the composition of two reflections: one sending x to y, and another fixing y, to construct a rotation
- The inner product structure is essential; the result does not hold for general normed spaces (e.g., ℝ² with sup norm)
- Special handling for infinite-dimensional spaces where `finrank` is 0 and the determinant condition is vacuous

https://claude.ai/code/session_01YRYtBTjyaV6VWDsSePZtSp