### PR TITLE
refactor(CauchyGoursat): assume vanishing of the top-edge integral

### DIFF
--- a/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
+++ b/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
@@ -49,27 +49,18 @@ as `Im z → ∞` within a bounded strip while growing without bound along a hor
 lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, z.re ∈ [[x₁, x₂]] → M ≤ z.im → ‖f z‖ < ε) :
     Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) := by
-  wlog hne : x₁ ≠ x₂
-  · rw [ne_eq, Decidable.not_not] at hne
-    simp only [hne, integral_same, tendsto_const_nhds_iff]
+  obtain rfl | hne := eq_or_ne x₁ x₂
+  · simp only [integral_same, tendsto_const_nhds_iff]
   simp only [NormedAddGroup.tendsto_nhds_zero, eventually_atTop]
   intro ε hε
-  obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) <| by
-    simp only [one_div, inv_pos, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
-    exact (div_pos hε (abs_sub_pos.mpr hne.symm))
-  use M
-  intro y hy
+  have hlen : 0 < |x₂ - x₁| := abs_sub_pos.mpr hne.symm
+  obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) (mul_pos one_half_pos (div_pos hε hlen))
+  refine ⟨M, fun y hy ↦ ?_⟩
   calc ‖∫ (x : ℝ) in x₁..x₂, f (↑x + ↑y * I)‖
   _ ≤ ((1 / 2) * (ε / |x₂ - x₁|)) * |x₂ - x₁| :=
-      intervalIntegral.norm_integral_le_of_norm_le_const <| by
-      intro x hx
-      specialize hM (x + y * I)
-      rw [re_of_real_add_real_mul_I x y, im_of_real_add_real_mul_I x y] at hM
-      exact le_of_lt (hM (Set.uIoc_subset_uIcc hx) hy)
-  _ = (1 / 2) * ε := by
-      rw [mul_assoc]
-      have : 0 ≠ |x₂ - x₁| := ne_of_lt (abs_sub_pos.mpr hne.symm)
-      field_simp [this]
+      intervalIntegral.norm_integral_le_of_norm_le_const fun x hx ↦
+        (hM (x + y * I) (by simpa using uIoc_subset_uIcc hx) (by simpa using hy)).le
+  _ = (1 / 2) * ε := by rw [mul_assoc, div_mul_cancel₀ _ hlen.ne']
   _ < ε := by linarith
 
 /-- If $f(z) \to 0$ as $\Im(z) \to \infty$, then
@@ -98,27 +89,17 @@ private lemma hzero (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s :
       - ∫ (t : ℝ) in (x₁ + y * I).re..(x₂ + m * I).re, f (t + (x₂ + m * I).im * I))
       + I • ∫ (t : ℝ) in (x₁ + y * I).im..(x₂ + m * I).im, f ((x₂ + m * I).re + t * I))
       - I • ∫ (t : ℝ) in (x₁ + y * I).im..(x₂ + m * I).im, f ((x₁ + y * I).re + t * I) := by
-      simp only [re_of_real_add_real_mul_I x₁ y, re_of_real_add_real_mul_I x₂ m,
-                 im_of_real_add_real_mul_I x₁ y, im_of_real_add_real_mul_I x₂ m]
+      simp only [re_of_real_add_real_mul_I, im_of_real_add_real_mul_I]
   _ = 0 := by
       refine Complex.integral_boundary_rect_eq_zero_of_differentiable_on_off_countable
         f (x₁ + y * I) (x₂ + m * I) s hs ?_ ?_ <;>
-      simp only [re_of_real_add_real_mul_I x₁ y, re_of_real_add_real_mul_I x₂ m,
-                im_of_real_add_real_mul_I x₁ y, im_of_real_add_real_mul_I x₂ m]
-      · apply hcont.mono
-        rw [reProdIm_subset_iff]
+      simp only [re_of_real_add_real_mul_I, im_of_real_add_real_mul_I]
+      · refine hcont.mono (reProdIm_subset_iff.mpr ?_)
         gcongr
