### PR TITLE
refactor: extract shared pointwise q-series bounds

### DIFF
--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -22,6 +22,7 @@ public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
 public import SpherePacking.ForMathlib.RadialSchwartz.SchwartzMap
 public import SpherePacking.ForMathlib.SlashActions
 public import SpherePacking.ForMathlib.SpecificLimits
+public import SpherePacking.ForMathlib.Test.QSeriesBounds
 public import SpherePacking.ForMathlib.UpperHalfPlane
 public import SpherePacking.ForMathlib.Vec
 public import SpherePacking.ForMathlib.VolumeOfBalls

--- a/SpherePacking.lean
+++ b/SpherePacking.lean
@@ -16,6 +16,7 @@ public import SpherePacking.ForMathlib.Fourier
 public import SpherePacking.ForMathlib.FunctionsBoundedAtInfty
 public import SpherePacking.ForMathlib.InvPowSummability
 public import SpherePacking.ForMathlib.MDifferentiableFunProp
+public import SpherePacking.ForMathlib.QSeriesBounds
 public import SpherePacking.ForMathlib.RadialSchwartz.Basic
 public import SpherePacking.ForMathlib.RadialSchwartz.Multidimensional
 public import SpherePacking.ForMathlib.RadialSchwartz.SchwartzMap

--- a/SpherePacking/ForMathlib/QSeriesBounds.lean
+++ b/SpherePacking/ForMathlib/QSeriesBounds.lean
@@ -5,8 +5,9 @@ Authors: Cameron Freer
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+public import Mathlib.Analysis.Complex.Trigonometric
 public import Mathlib.Analysis.Normed.Group.InfiniteSum
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Positivity
 