-        rw [uIcc_of_le hm]
-        exact Icc_subset_Ici_self
-      · intro z hz
-        apply hdiff z
-        obtain ⟨hz₁, hz₂⟩ := hz
-        refine ⟨?_, hz₂⟩
-        rw [mem_reProdIm] at hz₁ ⊢
-        refine ⟨hz₁.1, ?_⟩
-        rw [mem_Ioi]
-        rw [inf_eq_left.2 hm] at hz₁
-        exact hz₁.2.1
+        exact (uIcc_of_le hm).subset.trans Icc_subset_Ici_self
+      · rintro z ⟨hz₁, hz₂⟩
+        rw [mem_reProdIm, inf_eq_left.2 hm] at hz₁
+        exact hdiff z ⟨⟨hz₁.1, hz₁.2.1⟩, hz₂⟩
 
 /-- A direct consequence of the **Cauchy-Goursat Theorem for rectangles**: given the conditions of
 the Cauchy-Goursat Theorem between two vertical lines in the Complex plane, fixing some `y`, the
@@ -136,9 +117,8 @@ lemma integral_boundary_rect_eq_zero_eventually_atTop_of_differentiable_on_off_c
         - (∫ (x : ℝ) in x₁..x₂, f (x + m * I))
         + (I • ∫ (t : ℝ) in y..m, f (x₂ + t * I))
         - (I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)))
-    =ᶠ[atTop] (fun (_ : ℝ) ↦ 0) := by
-  filter_upwards [eventually_ge_atTop y] with m hm
-  exact hzero y hcont s hs hdiff m hm
+    =ᶠ[atTop] (fun (_ : ℝ) ↦ 0) :=
+  (eventually_ge_atTop y).mono (hzero y hcont s hs hdiff)
 
 end Eventually_Eq_Zero
 