--- a/SpherePacking/ForMathlib/QSeriesBounds.lean
+++ b/SpherePacking/ForMathlib/QSeriesBounds.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+public import Mathlib.Analysis.Normed.Group.InfiniteSum
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Positivity
+
+/-!
+# Pointwise bounds for q-series
+
+Absolute summability at a reference height `c` gives uniform bounds above that height.
+For shifted coefficients, the decay factor is `exp (-2π n₀ im z)`. For unshifted
+coefficients vanishing below `n₀`, it is `exp (-2π n₀ (im z - c))`: keeping the
+reference-height correction is essential when using the unshifted coefficient norm sum.
+-/
+
+@[expose] public section
+
+open Real
+
+namespace Complex
+
+/-- Bound a shifted q-series above its reference height of absolute summability. -/
+lemma norm_qseries_shift_le {a : ℕ → ℂ} (n₀ : ℕ) {c : ℝ}
+    (ha : Summable fun m : ℕ ↦ ‖a m‖ * Real.exp (-(2 * π * c) * m))
+    (z : ℂ) (hz : c ≤ z.im) :
+    ‖∑' m : ℕ, a m * exp (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z)‖ ≤
+      (∑' m : ℕ, ‖a m‖ * Real.exp (-(2 * π * c) * m)) *
+        Real.exp (-(2 * π) * n₀ * z.im) := by
+  have key (m : ℕ) : ‖a m * exp (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z)‖ ≤
+      ‖a m‖ * Real.exp (-(2 * π * c) * m) * Real.exp (-(2 * π) * n₀ * z.im) := by
+    rw [norm_mul, norm_exp, mul_assoc ‖a m‖]
+    apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
+    rw [← Real.exp_add, Real.exp_le_exp]
+    simp only [show (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z).re =
+      -(2 * π) * (m + n₀) * z.im by simp [mul_re, mul_im]]
+    nlinarith [mul_le_mul_of_nonneg_left hz
+      (mul_nonneg (by positivity : (0 : ℝ) ≤ 2 * π) m.cast_nonneg)]
+  have hs := Summable.of_nonneg_of_le (fun m ↦ norm_nonneg _) key (ha.mul_right _)
+  exact (norm_tsum_le_tsum_norm hs).trans
+    ((Summable.tsum_le_tsum key hs (ha.mul_right _)).trans_eq tsum_mul_right)
+
+/-- Bound a q-series whose coefficients vanish below `n₀`, retaining the reference-height
+correction in the decay factor. Unlike a shifted series, the coefficient norm sum is unshifted. -/
+lemma norm_qseries_le_of_coeff_vanish {b : ℕ → ℂ} (n₀ : ℕ) {c : ℝ}
+    (hb : ∀ m < n₀, b m = 0)
+    (hs : Summable fun m : ℕ ↦ ‖b m‖ * Real.exp (-(2 * π * c) * m))
+    (z : ℂ) (hz : c ≤ z.im) :
+    ‖∑' m : ℕ, b m * exp (2 * π * I * m * z)‖ ≤
+      (∑' m : ℕ, ‖b m‖ * Real.exp (-(2 * π * c) * m)) *
+        Real.exp (-(2 * π) * n₀ * (z.im - c)) := by
+  have key (m : ℕ) : ‖b m * exp (2 * π * I * m * z)‖ ≤
+      ‖b m‖ * Real.exp (-(2 * π * c) * m) * Real.exp (-(2 * π) * n₀ * (z.im - c)) := by
+    by_cases hm : m < n₀
+    · simp [hb m hm]
+    rw [norm_mul, norm_exp, mul_assoc ‖b m‖]
+    apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
+    rw [← Real.exp_add, Real.exp_le_exp]
+    simp only [show (2 * π * I * (m : ℂ) * z).re = -(2 * π) * m * z.im by
+      simp [mul_re, mul_im]]
+    have hm' : (n₀ : ℝ) ≤ m := by exact_mod_cast Nat.le_of_not_gt hm
+    nlinarith [mul_le_mul_of_nonneg_left
+      (mul_le_mul_of_nonneg_right hm' (sub_nonneg.mpr hz))
+      (by positivity : (0 : ℝ) ≤ 2 * π)]
+  have hsum := Summable.of_nonneg_of_le (fun m ↦ norm_nonneg _) key (hs.mul_right _)
+  exact (norm_tsum_le_tsum_norm hsum).trans
+    ((Summable.tsum_le_tsum key hsum (hs.mul_right _)).trans_eq tsum_mul_right)
+
+end Complex

--- a/SpherePacking/ForMathlib/Test/QSeriesBounds.lean
+++ b/SpherePacking/ForMathlib/Test/QSeriesBounds.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+module
+
+import SpherePacking.ForMathlib.QSeriesBounds
+import Mathlib.Tactic.Linarith
+
+/-!
+# Regression tests for pointwise q-series bounds
+
+Check zero starting indices, equality at the reference height (without a positivity assumption
+on that height), and the reference-height correction using a single nonzero coefficient.
+-/
+
+open Complex Real
+
+-- A zero shift contributes no exponential prefactor.
+example {a : ℕ → ℂ} {c : ℝ}
+    (ha : Summable fun m : ℕ ↦ ‖a m‖ * Real.exp (-(2 * π * c) * m))
+    (z : ℂ) (hz : c ≤ z.im) :
+    ‖∑' m : ℕ, a m * Complex.exp (2 * π * I * m * z)‖ ≤
+      ∑' m : ℕ, ‖a m‖ * Real.exp (-(2 * π * c) * m) := by
+  simpa using Complex.norm_qseries_shift_le 0 ha z hz
+
+-- The vanishing hypothesis is vacuous when the starting index is zero.
+example {b : ℕ → ℂ} {c : ℝ}
+    (hs : Summable fun m : ℕ ↦ ‖b m‖ * Real.exp (-(2 * π * c) * m))
+    (z : ℂ) (hz : c ≤ z.im) :
+    ‖∑' m : ℕ, b m * Complex.exp (2 * π * I * m * z)‖ ≤
+      ∑' m : ℕ, ‖b m‖ * Real.exp (-(2 * π * c) * m) := by
+  simpa using Complex.norm_qseries_le_of_coeff_vanish 0 (by simp) hs z hz
+
+-- At the reference height, the unshifted coefficient norm sum needs no extra factor.
+example {b : ℕ → ℂ} (n₀ : ℕ) {c : ℝ}
+    (hb : ∀ m < n₀, b m = 0)
+    (hs : Summable fun m : ℕ ↦ ‖b m‖ * Real.exp (-(2 * π * c) * m))
+    (z : ℂ) (hz : z.im = c) :
+    ‖∑' m : ℕ, b m * Complex.exp (2 * π * I * m * z)‖ ≤
+      ∑' m : ℕ, ‖b m‖ * Real.exp (-(2 * π * c) * m) := by
+  simpa [hz] using Complex.norm_qseries_le_of_coeff_vanish n₀ hb hs z hz.ge
+
+-- A series with only its index-one coefficient nonzero attains this boundary bound.
+example (c : ℝ) :
+    ‖∑' m : ℕ, (if m = 1 then (1 : ℂ) else 0) *
+      Complex.exp (2 * π * I * m * (c * I))‖ = Real.exp (-(2 * π) * c) := by
+  simp [ite_mul, Complex.norm_exp, Complex.mul_re, Complex.mul_im, mul_assoc]
+
+-- Dropping the reference-height correction gives a false bound when c > 0.
+example (c : ℝ) (hc : 0 < c) :
+    ¬ (‖∑' m : ℕ, (if m = 1 then (1 : ℂ) else 0) *
+      Complex.exp (2 * π * I * m * (c * I))‖ ≤
+      (∑' m : ℕ, ‖if m = 1 then (1 : ℂ) else 0‖ *
+        Real.exp (-(2 * π * c) * m)) * Real.exp (-(2 * π) * c)) := by
+  have hexp : Real.exp (-(2 * π) * c) < 1 :=
+    Real.exp_lt_one_iff.mpr (by nlinarith [mul_pos Real.pi_pos hc])
+  simpa [ite_mul, apply_ite, Complex.norm_exp, Complex.mul_re, Complex.mul_im, mul_assoc] using
+    (mul_lt_of_lt_one_right (Real.exp_pos (-(2 * π) * c)) hexp).not_ge

--- a/SpherePacking/ModularForms/ResToImagAxis.lean
+++ b/SpherePacking/ModularForms/ResToImagAxis.lean
@@ -4,6 +4,7 @@ public import Mathlib.Geometry.Manifold.Notation
 public import Mathlib.NumberTheory.ModularForms.QExpansion
 
 public import SpherePacking.ForMathlib.AtImInfty
+public import SpherePacking.ForMathlib.QSeriesBounds
 public import SpherePacking.ModularForms.SlashActionAuxil
 
 /-!
@@ -474,56 +475,9 @@ lemma isBigO_atImInfty_of_fourier_shift
   rw [Asymptotics.isBigO_iff]
   refine ⟨∑' m, ‖a m‖ * rexp (-(2 * π * c) * m), ?_⟩
   rw [Filter.eventually_atImInfty]
-  refine ⟨c, fun z hz => ?_⟩
-  rw [hF z, Real.norm_of_nonneg (le_of_lt (Real.exp_pos _))]
-  -- Real part of 2πi(m+n₀)z is -2π(m+n₀)·im z
-  have hexp_re m : (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z).re = -(2 * π) * (m + n₀) * z.im := by
-    simp only [Nat.cast_add, mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero,
-      Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, add_re, natCast_re,
-      add_im, natCast_im, coe_re, zero_add, coe_im, zero_sub, neg_mul]
-  -- Key bound: for y ≥ c, exp(-(2π)(m+n₀)y) ≤ exp(-(2πc)m) * exp(-(2πc)n₀)
-  have hexp_bound (m : ℕ) :
-      rexp (-(2 * π) * (↑m + ↑n₀) * z.im) ≤
-        rexp (-(2 * π * c) * m) * rexp (-(2 * π * c) * n₀) := by
-    rw [← Real.exp_add, Real.exp_le_exp]
-    have _ : (↑m + ↑n₀) * z.im ≥ (↑m + ↑n₀) * c := by nlinarith
-    nlinarith [Real.pi_pos, (Nat.cast_nonneg m : (0 : ℝ) ≤ m),
-      (Nat.cast_nonneg n₀ : (0 : ℝ) ≤ n₀), z.im_pos]
-  -- Summability of norms
-  have hsum_norms : Summable fun m => ‖a m * cexp (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z)‖ := by
-    refine .of_nonneg_of_le (fun _ => norm_nonneg _) (fun m => ?_)
-      (ha.mul_right (rexp (-(2 * π * c) * n₀)))
-    simp only [norm_mul, norm_exp, hexp_re]
-    calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
-        ≤ ‖a m‖ * (rexp (-(2 * π * c) * m) * rexp (-(2 * π * c) * n₀)) :=
-          mul_le_mul_of_nonneg_left (hexp_bound m) (norm_nonneg _)
-      _ = ‖a m‖ * rexp (-(2 * π * c) * m) * rexp (-(2 * π * c) * n₀) := by ring
-  have hsum_norms' : Summable fun m => ‖a m‖ * rexp (-(2 * π) * (m + n₀) * z.im) := by
-    convert hsum_norms with m; rw [norm_mul, norm_exp, hexp_re]
-  -- Main calculation
-  calc ‖∑' m, a m * cexp (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z)‖
-      ≤ ∑' m, ‖a m * cexp (2 * π * I * ((m + n₀ : ℕ) : ℂ) * z)‖ :=
-        norm_tsum_le_tsum_norm hsum_norms
-    _ = ∑' m, ‖a m‖ * rexp (-(2 * π) * (m + n₀) * z.im) := by
-        simp only [norm_mul, norm_exp, hexp_re]
-    _ ≤ ∑' m, ‖a m‖ * rexp (-(2 * π * c) * m) * rexp (-(2 * π) * n₀ * z.im) := by
-        refine Summable.tsum_le_tsum (fun m => ?_) hsum_norms'
-          (ha.mul_right (rexp (-(2 * π) * n₀ * z.im)))
-        have hsplit : rexp (-(2 * π) * (↑m + ↑n₀) * z.im) =
-            rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by
-          rw [← Real.exp_add]; ring_nf
-        have hexp_m : rexp (-(2 * π) * m * z.im) ≤ rexp (-(2 * π * c) * m) := by
-          rw [Real.exp_le_exp]
-          have key : (m : ℝ) * z.im ≥ m * c := by nlinarith
-          nlinarith [Real.pi_pos, (Nat.cast_nonneg m : (0 : ℝ) ≤ m), z.im_pos]
-        calc ‖a m‖ * rexp (-(2 * π) * (↑m + ↑n₀) * z.im)
-            = ‖a m‖ * rexp (-(2 * π) * m * z.im) * rexp (-(2 * π) * n₀ * z.im) := by
-              rw [hsplit]; ring
-          _ ≤ ‖a m‖ * rexp (-(2 * π * c) * m) * rexp (-(2 * π) * n₀ * z.im) := by
-              apply mul_le_mul_of_nonneg_right _ (le_of_lt (Real.exp_pos _))
-              exact mul_le_mul_of_nonneg_left hexp_m (norm_nonneg _)
-    _ = (∑' m, ‖a m‖ * rexp (-(2 * π * c) * m)) * rexp (-(2 * π) * n₀ * z.im) := tsum_mul_right
-    _ = _ := by ring_nf
+  refine ⟨c, fun z hz ↦ ?_⟩
+  rw [hF z, Real.norm_of_nonneg (Real.exp_pos _).le]
+  simpa [mul_assoc] using Complex.norm_qseries_shift_le n₀ ha (z : ℂ) hz
 
 /--
 If `F` has a Fourier expansion starting at index `n₀ > 0` with absolutely summable coefficients


### PR DESCRIPTION
## Stack

Based directly on `main`; a prerequisite for #304, independent of #472.
Merge this PR and #472 in either order, then #304, then #473.

## Changes

- Extract shared pointwise q-series bounds into `ForMathlib/QSeriesBounds.lean`, for shifted
  coefficients and for coefficients vanishing below `n₀`.
- Add `UpperHalfPlane.norm_le_qExpansion_of_coeff_vanish` in `ResToImagAxis.lean`. It bounds a
  1-periodic holomorphic function bounded at infinity using its canonical `qExpansion`
  coefficients, deriving summability and the series identity automatically.
- Reprove `isBigO_atImInfty_of_fourier_shift` using the shared bound, with its statement unchanged.

The coefficient-level lemmas remain available without holomorphy assumptions. The decay factor
for unshifted coefficients is `exp (-2π n₀ (im z - c))`; a short docstring remark explains why the
reference-height correction is necessary.

## Verification

Full `lake build`, `lake exe mk_all --check --module`, and `git diff --check` pass.
All three bounds use only `propext`, `Classical.choice`, and `Quot.sound`. No new sorries.