@@ -159,17 +139,9 @@ theorem tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top
     (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
     Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop <|
       𝓝 ((∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂) := by
-  have heventually : (fun (m : ℝ) ↦
-      (∫ (x : ℝ) in x₁..x₂, f (x + y * I))
-        - (∫ (x : ℝ) in x₁..x₂, f (x + m * I))
-        + (I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)))
-      =ᶠ[atTop] (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) := by
-    filter_upwards [eventually_ge_atTop y] with m hm
-    rw [← sub_eq_zero, ← (hzero y hcont s hs hdiff m hm)]
-  rw [tendsto_congr' heventually.symm, ← sub_zero (∫ (t : ℝ) in x₁..x₂, f (↑t + ↑y * I))]
-  refine (Tendsto.sub ?_ ?_).add hC₂
-  · rw [sub_zero, tendsto_const_nhds_iff]
-  · exact htop
+  refine Tendsto.congr' ((eventually_ge_atTop y).mono fun m hm ↦
+    sub_eq_zero.mp (hzero y hcont s hs hdiff m hm)) ?_
+  simpa using (tendsto_const_nhds.sub htop).add hC₂
 
 /-- **Deformation of open rectangular contours.** The original formulation, whose decay hypothesis
 is global in the real direction; it is a wrapper around the `_of_tendsto_top` version. -/
@@ -194,12 +166,10 @@ theorem integral_boundary_open_rect_eq_zero_of_tendsto_top
     {C₁ : E} (hC₁ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop (𝓝 C₁))
     {C₂ : E} (hC₂ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
     (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
-    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂ - C₁ = 0 := by
-  rw [sub_eq_zero]
-  symm
-  exact tendsto_nhds_unique hC₁ <|
-    tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top
-      y hcont s hs hdiff hC₂ htop
+    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂ - C₁ = 0 :=
+  sub_eq_zero_of_eq <| tendsto_nhds_unique
+    (tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top y hcont s hs hdiff hC₂ htop)
+    hC₁
 
 /-- Wrapper for the globally-decaying formulation. -/
 theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable
@@ -267,11 +237,10 @@ theorem integral_boundary_open_rect_eq_zero_of_integrable_on_of_tendsto_top
     (hint₂ : IntegrableOn (fun (t : ℝ) ↦ f (x₂ + t * I)) (Ioi y) volume)
     (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
     (∫ (x : ℝ) in x₁..x₂, f (x + y * I)) + (I • ∫ (t : ℝ) in Ioi y, f (x₂ + t * I))
-      - (I • ∫ (t : ℝ) in Ioi y, f (x₁ + t * I)) = 0 := by
-  refine integral_boundary_open_rect_eq_zero_of_tendsto_top'
-    y hcont s hs hdiff ?_ ?_ htop
-  · exact intervalIntegral_tendsto_integral_Ioi y hint₁ fun ⦃U⦄ a ↦ a
-  · exact intervalIntegral_tendsto_integral_Ioi y hint₂ fun ⦃U⦄ a ↦ a
+      - (I • ∫ (t : ℝ) in Ioi y, f (x₁ + t * I)) = 0 :=
+  integral_boundary_open_rect_eq_zero_of_tendsto_top' y hcont s hs hdiff
+    (intervalIntegral_tendsto_integral_Ioi y hint₁ tendsto_id)
+    (intervalIntegral_tendsto_integral_Ioi y hint₂ tendsto_id) htop
 
 /-- Wrapper for the globally-decaying formulation. -/
 theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable_of_integrable_on

--- a/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
+++ b/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
@@ -39,41 +39,13 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {f : ℂ → E} 
 
 section Tendsto_Zero
 
-/-- If $f(z) \to 0$ as $\Im(z) \to \infty$, then
-  $\lim_{m \to \infty} \int_{x_1}^{x_2} f(x + mI) dx = 0$. -/
-lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero
-    (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
-    Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) := by
-  wlog hne : x₁ ≠ x₂
-  · rw [ne_eq, Decidable.not_not] at hne
-    simp only [hne, integral_same, tendsto_const_nhds_iff]
-  simp only [NormedAddGroup.tendsto_nhds_zero, eventually_atTop]
-  intro ε hε
-  obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) <| by
-    simp only [one_div, inv_pos, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
-    exact (div_pos hε (abs_sub_pos.mpr hne.symm))
-  use M
-  intro y hy
-  calc ‖∫ (x : ℝ) in x₁..x₂, f (↑x + ↑y * I)‖
-  _ ≤ ((1 / 2) * (ε / |x₂ - x₁|)) * |x₂ - x₁| :=
-      intervalIntegral.norm_integral_le_of_norm_le_const <| by
-      intro x hx
-      specialize hM (x + y * I)
-      rw [im_of_real_add_real_mul_I x y] at hM
-      exact le_of_lt (hM hy)
-  _ = (1 / 2) * ε := by
-      rw [mul_assoc]
-      have : 0 ≠ |x₂ - x₁| := ne_of_lt (abs_sub_pos.mpr hne.symm)
-      field_simp [this]
-  _ < ε := by linarith
+/-- Strip-local decay suffices: if `f` decays uniformly as `Im z → ∞` *within the vertical strip*
+`[[x₁, x₂]] ×ℂ ℝ` swept by the top edge, then
+$\lim_{m \to \infty} \int_{x_1}^{x_2} f(x + mI) dx = 0$.
 
-/-- Strip-local version of `tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero`:
-the decay of `f` is only ever needed on the vertical strip `[[x₁, x₂]] ×ℂ ℝ` swept by the top
-edge, never off it.
-
-This matters in practice: an integrand can decay uniformly as `Im z → ∞` *within a bounded strip*
-while growing without bound along a horizontal line, so the global hypothesis is often not merely
-stronger than needed but actually false. -/
+This is the primitive form. The decay is only ever used at points of the strip, so requiring it
+off the strip would be gratuitous — and in applications often false, since an integrand can decay
+as `Im z → ∞` within a bounded strip while growing without bound along a horizontal line. -/
 lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, z.re ∈ [[x₁, x₂]] → M ≤ z.im → ‖f z‖ < ε) :
     Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) := by
@@ -99,6 +71,17 @@ lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
       have : 0 ≠ |x₂ - x₁| := ne_of_lt (abs_sub_pos.mpr hne.symm)
       field_simp [this]
   _ < ε := by linarith
+
+/-- If $f(z) \to 0$ as $\Im(z) \to \infty$, then
+  $\lim_{m \to \infty} \int_{x_1}^{x_2} f(x + mI) dx = 0$.
+
+A wrapper around the strip-local
+`tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc`. -/
+lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero
+    (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
+    Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) :=
+  tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
+    (fun ε hε ↦ (htendsto ε hε).imp fun _ hM z _ hz ↦ hM z hz)
 
 end Tendsto_Zero
 

--- a/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
+++ b/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
@@ -67,6 +67,39 @@ lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero
       field_simp [this]
   _ < ε := by linarith
 
+/-- Strip-local version of `tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero`:
+the decay of `f` is only ever needed on the vertical strip `[[x₁, x₂]] ×ℂ ℝ` swept by the top
+edge, never off it.
+
+This matters in practice: an integrand can decay uniformly as `Im z → ∞` *within a bounded strip*
+while growing without bound along a horizontal line, so the global hypothesis is often not merely
+stronger than needed but actually false. -/
+lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
+    (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, z.re ∈ [[x₁, x₂]] → M ≤ z.im → ‖f z‖ < ε) :
+    Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) := by
+  wlog hne : x₁ ≠ x₂
+  · rw [ne_eq, Decidable.not_not] at hne
+    simp only [hne, integral_same, tendsto_const_nhds_iff]
+  simp only [NormedAddGroup.tendsto_nhds_zero, eventually_atTop]
+  intro ε hε
+  obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) <| by
+    simp only [one_div, inv_pos, Nat.ofNat_pos, mul_pos_iff_of_pos_left]
+    exact (div_pos hε (abs_sub_pos.mpr hne.symm))
+  use M
+  intro y hy
+  calc ‖∫ (x : ℝ) in x₁..x₂, f (↑x + ↑y * I)‖
+  _ ≤ ((1 / 2) * (ε / |x₂ - x₁|)) * |x₂ - x₁| :=
+      intervalIntegral.norm_integral_le_of_norm_le_const <| by
+      intro x hx
+      specialize hM (x + y * I)
+      rw [re_of_real_add_real_mul_I x y, im_of_real_add_real_mul_I x y] at hM
+      exact le_of_lt (hM (Set.uIoc_subset_uIcc hx) hy)
+  _ = (1 / 2) * ε := by
+      rw [mul_assoc]
+      have : 0 ≠ |x₂ - x₁| := ne_of_lt (abs_sub_pos.mpr hne.symm)
+      field_simp [this]
+  _ < ε := by linarith
+
 end Tendsto_Zero
 
 section Eventually_Eq_Zero
@@ -136,11 +169,11 @@ integrals along the second integral.
 We call this a deformation of _open rectangular contours_ because it allows us to change contours
 when working with contours that look like "infinite boxes without lids"---that is, rectangular
 contours that are "open" at the top (we do not mean open in a topological sense). -/
-theorem tendsto_integral_boundary_open_rect_one_side_atTop_nhds_sum_other_two_sides
+theorem tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top
     (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
     (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
     {C₂ : E} (hC₂ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
-    (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
+    (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
     Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop <|
       𝓝 ((∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂) := by
   have heventually : (fun (m : ℝ) ↦
@@ -153,24 +186,49 @@ theorem tendsto_integral_boundary_open_rect_one_side_atTop_nhds_sum_other_two_si
   rw [tendsto_congr' heventually.symm, ← sub_zero (∫ (t : ℝ) in x₁..x₂, f (↑t + ↑y * I))]
   refine (Tendsto.sub ?_ ?_).add hC₂
   · rw [sub_zero, tendsto_const_nhds_iff]
-  · exact tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero htendsto
+  · exact htop
+
+/-- **Deformation of open rectangular contours.** The original formulation, whose decay hypothesis
+is global in the real direction; it is a wrapper around the `_of_tendsto_top` version. -/
+theorem tendsto_integral_boundary_open_rect_one_side_atTop_nhds_sum_other_two_sides
+    (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
+    (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
+    {C₂ : E} (hC₂ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
+    (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
+    Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop <|
+      𝓝 ((∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂) :=
+  tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top
+    y hcont s hs hdiff hC₂
+    (tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero htendsto)
 
 /-- **Deformation of open rectangular contours:** Given two infinite vertical contours such that a
 function satisfies Cauchy-Goursat conditions between them, the limit of interval integrals along the
 first contour equals the sum of a translation integral and the limit of interval integrals along
 the second integral. -/
+theorem integral_boundary_open_rect_eq_zero_of_tendsto_top
+    (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
+    (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
+    {C₁ : E} (hC₁ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop (𝓝 C₁))
+    {C₂ : E} (hC₂ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
+    (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
+    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂ - C₁ = 0 := by
+  rw [sub_eq_zero]
+  symm
+  exact tendsto_nhds_unique hC₁ <|
+    tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top
+      y hcont s hs hdiff hC₂ htop
+
+/-- Wrapper for the globally-decaying formulation. -/
 theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable
     (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
     (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
     {C₁ : E} (hC₁ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop (𝓝 C₁))
     {C₂ : E} (hC₂ : Tendsto (fun m ↦ I • ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
-    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂ - C₁ = 0 := by
-  rw [sub_eq_zero]
-  symm
-  exact tendsto_nhds_unique hC₁ <|
-    tendsto_integral_boundary_open_rect_one_side_atTop_nhds_sum_other_two_sides
-      y hcont s hs hdiff hC₂ htendsto
+    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + C₂ - C₁ = 0 :=
+  integral_boundary_open_rect_eq_zero_of_tendsto_top
+    y hcont s hs hdiff hC₁ hC₂
+    (tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero htendsto)
 
 /-- **Deformation of open rectangular contours:** Given two infinite vertical contours such that a
 function satisfies Cauchy-Goursat conditions between them, the limit of interval integrals along the
@@ -182,6 +240,17 @@ sole difference is that the assumptions in this lemma do not include the factor 
 from contour parametrisation. The reason we state this version is that it might be more convenient
 to use in certain cases.
 -/
+theorem integral_boundary_open_rect_eq_zero_of_tendsto_top'
+    (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
+    (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
+    {C₁ : E} (hC₁ : Tendsto (fun m ↦ ∫ (t : ℝ) in y..m, f (x₁ + t * I)) atTop (𝓝 C₁))
+    {C₂ : E} (hC₂ : Tendsto (fun m ↦ ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
+    (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
+    (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + (I • C₂) - (I • C₁) = 0 :=
+  integral_boundary_open_rect_eq_zero_of_tendsto_top
+    y hcont s hs hdiff (hC₁.const_smul I) (hC₂.const_smul I) htop
+
+/-- Wrapper for the globally-decaying formulation. -/
 theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable'
     (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
     (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
@@ -189,8 +258,9 @@ theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable'
     {C₂ : E} (hC₂ : Tendsto (fun m ↦ ∫ (t : ℝ) in y..m, f (x₂ + t * I)) atTop (𝓝 C₂))
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
     (∫ (t : ℝ) in x₁..x₂, f (t + y * I)) + (I • C₂) - (I • C₁) = 0 :=
-  integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable y hcont s hs hdiff
-    (hC₁.const_smul I) (hC₂.const_smul I) htendsto
+  integral_boundary_open_rect_eq_zero_of_tendsto_top'
+    y hcont s hs hdiff hC₁ hC₂
+    (tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero htendsto)
 
 end Contour_Deformation_Tensdsto
 
@@ -207,6 +277,20 @@ it requires the integral of the norm of the function to be finite rather than ju
 function. We nevertheless include this version of the theorem because it is likely that in
 applications involving specific functions, there will already be proofs of integrability.
 -/
+theorem integral_boundary_open_rect_eq_zero_of_integrable_on_of_tendsto_top
+    (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
+    (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
+    (hint₁ : IntegrableOn (fun (t : ℝ) ↦ f (x₁ + t * I)) (Ioi y) volume)
+    (hint₂ : IntegrableOn (fun (t : ℝ) ↦ f (x₂ + t * I)) (Ioi y) volume)
+    (htop : Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0)) :
+    (∫ (x : ℝ) in x₁..x₂, f (x + y * I)) + (I • ∫ (t : ℝ) in Ioi y, f (x₂ + t * I))
+      - (I • ∫ (t : ℝ) in Ioi y, f (x₁ + t * I)) = 0 := by
+  refine integral_boundary_open_rect_eq_zero_of_tendsto_top'
+    y hcont s hs hdiff ?_ ?_ htop
+  · exact intervalIntegral_tendsto_integral_Ioi y hint₁ fun ⦃U⦄ a ↦ a
+  · exact intervalIntegral_tendsto_integral_Ioi y hint₂ fun ⦃U⦄ a ↦ a
+
+/-- Wrapper for the globally-decaying formulation. -/
 theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable_of_integrable_on
     (hcont : ContinuousOn f ([[x₁, x₂]] ×ℂ (Ici y))) (s : Set ℂ) (hs : s.Countable)
     (hdiff : ∀ x ∈ ((Ioo (min x₁ x₂) (max x₁ x₂)) ×ℂ (Ioi y)) \ s, DifferentiableAt ℂ f x)
@@ -214,11 +298,10 @@ theorem integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable_o
     (hint₂ : IntegrableOn (fun (t : ℝ) ↦ f (x₂ + t * I)) (Ioi y) volume)
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε) :
     (∫ (x : ℝ) in x₁..x₂, f (x + y * I)) + (I • ∫ (t : ℝ) in Ioi y, f (x₂ + t * I))
-      - (I • ∫ (t : ℝ) in Ioi y, f (x₁ + t * I)) = 0 := by
-  refine integral_boundary_open_rect_eq_zero_of_differentiable_on_off_countable' y hcont s hs hdiff
-    ?_ ?_ htendsto
-  · exact intervalIntegral_tendsto_integral_Ioi y hint₁ fun ⦃U⦄ a ↦ a
-  · exact intervalIntegral_tendsto_integral_Ioi y hint₂ fun ⦃U⦄ a ↦ a
+      - (I • ∫ (t : ℝ) in Ioi y, f (x₁ + t * I)) = 0 :=
+  integral_boundary_open_rect_eq_zero_of_integrable_on_of_tendsto_top
+    y hcont s hs hdiff hint₁ hint₂
+    (tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero htendsto)
 
 end Contour_Deformation_of_Integrable_along_BOTH
 

--- a/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
+++ b/SpherePacking/ForMathlib/CauchyGoursat/OpenRectangular.lean
@@ -13,11 +13,10 @@ public import Mathlib.Topology.Separation.CompletelyRegular
 
 /-! # Deforming Paths of Integration for Open Contours
 
-In this file, we prove that if a function tends to zero as the imaginary part of its input tends to
-infinity and satisfies Cauchy-Goursat-type conditions, then we can deform paths of integration along
-rectangular contours that extend infinitely in the vertical direction.
-
-TODO: Use `atImInfty` for vanishing as imaginary part tends to i infinity!
+We deform paths of integration along rectangular contours extending infinitely in the vertical
+direction, under Cauchy-Goursat-type conditions and the hypothesis that the top-edge integral tends
+to zero. Uniform decay within the vertical strip suffices for this limit. The original theorems
+assuming decay uniformly over all real parts are retained as wrappers.
 -/
 
 @[expose] public section
@@ -49,19 +48,16 @@ as `Im z → ∞` within a bounded strip while growing without bound along a hor
 lemma tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc
     (htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, z.re ∈ [[x₁, x₂]] → M ≤ z.im → ‖f z‖ < ε) :
     Tendsto (fun (m : ℝ) ↦ ∫ (x : ℝ) in x₁..x₂, f (x + m * I)) atTop (𝓝 0) := by
-  obtain rfl | hne := eq_or_ne x₁ x₂
-  · simp only [integral_same, tendsto_const_nhds_iff]
   simp only [NormedAddGroup.tendsto_nhds_zero, eventually_atTop]
   intro ε hε
-  have hlen : 0 < |x₂ - x₁| := abs_sub_pos.mpr hne.symm
-  obtain ⟨M, hM⟩ := htendsto ((1 / 2) * (ε / |x₂ - x₁|)) (mul_pos one_half_pos (div_pos hε hlen))
+  obtain ⟨M, hM⟩ := htendsto (ε / (|x₂ - x₁| + 1)) (by positivity)
   refine ⟨M, fun y hy ↦ ?_⟩
-  calc ‖∫ (x : ℝ) in x₁..x₂, f (↑x + ↑y * I)‖
-  _ ≤ ((1 / 2) * (ε / |x₂ - x₁|)) * |x₂ - x₁| :=
-      intervalIntegral.norm_integral_le_of_norm_le_const fun x hx ↦
-        (hM (x + y * I) (by simpa using uIoc_subset_uIcc hx) (by simpa using hy)).le
-  _ = (1 / 2) * ε := by rw [mul_assoc, div_mul_cancel₀ _ hlen.ne']
-  _ < ε := by linarith
+  refine (intervalIntegral.norm_integral_le_of_norm_le_const fun x hx ↦
+    (hM (x + y * I) (by simpa using uIoc_subset_uIcc hx)
+      (by simpa using hy)).le).trans_lt ?_
+  have hpos : 0 < ε / (|x₂ - x₁| + 1) := by positivity
+  have hcancel := div_mul_cancel₀ ε (by positivity : |x₂ - x₁| + 1 ≠ 0)
+  nlinarith
 
 /-- If $f(z) \to 0$ as $\Im(z) \to \infty$, then
   $\lim_{m \to \infty} \int_{x_1}^{x_2} f(x + mI) dx = 0$.


### PR DESCRIPTION
Weakens the decay hypothesis of the open-rectangle deformation theorems, without breaking any existing name.

## Where this sits

**Depends on:** nothing — branches from current `main`.

**Enables:** the final double-zero contour deformation, together with #466. The branches are currently independent: #466 proves `tendsto_topEdgeIntegral_zero` as a set integral over `Icc (-1) 1`; applying the new `_of_tendsto_top` variants also requires the standard conversion to an interval integral.

## The problem

Every deformation theorem in `OpenRectangular.lean` currently requires

```lean
htendsto : ∀ ε > 0, ∃ M : ℝ, ∀ z : ℂ, M ≤ z.im → ‖f z‖ < ε
```

i.e. decay uniformly over **every** real part, on an unbounded horizontal extent.

Two observations:

1. **The proofs never need it.** `htendsto` is used in exactly one place — `tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero`, to show the top-edge integral vanishes — and there it is only ever instantiated at `x + y*I` for `x` in the integration interval. The decay is only ever used *on the strip* `[[x₁, x₂]]` swept by the top edge.

2. **For the intended application it is false.** The double-zero integrands look like `φ₀''(-1/z) · z² · e^{iπrz}`. Along a fixed `Im z = M`, the `z²` factor grows without bound while `|e^{iπrz}| = e^{-πrM}` is constant in `Re z`, and `φ₀''(-1/z)` degenerates as `-1/z → 0` approaches the real axis. So `‖f z‖ → ∞`, and no `M` can work. This is not a matter of proving something harder — the hypothesis cannot be discharged.

## What this adds

- **`tendsto_integral_atTop_nhds_zero_of_tendsto_im_atTop_nhds_zero_of_mem_uIcc`** — the primitive strip-local decay lemma, requiring `‖f z‖ < ε` only for `z.re ∈ [[x₁, x₂]]`. The original global-decay lemma keeps its signature as a two-line wrapper.
- **`_of_tendsto_top` variants** of the four deformation theorems, taking

  ```lean
  htop : Tendsto (fun m : ℝ ↦ ∫ x in x₁..x₂, f (x + m * I)) atTop (𝓝 0)
  ```

  directly. This is the weakest natural form: it states precisely what the proof needs, and it lets a caller supply the top-edge limit however they can prove it — strip-locally, or by any other route.

  | new | wrapper retained |
  |---|---|
  | `tendsto_integral_boundary_open_rect_one_side_atTop_of_tendsto_top` | `…_one_side_atTop_nhds_sum_other_two_sides` |
  | `integral_boundary_open_rect_eq_zero_of_tendsto_top` | `…_of_differentiable_on_off_countable` |
  | `integral_boundary_open_rect_eq_zero_of_tendsto_top'` | `…_of_differentiable_on_off_countable'` |
  | `integral_boundary_open_rect_eq_zero_of_integrable_on_of_tendsto_top` | `…_of_integrable_on` |

All four original theorems keep their exact signatures and are now one-line wrappers, so no existing call site changes.

## Not addressed here

The `sorry` at the end of the file (`…_of_integrable_on'`, deriving integrability along the second contour from the first) is a separate question and is untouched.

## Verification

Full `lake build` and the generated-import check pass, with no new `sorry` declarations. The strip-local proof uses `ε / (|x₂ - x₁| + 1)`, so zero-width and nonzero-width intervals follow the same argument. The module introduction now describes the top-edge-limit API.
